### PR TITLE
rewrite query to eliminate pass-through nodes

### DIFF
--- a/tests/query.rs
+++ b/tests/query.rs
@@ -102,7 +102,7 @@ test_cases!(
     rewrite_root,
     script_params_overwrite,
     script_params,
-    //streams,
+    streams,
     tremor_map,
     where_filter,
     window_by_two_scripted,

--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -490,14 +490,12 @@ mod tests {
 
     #[test]
     fn test_assign_local() {
-        dbg!();
         eval_global!(
             "\"hello\"; let test = [2,4,6,8]; let $out = test;",
             Value::from(hashmap! {
                 "out".into() => Value::from(vec![2u64, 4, 6, 8]),
             })
         );
-        dbg!();
         eval_global!(
             "\"hello\"; let test = [4,6,8,10]; let test = [test]; let $out = test;",
             Value::from(hashmap! {


### PR DESCRIPTION
This eliminates passthrough nodes. The tests pass but since it's invasive on the graph an extra careful review on the logic would be nice!

This closes #53 