### PR TITLE
Standardize error responses for tremor api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,13 +2137,14 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc9a434e0182abff944d7d44190f02d141f269a3f31c45ac5368dc548bb934b"
+checksum = "ffa4e35764a650ce8e709c50e985431eb8963eee7fc793d923134d4aa8e530b4"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-std",
+ "base64 0.13.0",
  "cookie 0.14.2",
  "futures-lite",
  "infer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ futures = "0.3"
 glob = "0.3"
 hashbrown = {version = "0.9", features = ["serde"]}
 hostname = "0.3"
-http-types = "2.6"
+http-types = "2.7"
 log4rs = "0.13"
 pin-project-lite = "0.1"
 rand = "0.7"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -151,7 +151,7 @@ error_chain! {
             description("Unknown operator")
                 display("Unknown operator: {}::{}", n, o)
         }
-        ArtifactNotFound(id: String) {
+        ArtefactNotFound(id: String) {
             description("The artifact was not found")
                 display("The artifact was not found: {}", id)
         }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -101,7 +101,7 @@ impl<A: Artefact> Repository<A> {
     pub fn unpublish(&mut self, mut id: ArtefactId) -> Result<A> {
         id.trim_to_artefact();
         match self.map.entry(id.clone()) {
-            Entry::Vacant(_) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            Entry::Vacant(_) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             Entry::Occupied(e) => {
                 let wrapper = e.get();
                 if wrapper.system {
@@ -125,7 +125,7 @@ impl<A: Artefact> Repository<A> {
                 w.instances.push(sid);
                 Ok(&w.artefact)
             }
-            None => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            None => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
         }
     }
     /// Unbinds an artefact with a given servant
@@ -137,7 +137,7 @@ impl<A: Artefact> Repository<A> {
                 w.instances.retain(|x| x != &sid);
                 Ok(&w.artefact)
             }
-            None => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            None => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
         }
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -208,7 +208,7 @@ impl World {
                 self.link_existing_pipeline(&id, m).await?;
                 Ok(res)
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {} ", id).into()),
         }
     }
@@ -225,7 +225,7 @@ impl World {
                 self.repo.unbind_pipeline(id).await?;
                 Ok(r)
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {}", id).into()),
         }
     }
@@ -256,7 +256,7 @@ impl World {
             };
             pipeline_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -273,7 +273,7 @@ impl World {
         if let Some(pipeline_a) = self.repo.find_pipeline(id).await? {
             pipeline_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -296,7 +296,7 @@ impl World {
             };
             r
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -334,7 +334,7 @@ impl World {
                 self.link_existing_onramp(&id, m).await?;
                 Ok(res)
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {} ", id).into()),
         }
     }
@@ -350,7 +350,7 @@ impl World {
                 self.repo.unbind_onramp(id).await?;
                 r
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {} ", id).into()),
         }
     }
@@ -373,7 +373,7 @@ impl World {
             };
             onramp_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -388,7 +388,7 @@ impl World {
         if let Some(onramp_a) = self.repo.find_onramp(id).await? {
             onramp_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -411,7 +411,7 @@ impl World {
             };
             Ok(r)
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -440,7 +440,7 @@ impl World {
                 self.link_existing_offramp(&id, m).await?;
                 Ok(res)
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {} ", id).into()),
         }
     }
@@ -457,7 +457,7 @@ impl World {
                 self.repo.unbind_offramp(id).await?;
                 r
             }
-            (None, _) => Err(ErrorKind::ArtifactNotFound(id.to_string()).into()),
+            (None, _) => Err(ErrorKind::ArtefactNotFound(id.to_string()).into()),
             (_, None) => Err(format!("Invalid URI for instance {} ", id).into()),
         }
     }
@@ -480,7 +480,7 @@ impl World {
             };
             offramp_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -495,7 +495,7 @@ impl World {
         if let Some(offramp_a) = self.repo.find_offramp(id).await? {
             offramp_a.artefact.link(self, id, mappings).await
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -518,7 +518,7 @@ impl World {
             };
             Ok(r)
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -575,7 +575,7 @@ impl World {
             };
             Ok(r)
         } else {
-            Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+            Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
         }
     }
 
@@ -649,7 +649,7 @@ impl World {
             return Ok(binding);
         }
 
-        Err(ErrorKind::ArtifactNotFound(id.to_string()).into())
+        Err(ErrorKind::ArtefactNotFound(id.to_string()).into())
     }
 
     /// Starts the runtime system

--- a/tremor-api/Cargo.toml
+++ b/tremor-api/Cargo.toml
@@ -15,5 +15,5 @@ serde_derive = "1"
 serde_yaml = "0.8"
 hashbrown = { version = "0.9", features = ["serde"] }
 tide = "0.13"
-http-types = "2.6"
+http-types = "2.7"
 simd-json = "0.3"

