### PR TITLE
Remove todo macro from tcp sink.

### DIFF
--- a/.github/checks/safety.sh
+++ b/.github/checks/safety.sh
@@ -33,7 +33,7 @@ while getopts hauiprebldxcft opt; do
             exit 0
             ;;
         a)
-            exec "$0" -uirpeldxcf
+            exec "$0" -uirpeldxcft
             ;;
         u)
             for file in $files

--- a/.github/checks/safety.sh
+++ b/.github/checks/safety.sh
@@ -14,6 +14,7 @@ code sanity checker
   -l         check for let _
   -e         check for expect
   -d         check for dbg!
+  -t         check for todo!
   -x         check for std::process::exit
   -b         check for bracket access
   -c         check for pedantic and other checks
@@ -25,7 +26,7 @@ EOF
 
 files=$(find . -name '*.rs' | grep -v -f .checkignore)
 
-while getopts hauiprebldxcf opt; do
+while getopts hauiprebldxcft opt; do
     case $opt in
         h)
             help
@@ -99,6 +100,18 @@ while getopts hauiprebldxcf opt; do
                 fi
             done
             ;;
+        t)
+            for file in $files
+            do
+                if sed -e '/mod test.*/,$d' -e '/ALLOW: /{N;d;}' "$file" | grep 'todo!' > /dev/null
+                then
+                    echo "##[error] todo! found in \"$file\". Just do it!."
+                    grep -nH 'todo!' "$file"
+                    count=$((count + 1))
+                fi
+            done
+            ;;
+
 
         x)
             for file in $files

--- a/src/sink/tcp.rs
+++ b/src/sink/tcp.rs
@@ -148,6 +148,6 @@ impl Sink for Tcp {
         }
     }
     fn is_active(&self) -> bool {
-        todo!()
+        self.stream.is_some()
     }
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wahl <mwahl@wayfair.com>

# Pull request

Remove leftover `todo!()` macro from TCP sink, rendering it unusable.

## Description

Remove leftover `todo!()` macro from TCP sink, rendering it unusable.
And add a check for todo! so it fails CI if this ever happens again.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment