### PR TITLE
Change docker entrypoint to allow passing any arguments to the tremor cli

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,23 +1,32 @@
 #!/bin/sh
 
 set -x
-if [ ! -z ${SLEEP+x} ]
+if [ -n "${SLEEP+x}" ]
 then
     sleep "$SLEEP"
 fi
 
-if [ -z ${LOGGER_FILE+x} ]
+
+if [ "$#" != "0" ]
 then
-   LOGGER_FILE="/etc/tremor/logger.yaml"
+    ARGS=$*
+else
+
+    if [ -z ${LOGGER_FILE+x} ]
+    then
+        LOGGER_FILE="/etc/tremor/logger.yaml"
+    fi
+
+    ARTEFACTS="/etc/tremor/config/*.yaml"
+    QUERIES=$(find /etc/tremor/config/ -name '*.trickle' -print 2>/dev/null | wc -l)
+    if [ "$QUERIES" != 0 ]
+    then
+        ARTEFACTS="$ARTEFACTS /etc/tremor/config/*.trickle"
+    fi
+    ARGS="server run -f ${ARTEFACTS} --logger-config ${LOGGER_FILE}"
 fi
 
-queries=`ls -1 /etc/tremor/config/*.trickle 2>/dev/null | wc -l`
-if [ $queries != 0 ]
-then
-    exec /tremor server run -f /etc/tremor/config/*.yaml /etc/tremor/config/*.trickle --logger-config "${LOGGER_FILE}"
-else
-    exec /tremor server run -f /etc/tremor/config/*.yaml --logger-config "${LOGGER_FILE}"
-fi
+exec /tremor "${ARGS}"
 
 
 


### PR DESCRIPTION
Default is running `server run` as before.

Signed-off-by: Matthias Wahl <mwahl@wayfair.com>