--- a/tremor-api/src/api/pipeline.rs
+++ b/tremor-api/src/api/pipeline.rs
@@ -51,9 +51,9 @@ pub async fn publish_artefact(mut req: Request) -> Result<Response> {
             )?;
 
             let id = query.id().ok_or_else(|| {
-                Error::generic(
+                Error::new(
                     StatusCode::UnprocessableEntity,
-                    &r#"no `#!config id = "trickle-id"` directive provided"#,
+                    r#"no `#!config id = "trickle-id"` directive provided"#.into(),
                 )
             })?;
 
@@ -65,7 +65,7 @@ pub async fn publish_artefact(mut req: Request) -> Result<Response> {
                 .map(|result| result.source().to_string())?;
             reply_trickle_flat(req, result, true, StatusCode::Created).await
         }
-        Some(_) | None => Err(Error::Generic(
+        Some(_) | None => Err(Error::new(
             StatusCode::UnsupportedMediaType,
             "No content type provided".into(),
         )),
@@ -77,7 +77,7 @@ pub async fn reply_trickle_flat(
     result_in: String,
     persist: bool,
     ok_code: StatusCode,
-) -> std::result::Result<Response, crate::Error> {
+) -> Result<Response> {
     if persist {
         let world = &req.state().world;
         world.save_config().await?;
@@ -99,7 +99,7 @@ pub async fn reply_trickle_instanced(
     instances: Vec<String>,
     persist: bool,
     ok_code: StatusCode,
-) -> std::result::Result<Response, crate::Error> {
+) -> Result<Response> {
     if persist {
         let world = &req.state().world;
         world.save_config().await?;

--- a/tremor-api/src/api/prelude.rs
+++ b/tremor-api/src/api/prelude.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 pub(crate) use crate::api::*;
+pub(crate) use crate::errors::Error;
 pub(crate) use http_types::StatusCode;
 pub(crate) use tide::Response;

--- a/tremor-api/src/api/version.rs
+++ b/tremor-api/src/api/version.rs
@@ -30,6 +30,6 @@ impl Default for Version {
     }
 }
 
-pub async fn get(req: Request) -> std::result::Result<Response, crate::Error> {
+pub async fn get(req: Request) -> Result<Response> {
     reply(req, Version::default(), false, StatusCode::Ok).await
 }

--- a/tremor-api/src/errors.rs
+++ b/tremor-api/src/errors.rs
@@ -117,8 +117,7 @@ impl From<TremorError> for Error {
                 StatusCode::Conflict,
                 "Resource still has active instances".into(),
             ),
-            // TODO fix typo here
-            ErrorKind::ArtifactNotFound(_) => {
+            ErrorKind::ArtefactNotFound(_) => {
                 Error::new(StatusCode::NotFound, "Artefact not found".into())
             }
             ErrorKind::PublishFailedAlreadyExists(_) => Error::new(

--- a/tremor-api/src/errors.rs
+++ b/tremor-api/src/errors.rs
@@ -1,0 +1,138 @@
+// Copyright 2020, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use http_types::{headers, StatusCode};
+use serde::Serialize;
+use std::sync::{MutexGuard, PoisonError};
+use tide::Response;
+use tremor_runtime::errors::{Error as TremorError, ErrorKind};
+
+/// Tremor API error
+#[derive(Debug, Serialize)]
+pub struct Error {
+    pub code: StatusCode,
+    pub error: String,
+}
+
+impl Error {
+    /// Create new error from the given status code and error string
+    #[must_use]
+    pub fn new(code: StatusCode, error: String) -> Self {
+        Self { code, error }
+    }
+
+    /// Convenience function for creating aretefact not found errors
+    pub fn not_found() -> Self {
+        Self::new(StatusCode::NotFound, "Artefact not found".into())
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+impl std::error::Error for Error {}
+
+impl Into<Response> for Error {
+    fn into(self) -> Response {
+        Response::builder(self.code)
+            .header(
+                headers::CONTENT_TYPE,
+                crate::api::ResourceType::Json.as_str(),
+            )
+            .body(format!(
+                r#"{{"code":{},"error":"{}"}}"#,
+                self.code, self.error
+            ))
+            .build()
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::new(StatusCode::InternalServerError, format!("IO error: {}", e))
+    }
+}
+
+impl From<simd_json::Error> for Error {
+    fn from(e: simd_json::Error) -> Self {
+        Self::new(StatusCode::BadRequest, format!("JSON error: {}", e))
+    }
+}
+
+impl From<serde_yaml::Error> for Error {
+    fn from(e: serde_yaml::Error) -> Self {
+        Self::new(StatusCode::BadRequest, format!("YAML error: {}", e))
+    }
+}
+
+impl From<http_types::Error> for Error {
+    fn from(e: http_types::Error) -> Self {
+        Self::new(
+            StatusCode::InternalServerError,
+            format!("HTTP type error: {}", e),
+        )
+    }
+}
+
+impl From<tremor_pipeline::errors::Error> for Error {
+    fn from(e: tremor_pipeline::errors::Error) -> Self {
+        Self::new(StatusCode::BadRequest, format!("Pipeline error: {}", e))
+    }
+}
+
+impl From<tremor_script::prelude::CompilerError> for Error {
+    fn from(e: tremor_script::prelude::CompilerError) -> Self {
+        Self::new(
+            StatusCode::InternalServerError,
+            format!("Compiler error: {:?}", e),
+        )
+    }
+}
+impl From<PoisonError<MutexGuard<'_, tremor_script::Registry>>> for Error {
+    fn from(e: PoisonError<MutexGuard<tremor_script::Registry>>) -> Self {
+        Self::new(
+            StatusCode::InternalServerError,
+            format!("Locking error: {}", e),
+        )
+    }
+}
+
+impl From<TremorError> for Error {
+    fn from(e: TremorError) -> Self {
+        match e.0 {
+            ErrorKind::UnpublishFailedNonZeroInstances(_) => Error::new(
+                StatusCode::Conflict,
+                "Resource still has active instances".into(),
+            ),
+            // TODO fix typo here
+            ErrorKind::ArtifactNotFound(_) => {
+                Error::new(StatusCode::NotFound, "Artefact not found".into())
+            }
+            ErrorKind::PublishFailedAlreadyExists(_) => Error::new(
+                StatusCode::Conflict,
+                "A resource with the requested ID already exists".into(),
+            ),
+            ErrorKind::UnpublishFailedSystemArtefact(_) => Error::new(
+                StatusCode::Forbidden,
+                "System artefacts cannot be unpublished".into(),
+            ),
+            _e => Error::new(
+                StatusCode::InternalServerError,
+                "Internal server error".into(),
+            ),
+        }
+    }
+}

--- a/tremor-api/src/lib.rs
+++ b/tremor-api/src/lib.rs
@@ -29,5 +29,6 @@
 extern crate serde_derive;
 
 mod api;
+mod errors;
 
 pub use api::*;

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -27,7 +27,7 @@ difference = "2"
 dirs-next = "2"
 env_logger = "0.8.1"
 halfbrown = "0.1"
-http-types = "2.6"
+http-types = "2.7"
 jemallocator = {version = "0.3", optional = false}
 log = "0.4"
 log4rs = "0.12.0"

--- a/tremor-cli/tests/api/command.yml
+++ b/tremor-cli/tests/api/command.yml
@@ -1076,15 +1076,81 @@ suites:
             contains:
               - "id: ws-linked"
               - "instances: []"
-
-
-
-
-        
-        
-
-
-
-
-
-              
+  - name: REST API - Error formatting
+    tags:
+      - error
+    cases:
+      - name: API error response should default to json
+        command: >
+          curl -vs -X DELETE http://localhost:9898/binding/non-existent/1
+        tags:
+          - delete
+        status: 0
+        expects:
+          - source: stderr
+            contains:
+              - HTTP/1.1 404 Not Found
+              - 'content-type: application/json'
+          - source: stdout
+            contains:
+              - '"error":"Artefact not found"}'
+      - name: YAML accept header should be respected while generating API error response
+        command: >
+          curl -vs -X DELETE -H"Accept: application/yaml" http://localhost:9898/binding/non-existent/1
+        tags:
+          - delete
+        status: 0
+        expects:
+          - source: stderr
+            contains:
+              - 'Accept: application/yaml'
+              - HTTP/1.1 404 Not Found
+              - 'content-type: application/yaml'
+          - source: stdout
+            contains:
+              - 'error: Artefact not found'
+      - name: JSON accept header should be respected while generating API error response
+        command: >
+          curl -vs -X DELETE -H"Accept: application/json" http://localhost:9898/binding/non-existent/1
+        tags:
+          - delete
+        status: 0
+        expects:
+          - source: stderr
+            contains:
+              - 'Accept: application/json'
+              - HTTP/1.1 404 Not Found
+              - 'content-type: application/json'
+          - source: stdout
+            contains:
+              - '"error":"Artefact not found"}'
+      - name: Trickle accept header should be ignored while generating error response and it should default to json
+        command: >
+          curl -vs -X GET -H"Accept: application/vnd.trickle" http://localhost:9898/pipeline/non-existent
+        tags:
+          - get
+        status: 0
+        expects:
+          - source: stderr
+            contains:
+              - 'Accept: application/vnd.trickle'
+              - HTTP/1.1 404 Not Found
+              - 'content-type: application/json'
+          - source: stdout
+            contains:
+              - '"error":"Artefact not found"}'
+      - name: Other accept headers should be ignored while generating error response and it should default to json
+        command: >
+          curl -vs -X DELETE -H"Accept: application/snot" http://localhost:9898/binding/non-existent/1
+        tags:
+          - delete
+        status: 0
+        expects:
+          - source: stderr
+            contains:
+              - 'Accept: application/snot'
+              - HTTP/1.1 404 Not Found
+              - 'content-type: application/json'
+          - source: stdout
+            contains:
+              - '"error":"Artefact not found"}'


### PR DESCRIPTION
# Pull request

Standardize error responses for tremor api.

## Description

Ensure that tremor API error responses are consistently formatted for all error paths -- defaults as json and respects the accept request header when present (for values of json and yaml).

Looked into doing this more cleanly via tide's middleware (eg: based on their [error handling example](https://github.com/http-rs/tide/blob/main/examples/error_handling.rs)), but looks like it's not possible to consider request while modifying the outgoing response there (which we need to do to respect the request accept header).

## Related

* Related Issues: fixes #483
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment