### PR TITLE
Remove generic and associated type from SourceReply.

### DIFF
--- a/src/source/blaster.rs
+++ b/src/source/blaster.rs
@@ -97,8 +97,6 @@ impl Acc {
 
 #[async_trait::async_trait()]
 impl Source for Blaster {
-    type SourceReplyStreamExtra = ();
-
     fn id(&self) -> &TremorURL {
         &self.onramp_id
     }

--- a/src/source/crononome.rs
+++ b/src/source/crononome.rs
@@ -273,13 +273,11 @@ impl ChronomicQueue {
 
 #[async_trait::async_trait()]
 impl Source for Crononome {
-    type SourceReplyStreamExtra = ();
-
     fn id(&self) -> &TremorURL {
         &self.onramp_id
     }
 
-    async fn pull_event(&mut self, id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, id: u64) -> Result<SourceReply> {
         if let Some(trigger) = self.cq.next() {
             let mut origin_uri = self.origin_uri.clone();
             origin_uri.path.push(trigger.0.clone());

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -108,13 +108,11 @@ impl onramp::Impl for File {
 
 #[async_trait::async_trait()]
 impl Source for Int {
-    type SourceReplyStreamExtra = ();
-
     fn id(&self) -> &TremorURL {
         &self.onramp_id
     }
 
-    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
         if let Some(Ok(line)) = self.lines.next().await {
             Ok(SourceReply::Data {
                 origin_uri: self.origin_uri.clone(),

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -254,15 +254,13 @@ pub type LoggingConsumer = StreamConsumer<LoggingConsumerContext>;
 
 #[async_trait::async_trait()]
 impl Source for Int {
-    type SourceReplyStreamExtra = ();
-
     fn is_transactional(&self) -> bool {
         !self.auto_commit
     }
     fn id(&self) -> &TremorURL {
         &self.onramp_id
     }
-    async fn pull_event(&mut self, id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, id: u64) -> Result<SourceReply> {
         if let Some(stream) = self.stream.as_mut() {
             let s = unsafe { stream.mut_suffix() };
             if let Some(Ok(m)) = s.next().await {

--- a/src/source/metronome.rs
+++ b/src/source/metronome.rs
@@ -60,7 +60,6 @@ impl onramp::Impl for Metronome {
 
 #[async_trait::async_trait()]
 impl Source for Metronome {
-    type SourceReplyStreamExtra = ();
     fn id(&self) -> &TremorURL {
         &self.onramp_id
     }

--- a/src/source/postgres.rs
+++ b/src/source/postgres.rs
@@ -139,8 +139,7 @@ impl Int {
 
 #[async_trait::async_trait]
 impl Source for Int {
-    type SourceReplyStreamExtra = ();
-    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
         if let Some(row) = self.rows.pop() {
             return Ok(SourceReply::Structured {
                 origin_uri: self.origin_uri.clone(),

--- a/src/source/rest.rs
+++ b/src/source/rest.rs
@@ -340,10 +340,8 @@ fn make_response(
 
 #[async_trait::async_trait()]
 impl Source for Int {
-    type SourceReplyStreamExtra = ();
-
     // TODO possible to do this in source trait?
-    async fn pull_event(&mut self, id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, id: u64) -> Result<SourceReply> {
         if let Some(listener) = self.listener.as_ref() {
             match listener.try_recv() {
                 Ok(RestSourceReply(Some(response_tx), source_reply)) => {

--- a/src/source/udp.rs
+++ b/src/source/udp.rs
@@ -74,8 +74,7 @@ impl onramp::Impl for Udp {
 
 #[async_trait::async_trait]
 impl Source for Int {
-    type SourceReplyStreamExtra = ();
-    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply<Self::SourceReplyStreamExtra>> {
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
         let mut buf = [0; 65535];
 
         if let Some(socket) = self.socket.as_mut() {


### PR DESCRIPTION
And internalize the stuff that was there to the ws source, the only place where it was needed.

Fixes #486 