### PR TITLE
Log tremor logs to stdout on info level, no file.

### DIFF
--- a/demo/configs/tremor/logger.yaml
+++ b/demo/configs/tremor/logger.yaml
@@ -6,23 +6,19 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/logs/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
-# Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
 
 loggers:
-  # Write info level logs to the log file
   tremor_runtime:
     level: info
     appenders:
-      - file
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
     additive: false

--- a/docker/logger.yaml
+++ b/docker/logger.yaml
@@ -1,7 +1,3 @@
-# Example minimal config, also used in docker images
-# please do not change!
----
-
 # Scan this file for changes every 30 seconds
 refresh_rate: 30 seconds
 
@@ -10,24 +6,19 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/logs/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
-# Write only warnings to stdout
 root:
-  level: error
+  level: warn
   appenders:
     - stdout
 
 loggers:
-  # Write info level logs to the log file
   tremor_runtime:
     level: info
     appenders:
-      - file
+      - stdout
     additive: false
-
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false


### PR DESCRIPTION
# Pull request

log to stdout in docker and for the demo logger file:

* temor stuff: INFO
* other stuff: WARN

## Description

Unify docker logging with the workshop logging: https://github.com/tremor-rs/tremor-www-docs/pull/41

## Related

* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/41)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment