### PR TITLE
Fix linked offramp not shutting down after binding is deleted.

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -123,6 +123,10 @@ where
     fn new_box(sink: T) -> Box<Self> {
         Box::new(Self::new(sink))
     }
+
+    fn has_dest_pipelines(&self) -> bool {
+        self.dest_pipelines.values().any(|xs| !xs.is_empty())
+    }
 }
 
 #[async_trait::async_trait]
@@ -199,13 +203,13 @@ where
 
     fn remove_pipeline(&mut self, id: TremorURL) -> bool {
         self.pipelines.remove(&id);
-        self.pipelines.is_empty() && self.dest_pipelines.is_empty()
+        self.pipelines.is_empty() && !self.has_dest_pipelines()
     }
     fn remove_dest_pipeline(&mut self, port: Cow<'static, str>, id: TremorURL) -> bool {
         if let Some(port_ps) = self.dest_pipelines.get_mut(&port) {
             port_ps.retain(|(url, _)| url != &id)
         }
-        self.pipelines.is_empty() && self.dest_pipelines.is_empty()
+        self.pipelines.is_empty() && !self.has_dest_pipelines()
     }
 
     async fn on_signal(&mut self, signal: Event) -> Option<Event> {

--- a/tremor-cli/tests/api/command.yml
+++ b/tremor-cli/tests/api/command.yml
@@ -1076,7 +1076,7 @@ suites:
           - source: stdout
             contains:
               - "id: ws-linked"
-              # - "instances: []" # Disable for now since this is a known bug tracked in another PR
+              - "instances: []"
   - name: REST API - Error formatting
     tags:
       - error

--- a/tremor-cli/tests/api/data/linked/binding.yaml
+++ b/tremor-cli/tests/api/data/linked/binding.yaml
@@ -2,8 +2,8 @@ id: linked
 links:
   '/onramp/ws-linked/{instance}/out': ['/pipeline/system::passthrough/system/in']
   '/pipeline/system::passthrough/system/out': ['/offramp/ws-linked/{instance}/in']
-  'offramp/ws-linked/{instance}/out': ['/pipeline/main/{instance}/in']
-  'offramp/ws-linked/{instance}/err': ['/pipeline/main/{instance}/in']
+  '/offramp/ws-linked/{instance}/out': ['/pipeline/main/{instance}/in']
+  '/offramp/ws-linked/{instance}/err': ['/pipeline/main/{instance}/in']
   '/onramp/ws-linked/{instance}/err': ['/pipeline/main/system/in']
   '/pipeline/main/{instance}/out': ['/onramp/ws-linked/{instance}/in']
   '/pipeline/main/{instance}/err': ['/onramp/ws-linked/{instance}/in']


### PR DESCRIPTION
# Pull request

properly check for empty linked pipelines in offramps.

## Description

properly check for empty linked pipelines in offramps.

## Related

## Checklist


* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment