### PR TITLE
Disable tokio dependency for rdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,7 +3803,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.22",
 ]
 
 [[package]]
@@ -5438,7 +5437,6 @@ dependencies = [
  "pretty_assertions",
  "rand 0.7.3",
  "rdkafka",
- "rdkafka-sys",
  "regex",
  "rental",
  "rmp-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,8 +3793,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db594dc221933be6f2ad804b997b48a57a63436c26ab924222c28e9a36ad210a"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=2901a4b9027c3cce6fcae48c124fe5296397704a#2901a4b9027c3cce6fcae48c124fe5296397704a"
 dependencies = [
  "futures 0.3.6",
  "libc",
@@ -3808,8 +3807,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "2.1.0+1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3f17044cba41c7309facedc72ca9bf25f177bf1e06756318e010f043713017"
+source = "git+https://github.com/fede1024/rust-rdkafka?rev=2901a4b9027c3cce6fcae48c124fe5296397704a#2901a4b9027c3cce6fcae48c124fe5296397704a"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ version = "0.9.0"
 [workspace]
 
 members = [
-    "tremor-api",
-    "tremor-influx",
-    "tremor-pipeline",
-    "tremor-script",
-    "tremor-cli",
-    "tremor-common"
+  "tremor-api",
+  "tremor-influx",
+  "tremor-pipeline",
+  "tremor-script",
+  "tremor-cli",
+  "tremor-common",
 ]
 
 [profile.release]
@@ -56,8 +56,8 @@ serde_yaml = "0.8"
 simd-json = {version = "0.3", features = ["known-key"]}
 simd-json-derive = "0.1.11"
 surf = "=2.0.0"
-tremor-pipeline = { path = "tremor-pipeline" }
-tremor-common = { path = "tremor-common" }
+tremor-common = {path = "tremor-common"}
+tremor-pipeline = {path = "tremor-pipeline"}
 url = "2.1"
 value-trait = "0.1"
 
@@ -85,8 +85,9 @@ postgres-protocol = "0.5"
 tokio-postgres = "0.5"
 
 # kafka. cmake is the encouraged way to build this and also the one that works on windows/with musl.
-rdkafka = {version = "0.24", features = ["cmake-build"]}
-rdkafka-sys = {version = "2.1", features = ["cmake-build"]}
+# use default-features= false to not depend on tokio here
+rdkafka = {version = "0.24", features = ["cmake-build", "libz"], default-features = false}
+#rdkafka-sys = {version = "2.1", features = ["cmake-build"]}
 
 # crononome
 cron = "0.6.1"
@@ -116,8 +117,8 @@ regex = "1"
 default = []
 
 # arm suopport
-neon = ["simd-json/neon"]
 bert = ["tremor-pipeline/bert"]
+neon = ["simd-json/neon"]
 
 [patch.crates-io]
 rust-bert = {git = 'https://github.com/mfelsche/rust-bert.git', rev = '1140989'}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ postgres-protocol = "0.5"
 tokio-postgres = "0.5"
 
 # kafka. cmake is the encouraged way to build this and also the one that works on windows/with musl.
-# use default-features= false to not depend on tokio here
-rdkafka = {version = "0.24", features = ["cmake-build", "libz"], default-features = false}
+# use `default-features = false` to not depend on tokio here
+rdkafka = {git = "https://github.com/fede1024/rust-rdkafka", rev = "2901a4b9027c3cce6fcae48c124fe5296397704a", features = ["cmake-build", "libz"], default-features = false}
 #rdkafka-sys = {version = "2.1", features = ["cmake-build"]}
 
 # crononome

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -125,24 +125,6 @@ fn is_fatal(e: &KafkaError) -> bool {
     }
 }
 
-unsafe fn get_fatal_error<C>(
-    client: &rdkafka::client::Client<C>,
-) -> Option<(rdkafka::types::RDKafkaRespErr, String)>
-where
-    C: rdkafka::ClientContext,
-{
-    const LEN: usize = 4096;
-    let mut buf: [i8; LEN] = std::mem::MaybeUninit::uninit().assume_init();
-    let client_ptr = client.native_ptr();
-
-    let code = rdkafka_sys::bindings::rd_kafka_fatal_error(client_ptr, buf.as_mut_ptr(), LEN);
-    if code == rdkafka::types::RDKafkaRespErr::RD_KAFKA_RESP_ERR_NO_ERROR {
-        None
-    } else {
-        Some((code, rdkafka::util::cstr_to_owned(buf.as_ptr())))
-    }
-}
-
 #[async_trait::async_trait]
 impl Sink for Kafka {
     async fn on_event(
@@ -174,9 +156,7 @@ impl Sink for Kafka {
                 Err((e, _r)) => {
                     error!("[Kafka Offramp] failed to enque message: {}", e);
                     if is_fatal(&e) {
-                        if let Some((code, fatal)) =
-                            unsafe { get_fatal_error(self.producer.client()) }
-                        {
+                        if let Some((code, fatal)) = self.producer.client().fatal_error() {
                             error!("[Kafka Offramp] Fatal Error({:?}): {}", code, fatal);
                         }
                         self.producer = self.config.producer()?;


### PR DESCRIPTION
# Pull request

Disable tokio dependency for rdkafka and also remove explicit dep to `rdkafka-sys` by ugrading to a git tag: https://github.com/fede1024/rust-rdkafka/commit/2901a4b9027c3cce6fcae48c124fe5296397704a slightly beyond release 0.24.

## Description

We include tokio for rdkafka, which we dont need. We still need tokio for `tokio-postgres`, but it still makes sense.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
