### PR TITLE
Fix dockerfile entrypoint arg quoting bug.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,7 +26,8 @@ else
     ARGS="server run -f ${ARTEFACTS} --logger-config ${LOGGER_FILE}"
 fi
 
-exec /tremor "${ARGS}"
+# IMPORTANT: do not quote ARGS, no matter what shellcheck tells you
+exec /tremor ${ARGS}
 
 
 


### PR DESCRIPTION
# Pull request

The current docker image was unusable because it was quoting all args, so `exec` was treating all of them as one.

## Description

<!-- please add a description of what the goal of this pull request is -->

## Checklist


* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment