### PR TITLE
Improve Websocket Sink

### DIFF
--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -481,8 +481,8 @@ impl ResponseIdGenerator {
 async fn codec_task(
     sink_uid: u64,
     sink_url: TremorURL,
-    mut postprocessors: Vec<Box<dyn Postprocessor>>,
-    mut preprocessors: Vec<Box<dyn Preprocessor>>,
+    mut postprocessors: Postprocessors,
+    mut preprocessors: Preprocessors,
     codec: Box<dyn Codec>,
     codec_map: HashMap<String, Box<dyn Codec>>,
     endpoint: Endpoint,

--- a/src/sink/ws.rs
+++ b/src/sink/ws.rs
@@ -20,20 +20,18 @@ use async_channel::{bounded, unbounded, Receiver, Sender};
 use async_tungstenite::async_std::connect_async;
 use futures::SinkExt;
 use halfbrown::HashMap;
-use std::boxed::Box;
 use std::time::Duration;
+use std::{boxed::Box, sync::Arc};
 use tremor_pipeline::OpMeta;
+use tremor_script::LineValue;
 use tungstenite::protocol::Message;
 use url::Url;
 
-type WsAddr = Sender<(Ids, OpMeta, WsMessage)>;
-type WsReceiver = Receiver<(Ids, OpMeta, WsMessage)>;
 type WsUrl = String;
-
-enum WsMessage {
-    Binary(Vec<u8>),
-    Text(String),
-}
+type WsConnectionHandle = (
+    Option<Sender<ConnectionTaskMsg>>,
+    task::JoinHandle<Result<()>>,
+);
 
 // TODO once we get rid of link option in offramp config,
 // we can just align this with offramp Config
@@ -50,130 +48,265 @@ pub struct Config {
     pub binary: bool,
 }
 
-enum WsResult {
-    Connected(WsUrl, WsAddr),
+enum WsConnectionMsg {
+    Connected(WsUrl, Sender<ConnectionTaskMsg>),
     Disconnected(WsUrl),
-    Ack(Ids, OpMeta),
-    Fail(Ids, OpMeta),
-    Response(Ids, Box<Result<WsMessage>>),
+}
+
+enum ConnectionTaskMsg {
+    SendEvent(Ids, WsMessageMeta, OpMeta, u64, LineValue),
+    //ToEvent(Ids, u64, Message),
 }
 
 /// An offramp that writes to a websocket endpoint
 pub struct Ws {
     sink_url: TremorURL,
+    event_origin_uri: EventOriginUri,
     config: Config,
-    postprocessors: Postprocessors,
-    preprocessors: Preprocessors,
-    codec: Box<dyn Codec>,
-    tx: Sender<WsResult>,
-    rx: Receiver<WsResult>,
-    connections: HashMap<WsUrl, Option<WsAddr>>,
+    preprocessors: Vec<String>,
+    postprocessors: Vec<String>,
+    shared_codec: Arc<dyn Codec>,
+    connection_lifecycle_tx: Sender<WsConnectionMsg>,
+    connection_lifecycle_rx: Receiver<WsConnectionMsg>,
+    connections: HashMap<WsUrl, WsConnectionHandle>,
     is_linked: bool,
     merged_meta: OpMeta,
     reply_tx: Sender<sink::Reply>,
 }
-async fn ws_loop(
+
+#[inline]
+async fn handle_error_with_fail(
+    sink_url: &TremorURL,
+    e: &str,
+    reply_tx: &Sender<sink::Reply>,
+    ids: &Ids,
+    event_origin_uri: &EventOriginUri,
+    op_meta: OpMeta,
+) -> Result<()> {
+    error!("[Sink::{}] {}", sink_url, e);
+    // send fail
+    let mut fail_event = Event::cb_fail(nanotime(), ids.clone());
+    fail_event.op_meta = op_meta;
+    reply_tx.send(sink::Reply::Insight(fail_event)).await?;
+
+    // send standardized error response
+    reply_tx
+        .send(sink::Reply::Response(
+            ERR,
+            Ws::create_error_response(ids, e, event_origin_uri),
+        ))
+        .await?;
+    Ok(())
+}
+
+#[inline]
+async fn handle_error_no_fail(
+    sink_url: &TremorURL,
+    e: &str,
+    reply_tx: &Sender<sink::Reply>,
+    ids: &Ids,
+    event_origin_uri: &EventOriginUri,
+) -> Result<()> {
+    error!("[Sink::{}] {}", sink_url, e);
+    // send standardized error response
+    reply_tx
+        .send(sink::Reply::Response(
+            ERR,
+            Ws::create_error_response(ids, e, event_origin_uri),
+        ))
+        .await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn ws_connection_loop(
     sink_url: TremorURL,
     url: String,
-    offramp_tx: Sender<WsResult>,
-    tx: WsAddr,
-    rx: WsReceiver,
+    mut event_origin_url: EventOriginUri,
+    connection_lifecycle_tx: Sender<WsConnectionMsg>,
+    reply_tx: Sender<sink::Reply>,
+    tx: Sender<ConnectionTaskMsg>,
+    rx: Receiver<ConnectionTaskMsg>,
     has_link: bool,
+    mut preprocessors: Preprocessors,
+    mut postprocessors: Postprocessors,
+    codec: Arc<dyn Codec>,
 ) -> Result<()> {
     loop {
+        info!("[Sink::{}] Connecting to {} ...", &sink_url, url);
         let mut ws_stream = if let Ok((ws_stream, _)) = connect_async(&url).await {
+            if let Ok(peer) = ws_stream.get_ref().peer_addr() {
+                event_origin_url.port = Some(peer.port());
+                event_origin_url.host = peer.ip().to_string();
+            }
+            if let Ok(local) = ws_stream.get_ref().local_addr() {
+                event_origin_url.path = vec![local.port().to_string()];
+            }
             ws_stream
         } else {
             error!(
                 "[Sink::{}] Failed to connect to {}, retrying in 1s",
                 &sink_url, url
             );
-            offramp_tx.send(WsResult::Disconnected(url.clone())).await?;
+            connection_lifecycle_tx
+                .send(WsConnectionMsg::Disconnected(url.clone()))
+                .await?;
             task::sleep(Duration::from_secs(1)).await;
             continue;
         };
-        offramp_tx
-            .send(WsResult::Connected(url.clone(), tx.clone()))
+        connection_lifecycle_tx
+            .send(WsConnectionMsg::Connected(url.clone(), tx.clone()))
             .await?;
 
-        while let Ok((id, meta, msg)) = rx.recv().await {
-            let r = match msg {
-                WsMessage::Text(t) => ws_stream.send(Message::Text(t)).await,
-                WsMessage::Binary(t) => ws_stream.send(Message::Binary(t)).await,
-            };
-            if let Err(e) = r {
-                error!(
-                    "[Sink::{}] Websocket error while sending event to server {}: {}. Reconnecting...",
-                    &sink_url,
-                    url, e
-                );
-                // TODO avoid these clones for non linked-transport usecase
-                offramp_tx.send(WsResult::Fail(id.clone(), meta)).await?;
-                if has_link {
-                    offramp_tx
-                        .send(WsResult::Response(
-                            id,
-                            Box::new(Err(Error::from(format!(
-                                "[Sink::{}] Error sending event to server {}: {}",
-                                &sink_url, url, e
-                            )))),
-                        ))
-                        .await?;
+        'recv_loop: while let Ok(ConnectionTaskMsg::SendEvent(
+            ids,
+            message_meta,
+            op_meta,
+            ingest_ns,
+            data,
+        )) = rx.recv().await
+        {
+            match event_to_message(
+                &codec,
+                &mut postprocessors,
+                ingest_ns,
+                &data,
+                message_meta.binary,
+            ) {
+                Ok(iter) => {
+                    for msg_result in iter {
+                        match msg_result {
+                            Ok(msg) => {
+                                match ws_stream.send(msg).await {
+                                    Ok(_) => {
+                                        let mut e = Event::cb_ack(nanotime(), ids.clone());
+                                        e.op_meta = op_meta.clone();
+                                        reply_tx.send(sink::Reply::Insight(e)).await?;
+                                    }
+                                    Err(e) => {
+                                        let e = format!(
+                                            "Error sending event to server {}: {}.",
+                                            &url, e
+                                        );
+                                        handle_error_with_fail(
+                                            &sink_url,
+                                            &e,
+                                            &reply_tx,
+                                            &ids,
+                                            &event_origin_url,
+                                            op_meta.clone(),
+                                        )
+                                        .await?;
+
+                                        // close connection explicitly
+                                        ws_stream.close(None).await?;
+                                        connection_lifecycle_tx
+                                            .send(WsConnectionMsg::Disconnected(url.clone()))
+                                            .await?;
+                                        break 'recv_loop; // exit recv loop in order to reconnect
+                                    }
+                                }
+                            }
+                            Err(msg_err) => {
+                                let e = format!("Invalid websocket message: {}", msg_err);
+                                handle_error_with_fail(
+                                    &sink_url,
+                                    &e,
+                                    &reply_tx,
+                                    &ids,
+                                    &event_origin_url,
+                                    op_meta.clone(),
+                                )
+                                .await?;
+                                continue; // next message, lets hope it is better
+                            }
+                        }
+                    }
                 }
-                break;
-            } else {
-                offramp_tx.send(WsResult::Ack(id.clone(), meta)).await?;
+                Err(encode_error) => {
+                    let e = format!(
+                        "Error during serialization (codec/postprocessors): {}",
+                        encode_error
+                    );
+                    handle_error_with_fail(
+                        &sink_url,
+                        &e,
+                        &reply_tx,
+                        &ids,
+                        &event_origin_url,
+                        op_meta,
+                    )
+                    .await?;
+                    continue; // next message, lets hope it is better
+                }
             }
 
-            // TODO should we async this (async_sink?) so that a slow request on a
-            // single connection does not block subsequent requests (for that connection)
-            // (over separate connections, it is already async)
+            // TODO: split ws_stream and spawn a separate task for receiving messages.
+            //       then we need to associate requests with responses and include the event id of the causing request
             if has_link {
                 if let Some(msg) = ws_stream.next().await {
                     match msg {
-                        Ok(Message::Text(t)) => {
-                            offramp_tx
-                                .send(WsResult::Response(id, Box::new(Ok(WsMessage::Text(t)))))
-                                .await?;
-                        }
-                        Ok(Message::Binary(t)) => {
-                            offramp_tx
-                                .send(WsResult::Response(id, Box::new(Ok(WsMessage::Binary(t)))))
-                                .await?;
+                        Ok(message @ Message::Text(_)) | Ok(message @ Message::Binary(_)) => {
+                            let mut ingest_ns = nanotime();
+                            match message_to_event(
+                                &sink_url,
+                                &event_origin_url,
+                                &codec,
+                                &mut preprocessors,
+                                &mut ingest_ns,
+                                &ids,
+                                message,
+                            ) {
+                                Ok(events) => {
+                                    for event in events {
+                                        reply_tx.send(sink::Reply::Response(OUT, event)).await?;
+                                    }
+                                }
+                                Err(decode_error) => {
+                                    let e_msg = format!(
+                                        "Error deserializing Response message (codec/preprocessors): {}",
+                                        decode_error
+                                    );
+                                    handle_error_no_fail(
+                                        &sink_url,
+                                        &e_msg,
+                                        &reply_tx,
+                                        &ids,
+                                        &event_origin_url,
+                                    )
+                                    .await?;
+                                    continue;
+                                }
+                            }
                         }
                         Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
                         Ok(Message::Close(_)) => {
                             warn!(
-                                "[Sink::{}] Server {} closed websocket connection",
-                                &sink_url, url
+                                "[Sink::{}] Server {} closed websocket connection.",
+                                &sink_url, &url,
                             );
-                            offramp_tx.send(WsResult::Disconnected(url.clone())).await?;
-                            offramp_tx
-                                .send(WsResult::Response(
-                                    id,
-                                    Box::new(Err(Error::from(format!(
-                                        "Error receiving reply from server {}: Server closed websocket connection",
-                                        url
-                                    )))),
-                                ))
+                            connection_lifecycle_tx
+                                .send(WsConnectionMsg::Disconnected(url.clone()))
                                 .await?;
-                            break;
+                            break 'recv_loop; // exit recv loop in order to reconnect
                         }
                         Err(e) => {
-                            error!(
-                                "[Sink::{}] Websocket error while receiving reply from server {}: {}",
+                            let e_msg =
+                                format!("Error while receiving reply from server {}: {}", &url, e);
+                            handle_error_no_fail(
                                 &sink_url,
-                                url, e
-                            );
-                            offramp_tx
-                                .send(WsResult::Response(
-                                    id,
-                                    Box::new(Err(Error::from(format!(
-                                        "Error receiving reply from server {}: {}",
-                                        url, e
-                                    )))),
-                                ))
+                                &e_msg,
+                                &reply_tx,
+                                &ids,
+                                &event_origin_url,
+                            )
+                            .await?;
+                            // close connection explicitly
+                            ws_stream.close(None).await?;
+                            connection_lifecycle_tx
+                                .send(WsConnectionMsg::Disconnected(url.clone()))
                                 .await?;
+                            break 'recv_loop; // exit recv loop in order to reconnect
                         }
                     }
                 }
@@ -182,6 +315,72 @@ async fn ws_loop(
     }
 }
 
+fn event_to_message(
+    codec: &Arc<dyn Codec>,
+    postprocessors: &mut Postprocessors,
+    ingest_ns: u64,
+    data: &LineValue,
+    binary: bool,
+) -> Result<impl Iterator<Item = Result<Message>>> {
+    let raw = codec.encode(data.suffix().value())?;
+    let datas = postprocess(postprocessors, ingest_ns, raw)?;
+    Ok(datas.into_iter().map(move |raw_data| {
+        if binary {
+            Ok(Message::Binary(raw_data))
+        } else if let Ok(txt) = String::from_utf8(raw_data) {
+            Ok(Message::Text(txt))
+        } else {
+            let msg = "Invalid utf8 data for text message";
+            Err(msg.into())
+        }
+    }))
+}
+
+fn message_to_event(
+    sink_url: &TremorURL,
+    event_origin_uri: &EventOriginUri,
+    codec: &Arc<dyn Codec>,
+    preprocessors: &mut Preprocessors,
+    ingest_ns: &mut u64,
+    ids: &Ids,
+    message: Message,
+) -> Result<Vec<Event>> {
+    let mut meta = Value::object_with_capacity(1);
+    let response_bytes = match message {
+        Message::Text(d) => {
+            meta.insert("binary", false)?;
+            d.into_bytes()
+        }
+        Message::Binary(d) => d,
+        _ => {
+            // we verified that we have binary or text above, all good
+            let msg = "Invalid response Message";
+            return Err(msg.into());
+        }
+    };
+    let preprocessed = preprocess(preprocessors, ingest_ns, response_bytes, &sink_url)?;
+    // tried using an iter, but failed, so here we go
+    let mut res = Vec::with_capacity(preprocessed.len());
+    for pp in preprocessed {
+        let data = LineValue::try_new(vec![pp], |mutd| {
+            // ALLOW: we know this is save, as we just put pp into mutd
+            let mut_data = mutd[0].as_mut_slice();
+            let body = codec
+                .decode(mut_data, nanotime())?
+                .unwrap_or_else(Value::object);
+
+            Ok(ValueAndMeta::from_parts(body, meta.clone()))
+        })
+        .map_err(|e: rental::RentalError<Error, _>| e.0)?;
+        res.push(Event {
+            id: ids.clone(),
+            origin_uri: Some(event_origin_uri.clone()),
+            data,
+            ..Event::default()
+        });
+    }
+    Ok(res)
+}
 impl offramp::Impl for Ws {
     fn from_config(config: &Option<OpConfig>) -> Result<Box<dyn Offramp>> {
         if let Some(config) = config {
@@ -195,17 +394,18 @@ impl offramp::Impl for Ws {
             let (reply_tx, _) = bounded(1);
 
             Ok(SinkManager::new_box(Self {
-                sink_url: TremorURL::from_onramp_id("ws")?, // dummy value
-                codec: Box::new(crate::codec::null::Null {}),
-                preprocessors: vec![],
-                postprocessors: vec![],
-                is_linked: false,
-                connections: HashMap::new(),
+                sink_url: TremorURL::from_onramp_id("ws")?,  // dummy value
+                event_origin_uri: EventOriginUri::default(), // dummy
                 config,
-                tx,
-                rx,
+                connection_lifecycle_tx: tx,
+                connection_lifecycle_rx: rx,
+                connections: HashMap::new(),
+                is_linked: false,
                 merged_meta: OpMeta::default(),
                 reply_tx,
+                preprocessors: vec![],  // dummy, overwritten in init
+                postprocessors: vec![], // dummy, overwritten in init
+                shared_codec: Arc::new(crate::codec::null::Null {}), //dummy, overwritten in init
             }))
         } else {
             Err("[WS Offramp] Offramp requires a config".into())
@@ -214,123 +414,48 @@ impl offramp::Impl for Ws {
 }
 
 impl Ws {
-    // TODO adopt similar reply mechanism as rest sink
-    async fn drain_insights(&mut self, ingest_ns: u64) -> Result<()> {
-        let len = self.rx.len();
+    async fn handle_connection_lifecycle_events(&mut self, ingest_ns: u64) -> Result<()> {
+        let len = self.connection_lifecycle_rx.len();
         for _ in 0..len {
-            match self.rx.recv().await? {
-                WsResult::Connected(url, addr) => {
+            match self.connection_lifecycle_rx.recv().await? {
+                WsConnectionMsg::Connected(url, addr) => {
                     // TODO trigger per url/connection (only resuming events with that url)
                     if url == self.config.url {
                         let mut e = Event::cb_restore(ingest_ns);
                         e.op_meta = self.merged_meta.clone();
                         self.reply_tx.send(sink::Reply::Insight(e)).await?;
                     }
-                    self.connections.insert(url, Some(addr));
+                    self.connections
+                        .entry(url)
+                        .and_modify(|mut tuple| tuple.0 = Some(addr));
                 }
-                WsResult::Disconnected(url) => {
+                WsConnectionMsg::Disconnected(url) => {
                     // TODO trigger per url/connection (only events with that url should be paused)
                     if url == self.config.url {
                         let mut e = Event::cb_trigger(ingest_ns);
                         e.op_meta = self.merged_meta.clone();
                         self.reply_tx.send(sink::Reply::Insight(e)).await?;
                     }
-                    self.connections.insert(url, None);
-                }
-                WsResult::Ack(id, op_meta) => {
-                    let mut e = Event::cb_ack(ingest_ns, id.clone());
-                    e.op_meta = op_meta;
-                    self.reply_tx.send(sink::Reply::Insight(e)).await?;
-                }
-                WsResult::Fail(id, op_meta) => {
-                    let mut e = Event::cb_fail(ingest_ns, id.clone());
-                    e.op_meta = op_meta;
-                    self.reply_tx.send(sink::Reply::Insight(e)).await?;
-                }
-                WsResult::Response(id, msg_result) => match *msg_result {
-                    Ok(msg) => match self.build_response_events(&id, msg) {
-                        Ok(events) => {
-                            for event in events {
-                                self.reply_tx
-                                    .send(sink::Reply::Response(OUT, event))
-                                    .await?;
-                            }
-                        }
-                        Err(err) => {
-                            error!("[Sink:{}] {}", self.sink_url, err);
-                            let err_response = Self::create_error_response(&id, err.to_string());
-                            self.reply_tx
-                                .send(sink::Reply::Response(ERR, err_response))
-                                .await?;
-                        }
-                    },
-                    Err(err) => {
-                        error!("[Sink:{}] {}", self.sink_url, err);
-                        let err_response = Self::create_error_response(&id, err.to_string());
-                        self.reply_tx
-                            .send(sink::Reply::Response(ERR, err_response))
-                            .await?;
+                    if let Some((_, handle)) = self.connections.remove(&url) {
+                        handle.cancel().await;
                     }
-                },
+                }
             }
         }
         Ok(())
     }
 
-    fn build_response_events(&mut self, id: &Ids, msg: WsMessage) -> Result<Vec<Event>> {
-        let mut meta = Value::object_with_capacity(1);
-        let response_bytes = match msg {
-            WsMessage::Text(d) => {
-                meta.insert("binary", false)?;
-                d.into_bytes()
-            }
-            WsMessage::Binary(d) => d,
-        };
-
-        let mut ingest_ns = nanotime();
-        let preprocessed = preprocess(
-            &mut self.preprocessors,
-            &mut ingest_ns,
-            response_bytes,
-            &TremorURL::from_offramp_id("ws")?, // TODO: get proper url from offramp manager
-        )?;
-        let mut events = Vec::with_capacity(preprocessed.len());
-
-        for pp in preprocessed {
-            events.push(
-                LineValue::try_new(vec![pp], |mutd| {
-                    // ALLOW: mutd is vec![pp] in the line above
-                    let mut_data = mutd[0].as_mut_slice();
-                    let body = self
-                        .codec
-                        .decode(mut_data, nanotime())?
-                        .unwrap_or_else(Value::object);
-
-                    Ok(ValueAndMeta::from_parts(body, meta.clone())) // TODO: no need to clone the last element?
-                })
-                .map_err(|e: rental::RentalError<Error, _>| e.0)
-                .map(|data| Event {
-                    id: id.clone(),
-                    origin_uri: None, // TODO
-                    data,
-                    ..Event::default()
-                })?,
-            );
-        }
-        Ok(events)
-    }
-
-    fn create_error_response(event_id: &Ids, e: String) -> Event {
+    fn create_error_response(event_id: &Ids, e: &str, origin_uri: &EventOriginUri) -> Event {
         let mut error_data = simd_json::value::borrowed::Object::with_capacity(2);
-        error_data.insert_nocheck("error".into(), Value::from(e.clone()));
+        error_data.insert_nocheck("error".into(), Value::from(e.to_string()));
         error_data.insert_nocheck("event_id".into(), Value::from(event_id.to_string()));
 
         let mut meta = simd_json::value::borrowed::Object::with_capacity(1);
-        meta.insert_nocheck("error".into(), Value::from(e));
+        meta.insert_nocheck("error".into(), Value::from(e.to_string()));
 
         Event {
             id: event_id.clone(),
-            origin_uri: None, // TODO
+            origin_uri: Some(origin_uri.clone()),
             data: (error_data, meta).into(),
             ..Event::default()
         }
@@ -340,7 +465,6 @@ impl Ws {
         WsMessageMeta {
             url: meta
                 .get("url")
-                // TODO simplify
                 .and_then(Value::as_str)
                 .unwrap_or(&self.config.url)
                 .into(),
@@ -362,114 +486,103 @@ impl Sink for Ws {
         // TODO track per url/connection (instead of just using default config url)
         self.connections
             .get(&self.config.url)
-            .map_or(false, Option::is_some)
+            .map_or(false, |(addr, _)| addr.is_some())
     }
 
     async fn on_signal(&mut self, signal: Event) -> ResultVec {
-        self.drain_insights(signal.ingest_ns).await?;
+        self.handle_connection_lifecycle_events(signal.ingest_ns)
+            .await?;
         Ok(None)
     }
 
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        _codec: &dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {
         if self.is_linked && event.is_batch {
             return Err("Batched events are not supported for linked websocket offramps".into());
         }
+        // check for connects or disconnects
+        // otherwise, we might lose some events to a connection, where connect is in progress
+        self.handle_connection_lifecycle_events(nanotime()).await?;
 
-        self.merged_meta.merge(event.op_meta.clone());
+        let Event {
+            id,
+            data,
+            ingest_ns,
+            op_meta,
+            ..
+        } = event;
 
-        for (value, meta) in event.value_meta_iter() {
-            let msg_meta = self.get_message_meta(meta);
+        self.merged_meta.merge(op_meta);
+        let msg_meta = self.get_message_meta(data.suffix().meta());
 
-            // actually used when we have new connection to make (overriden from event-meta)
-            let temp_conn_tx;
-            let ws_conn_tx = if let Some(ws_conn_tx) = self.connections.get(&msg_meta.url) {
-                ws_conn_tx
-            } else {
-                let (conn_tx, conn_rx) = bounded(crate::QSIZE);
-                // separate task to handle new url connection
-                task::spawn(ws_loop(
-                    self.sink_url.clone(),
-                    msg_meta.url.clone(),
-                    self.tx.clone(),
-                    conn_tx.clone(),
-                    conn_rx,
-                    self.is_linked,
-                ));
-                // TODO default to None for initial connection? (like what happens for
-                // default offramp config url). if we do circuit-breakers-per-url
-                // connection, this will be handled better.
-                self.connections
-                    .insert(msg_meta.url.clone(), Some(conn_tx.clone()));
-                // sender here ensures we don't drop the current in-flight event
-                temp_conn_tx = Some(conn_tx);
-                &temp_conn_tx
-            };
+        // actually used when we have new connection to make (overriden from event-meta)
+        let temp_conn_tx;
+        let ws_conn_tx = if let Some((ws_conn_tx, _)) = self.connections.get(&msg_meta.url) {
+            ws_conn_tx
+        } else {
+            let (conn_tx, conn_rx) = bounded(crate::QSIZE);
+            // separate task to handle new url connection
+            let handle = task::spawn(ws_connection_loop(
+                self.sink_url.clone(),
+                msg_meta.url.clone(),
+                self.event_origin_uri.clone(),
+                self.connection_lifecycle_tx.clone(),
+                self.reply_tx.clone(),
+                conn_tx.clone(),
+                conn_rx,
+                self.is_linked,
+                make_preprocessors(self.preprocessors.as_slice())?,
+                make_postprocessors(self.postprocessors.as_slice())?,
+                self.shared_codec.clone(),
+            ));
+            // TODO default to None for initial connection? (like what happens for
+            // default offramp config url). if we do circuit-breakers-per-url
+            // connection, this will be handled better.
+            self.connections
+                .insert(msg_meta.url.clone(), (Some(conn_tx.clone()), handle));
+            // sender here ensures we don't drop the current in-flight event
+            temp_conn_tx = Some(conn_tx);
+            &temp_conn_tx
+        };
 
-            if let Some(conn_tx) = ws_conn_tx {
-                let raw = codec.encode(value)?; // TODO 001: handle errors with CBFail and response via ERR port, see rest sink l. 487..
-                let datas = postprocess(&mut self.postprocessors, event.ingest_ns, raw)?; // TODO 001: same here
-                for raw in datas {
-                    if msg_meta.binary {
-                        conn_tx
-                            .send((
-                                event.id.clone(),
-                                self.merged_meta.clone(),
-                                WsMessage::Binary(raw),
-                            ))
-                            .await?;
-                    } else if let Ok(txt) = String::from_utf8(raw) {
-                        conn_tx
-                            .send((
-                                event.id.clone(),
-                                self.merged_meta.clone(),
-                                WsMessage::Text(txt),
-                            ))
-                            .await?;
-                    } else {
-                        error!("[WS Offramp] Invalid utf8 data for text message");
-                        let e = "Invalid utf8 data for text message";
-
-                        self.reply_tx
-                            .send(sink::Reply::Response(
-                                ERR,
-                                Self::create_error_response(&event.id, e.to_string()),
-                            ))
-                            .await?;
-                        return Err(e.into());
-                    }
-                }
-            } else {
-                // connnection is in a disconnected state, but if this is a linked offramp,
-                // got to send a response
-                // TODO send this always and also log error here?
-                if self.is_linked {
-                    let err = "Error getting response for event: websocket sink is not connected";
-                    self.reply_tx
-                        .send(sink::Reply::Response(
-                            ERR,
-                            Self::create_error_response(&event.id, err.to_string()),
-                        ))
-                        .await?;
-                }
-            }
+        if let Some(conn_tx) = ws_conn_tx {
+            conn_tx
+                .send(ConnectionTaskMsg::SendEvent(
+                    id,
+                    msg_meta,
+                    self.merged_meta.clone(),
+                    ingest_ns,
+                    data,
+                ))
+                .await?;
+        } else {
+            let err = format!("No connection available for {}.", &msg_meta.url);
+            handle_error_with_fail(
+                &self.sink_url,
+                &err,
+                &self.reply_tx,
+                &id,
+                &self.event_origin_uri,
+                self.merged_meta.clone(),
+            )
+            .await?;
         }
-        self.drain_insights(event.ingest_ns).await?;
         Ok(None)
     }
 
     fn default_codec(&self) -> &str {
         "json"
     }
+
     #[allow(clippy::too_many_arguments)]
     async fn init(
         &mut self,
-        _sink_uid: u64,
+        sink_uid: u64,
         sink_url: &TremorURL,
         codec: &dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
@@ -477,25 +590,52 @@ impl Sink for Ws {
         is_linked: bool,
         reply_channel: Sender<sink::Reply>,
     ) -> Result<()> {
-        self.postprocessors = make_postprocessors(processors.post)?;
-        self.preprocessors = make_preprocessors(processors.pre)?;
+        self.shared_codec = codec.boxed_clone().into();
+        self.postprocessors = processors.post.to_vec();
+        self.preprocessors = processors.pre.to_vec();
+
         self.is_linked = is_linked;
-        // TODO use reply_channel here too (like for rest)
+        self.sink_url = sink_url.clone();
+        let parsed = Url::parse(&self.config.url)?; // should not fail as it has already been verified
+        let origin_url = EventOriginUri {
+            uid: sink_uid,
+            scheme: "tremor-ws".to_string(),
+            host: parsed.host_str().unwrap_or("UNKNOWN").to_string(),
+            port: parsed.port(),
+            path: vec![],
+        };
+        self.event_origin_uri = origin_url;
 
         // handle connection for the offramp config url (as default)
         let (conn_tx, conn_rx) = bounded(crate::QSIZE);
-        self.connections.insert(self.config.url.clone(), None);
-        self.codec = codec.boxed_clone();
         self.reply_tx = reply_channel;
-        task::spawn(ws_loop(
-            sink_url.clone(),
-            self.config.url.clone(),
-            self.tx.clone(),
-            conn_tx,
-            conn_rx,
-            is_linked,
-        ));
+        let handle = task::Builder::new()
+            .name(format!("{}-connection-{}", &sink_url, &self.config.url))
+            .spawn(ws_connection_loop(
+                sink_url.clone(),
+                self.config.url.clone(),
+                self.event_origin_uri.clone(),
+                self.connection_lifecycle_tx.clone(),
+                self.reply_tx.clone(),
+                conn_tx,
+                conn_rx,
+                is_linked,
+                make_preprocessors(self.preprocessors.as_slice())?,
+                make_postprocessors(self.postprocessors.as_slice())?,
+                self.shared_codec.clone(),
+            ))?;
+        self.connections
+            .insert(self.config.url.clone(), (None, handle));
 
         Ok(())
+    }
+
+    async fn terminate(&mut self) {
+        futures::future::join_all(
+            self.connections
+                .drain()
+                .map(|(_, (_, handle))| handle.cancel()),
+        )
+        .await;
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -47,6 +47,7 @@ pub(crate) mod ws;
 
 struct StaticValue(Value<'static>);
 
+#[derive(Default)]
 /// Set of pre and postprocessors
 pub struct Processors<'processor> {
     /// preprocessors


### PR DESCRIPTION
# Pull request

Improve Websocket Sink

## Description

* Handle serialization of outgoing events and deserialization of incoming messages completely on the connection task that is spawned for each tcp connection (by default only 1 for the configured url) to increase parallelism between connections.
* Make use of reply_channel wherever possible to have quick acks and responses
* websocket connection lifecycle events leading to a CB close or open are handled every time an event or a signal comes in. This bumps us up to max 100ms delay in the worst case, but only for CB::close/open events, nothing else.

Fixes #489 
Fixes #490 

## Related

## Checklist



* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment