### PR TITLE
Docker improvements

### DIFF
--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -1,18 +1,21 @@
-name: Publish Docker - Release
+name: Publish to Registry - Release
 on:
+  release:
+    types: [published]
   push:
-    tags:
-      - v*
+    branches:
+      - master
+  schedule:
+    - cron: "0 2 * * 0" # Weekly on Sundays at 02:00
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: tremorproject/tremor
+          name: myDocker/repository
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: latest
           tag_semver: true

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -1,4 +1,4 @@
-name: Publish to Registry - Release
+name: Publish Docker - Release
 on:
   release:
     types: [published]
@@ -15,7 +15,7 @@ jobs:
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: myDocker/repository
+          name: tremorproject/tremor
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_semver: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ ENV RUSTFLAGS="-C target-feature=+avx,+avx2,+sse4.2"
 
 COPY Cargo.* ./
 
+# We change lto to 'thin' for docker builds so it
+# can be build on more moderate system
+RUN mv Cargo.toml Cargo.toml.orig && sed 's/lto = true/lto = "thin"/' Cargo.toml.orig > Cargo.toml
+
 # Main library
 COPY src ./src
 # supporting libraries
@@ -30,6 +34,7 @@ COPY tremor-common ./tremor-common
 
 RUN cat /proc/cpuinfo
 RUN cargo build --release --all --verbose
+RUN strip target/release/tremor
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
* update release config to only publish tags and not the "latest". fixes #511 
* strip docker builds. fixes #492 
* use thin lto for docker (~2% perf decrease but docker builds are for compatibility not highest perf) might fix docker builds
