### PR TITLE
Publish to github docker repository

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -15,11 +15,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: edge
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: tremordockerbuild
+          password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
           repository: tremor-rs/tremor
-          tags: tremor-runtime/tremor:edge
+          push: true
+          tags: edge

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -20,6 +20,6 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: tremor-rs/tremor-runtime/tremor
+          registry: ghcr.io
+          repository: tremor-rs/tremor
           tags: tremor-runtime/tremor:edge

--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -15,3 +15,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: edge
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: tremor-rs/tremor-runtime/tremor
+          tags: tremor-runtime/tremor:edge

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -24,6 +24,6 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: tremor-rs/tremor-runtime/tremor
+          registry: ghcr.io
+          repository: tremor-rs/tremor
           tag_with_ref: true

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -19,3 +19,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_semver: true
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: tremor-rs/tremor-runtime/tremor
+          tag_with_ref: true

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -2,11 +2,6 @@ name: Publish Docker - Release
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - master
-  schedule:
-    - cron: "0 2 * * 0" # Weekly on Sundays at 02:00
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -19,11 +19,21 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_semver: true
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          images: tremor-rs/tremor
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          username: tremordockerbuild
+          password: ${{ secrets.GHCR_PAT }}
           registry: ghcr.io
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
           repository: tremor-rs/tremor
-          tag_with_ref: true
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.46.0 as builder
+FROM rust:1.47.0 as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM rust:1.46.0 as builder
+FROM rust:1.47.0 as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
# Pull request

Publish to dockerhub and GH repository in parallel

## Description

With docker starting to charge for downloads we want to make sure images for tremor are available without the user needing to pay. We publish to the GH repository in parallel so we mirror images between the two.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs (docs will be updated once we have images published so it is testable)
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment