### PR TITLE
Fix slow kafka sink when queue.buffering.max.ms is set to > 0.

### DIFF
--- a/src/sink/elastic.rs
+++ b/src/sink/elastic.rs
@@ -91,7 +91,7 @@ impl offramp::Impl for Elastic {
 
 impl Elastic {
     async fn drain_insights(&mut self) -> ResultVec {
-        let mut v = Vec::with_capacity(self.tx.len() + 1);
+        let mut v = Vec::with_capacity(self.rx.len() + 1);
         while let Ok(e) = self.rx.try_recv() {
             v.push(e)
         }

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -23,7 +23,7 @@
 //! See [Config](struct.Config.html) for details.
 
 use crate::sink::prelude::*;
-use crate::source::kafka::SmolRuntime;
+use async_channel::{bounded, Receiver, Sender};
 use halfbrown::HashMap;
 use rdkafka::config::ClientConfig;
 use rdkafka::{
@@ -31,7 +31,6 @@ use rdkafka::{
     producer::{FutureProducer, FutureRecord},
 };
 use std::fmt;
-use std::time::Duration;
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -60,11 +59,15 @@ pub struct Config {
 impl Config {
     fn producer(&self) -> Result<FutureProducer> {
         let mut producer_config = ClientConfig::new();
+
+        // ENABLE LIBRDKAFKA DEBUGGING:
+        // - set librdkafka logger to debug in logger.yaml
+        // - configure: debug: "all" for this onramp
         let producer_config = producer_config
             .set("client.id", &format!("tremor-{}-{}", self.hostname, 0))
             .set("bootstrap.servers", &self.brokers.join(","))
             .set("message.timeout.ms", "5000")
-            .set("queue.buffering.max.ms", "0");
+            .set("queue.buffering.max.ms", "0"); // set to 0 for sending each message out immediately without kafka client internal batching --> low latency, busy network
 
         Ok(self
             .rdkafka_options
@@ -82,14 +85,18 @@ fn d_host() -> String {
 
 /// Kafka offramp connectoz
 pub struct Kafka {
+    sink_url: TremorURL,
     config: Config,
     producer: FutureProducer,
     postprocessors: Postprocessors,
+    reply_tx: Sender<sink::Reply>,
+    error_rx: Receiver<KafkaError>,
+    error_tx: Sender<KafkaError>,
 }
 
 impl fmt::Debug for Kafka {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Kafka: {}", self.config.topic)
+        write!(f, "[Sink::{}] Kafka: {}", &self.sink_url, self.config.topic)
     }
 }
 
@@ -99,11 +106,18 @@ impl offramp::Impl for Kafka {
             let config: Config = Config::new(config)?;
             let producer = config.producer()?;
             // Create the thread pool where the expensive computation will be performed.
+            let (dummy_tx, _) = bounded(1);
 
+            // TODO: does this need to be unbounded?
+            let (error_tx, error_rx) = bounded(crate::QSIZE);
             Ok(SinkManager::new_box(Self {
+                sink_url: TremorURL::from_offramp_id("kafka")?, // dummy
                 config,
                 producer,
                 postprocessors: vec![],
+                reply_tx: dummy_tx,
+                error_rx,
+                error_tx,
             }))
         } else {
             Err("Kafka offramp requires a config".into())
@@ -145,6 +159,74 @@ where
     }
 }
 
+/// Waits for actual delivery to kafka cluster and sends ack or fail.
+/// Also sends fatal errors for handling in offramp task.
+async fn wait_for_delivery(
+    sink_url: String,
+    futures: Vec<rdkafka::producer::DeliveryFuture>,
+    mut insight_event: Event,
+    reply_tx: Sender<sink::Reply>,
+    error_tx: Sender<KafkaError>,
+) -> Result<()> {
+    let cb = match futures::future::try_join_all(futures).await {
+        Ok(results) => {
+            if let Some((kafka_error, _)) = results.into_iter().find_map(|res| res.err()) {
+                error!(
+                    "[Sink::{}] Error delivering kafka record: {}",
+                    sink_url, &kafka_error
+                );
+                if is_fatal(&kafka_error) {
+                    error_tx.send(kafka_error).await?;
+                }
+                CBAction::Fail
+            } else {
+                // all good. send ack
+                CBAction::Ack
+            }
+        }
+        Err(e) => {
+            error!(
+                "[Sink::{}] DeliveryFuture cancelled. Message delivery status unclear, considering it failed.: {}",
+                sink_url, e
+            );
+            // oh noes, send fail
+            CBAction::Fail
+        }
+    };
+    insight_event.cb = cb;
+    reply_tx.send(sink::Reply::Insight(insight_event)).await?;
+    Ok(())
+}
+
+impl Kafka {
+    fn drain_fatal_errors(&mut self) -> Result<()> {
+        let mut handled = false;
+        while let Ok(e) = self.error_rx.try_recv() {
+            if !handled {
+                // only handle on first fatal error
+                self.handle_fatal_error(e)?;
+                handled = true;
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_fatal_error(&mut self, _fatal_error: KafkaError) -> Result<()> {
+        let maybe_fatal_error = unsafe { get_fatal_error(self.producer.client()) };
+        if let Some(fatal_error) = maybe_fatal_error {
+            error!(
+                "[Sink::{}] Fatal Error({:?}): {}",
+                &self.sink_url, fatal_error.0, fatal_error.1
+            );
+        }
+        error!("[Sink::{}] Reinitiating client...", &self.sink_url);
+        self.producer = self.config.producer()?;
+        error!("[Sink::{}] Client reinitiated.", &self.sink_url);
+
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
 impl Sink for Kafka {
     async fn on_event(
@@ -152,48 +234,56 @@ impl Sink for Kafka {
         _input: &str,
         codec: &dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
-        event: Event,
+        mut event: Event,
     ) -> ResultVec {
-        let mut success = true;
+        // ensure we handle any fatal errors occured during last on_event invocation
+        self.drain_fatal_errors()?;
+
         let ingest_ns = event.ingest_ns;
+        let mut delivery_futures = Vec::with_capacity(event.len()); // might not be enough
+        let mut insight_event = event.insight_ack(); // we gonna change the success status later, if need be
         for (value, meta) in event.value_meta_iter() {
             let encoded = codec.encode(value)?;
             let processed = postprocess(self.postprocessors.as_mut_slice(), ingest_ns, encoded)?;
-            for raw in processed {
-                let mut record = FutureRecord::to(&self.config.topic);
-                record = record.payload(&raw);
+            let meta_kafka_key = meta.get("kafka_key").and_then(Value::as_str);
+            for payload in processed {
+                // TODO: allow defining partition and timestamp in meta
+                let mut record = FutureRecord::to(self.config.topic.as_str());
+                record = record.payload(&payload);
+                if let Some(kafka_key) = meta_kafka_key {
+                    record = record.key(kafka_key);
+                } else if let Some(kafka_key) = &self.config.key {
+                    record = record.key(kafka_key.as_str());
+                }
 
-                let record = if let Some(k) = meta.get("kafka_key").and_then(Value::as_str) {
-                    record.key(k)
-                } else if let Some(ref k) = self.config.key {
-                    record.key(k.as_str())
-                } else {
-                    record
-                };
-                match self
-                    .producer
-                    .send_with_runtime::<SmolRuntime, _, _, _>(record, Duration::from_secs(0))
-                    .await
-                {
-                    Ok(_) => {}
-                    Err((e, _r)) => {
-                        error!("[Kafka Offramp] failed to enque message: {}", e);
+                // send out without blocking on delivery
+                match self.producer.send_result(record) {
+                    Ok(delivery_future) => {
+                        delivery_futures.push(delivery_future);
+                    }
+                    Err((e, _)) => {
+                        error!("[Sink::{}] failed to enque message: {}", &self.sink_url, e);
                         if is_fatal(&e) {
-                            if let Some((code, fatal)) =
-                                unsafe { get_fatal_error(self.producer.client()) }
-                            {
-                                error!("[Kafka Offramp] Fatal Error({:?}): {}", code, fatal);
-                            }
-                            self.producer = self.config.producer()?;
-                            error!("[Kafka Offramp] reinitiating client");
+                            // handle fatal errors right here, without enqueueing
+                            self.handle_fatal_error(e)?;
                         }
-                        success = false;
-                        break;
+                        // bail out with a CB fail on enqueue error
+                        insight_event.cb = CBAction::Fail;
+                        return Ok(Some(vec![sink::Reply::Insight(insight_event)]));
                     }
                 }
             }
         }
-        Ok(Some(vec![sink::Reply::Insight(event.insight(success))]))
+        // successfully enqueued all messages
+        // spawn the task waiting for delivery and send acks/fails then
+        task::spawn(wait_for_delivery(
+            self.sink_url.to_string(),
+            delivery_futures,
+            insight_event,
+            self.reply_tx.clone(),
+            self.error_tx.clone(),
+        ));
+        Ok(None)
     }
     fn default_codec(&self) -> &str {
         "json"
@@ -202,17 +292,20 @@ impl Sink for Kafka {
     async fn init(
         &mut self,
         _sink_uid: u64,
-        _sink_url: &TremorURL,
+        sink_url: &TremorURL,
         _codec: &dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         processors: Processors<'_>,
         _is_linked: bool,
-        _reply_channel: Sender<sink::Reply>,
+        reply_channel: Sender<sink::Reply>,
     ) -> Result<()> {
         self.postprocessors = make_postprocessors(processors.post)?;
+        self.reply_tx = reply_channel.clone();
+        self.sink_url = sink_url.clone();
         Ok(())
     }
     async fn on_signal(&mut self, _signal: Event) -> ResultVec {
+        self.drain_fatal_errors()?;
         Ok(None)
     }
     fn is_active(&self) -> bool {

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -21,7 +21,7 @@ use futures::future::{self, FutureExt};
 use futures::StreamExt;
 use halfbrown::HashMap;
 use rdkafka::client::ClientContext;
-use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
+use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::{self, StreamConsumer};
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext};
 use rdkafka::error::KafkaResult;

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -37,7 +37,7 @@ use std::time::{Duration, Instant};
 pub struct SmolRuntime;
 
 impl AsyncRuntime for SmolRuntime {
-    type Delay = future::Map<async_io::Timer, fn(Instant)>;
+    type Delay = future::Map<smol::Timer, fn(Instant)>;
 
     fn spawn<T>(task: T)
     where
@@ -331,6 +331,10 @@ impl Source for Int {
         info!("Starting kafka onramp {}", self.onramp_id);
         // Setting up the configuration with default and then overwriting
         // them with custom settings.
+        //
+        // ENABLE LIBRDKAFKA DEBUGGING:
+        // - set librdkafka logger to debug in logger.yaml
+        // - configure: debug: "all" for this onramp
         let client_config = client_config
             .set("group.id", &self.config.group_id)
             .set(
@@ -344,8 +348,7 @@ impl Source for Int {
             .set("enable.auto.commit", "true")
             .set("auto.commit.interval.ms", "5000")
             // but only commit the offsets explicitly stored via `consumer.store_offset`.
-            .set("enable.auto.offset.store", "true")
-            .set_log_level(RDKafkaLogLevel::Debug);
+            .set("enable.auto.offset.store", "true");
 
         let client_config = if let Some(options) = self.config.rdkafka_options.as_ref() {
             options

--- a/tremor-pipeline/src/event.rs
+++ b/tremor-pipeline/src/event.rs
@@ -174,12 +174,7 @@ impl Event {
     /// normally 1, but for batched events possibly > 1
     pub fn len(&self) -> usize {
         if self.is_batch {
-            self.data
-                .suffix()
-                .value()
-                .as_array()
-                .map(Vec::len)
-                .unwrap_or_default()
+            self.data.suffix().value().as_array().map_or(0, Vec::len)
         } else {
             1
         }
@@ -194,8 +189,7 @@ impl Event {
                 .suffix()
                 .value()
                 .as_array()
-                .map(Vec::is_empty)
-                .unwrap_or(true)
+                .map_or(true, Vec::is_empty)
     }
 }
 

--- a/tremor-pipeline/src/event.rs
+++ b/tremor-pipeline/src/event.rs
@@ -168,6 +168,22 @@ impl Event {
             ..Event::default()
         }
     }
+
+    #[must_use]
+    /// return the number of events contained within this event
+    /// normally 1, but for batched events possibly > 1
+    pub fn len(&self) -> usize {
+        if self.is_batch {
+            self.data
+                .suffix()
+                .value()
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or_default()
+        } else {
+            1
+        }
+    }
 }
 
 /// Iterator over the event value and metadata


### PR DESCRIPTION
# Pull request

## Description

Our kafka sink was not only enqueueing every kafka record coming from an event, but also waiting for its delivery before returning. The setting `queue.buffering.max.ms` determined how the rdkafka broker thread waited upon receiving the message in its queue until it sends it off to the broker. The goal here is to possibly batch messages for more efficient transport. But we handle each sink in its own task, and this one task is blocked until message N is delivered. So there is no other message which can arrive before `queue.buffering.max.ms` expires. Ergo, we not only always waited for `queue.buffering.max.ms` (if set to > 0), we never applied any kafka internal batching and always sent out 1 message to the broker. Yes, indeed!

Now we only enqueue all messages coming from an event and then, in another spawned task, wait for the delivery to happen to send out acks/fails.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #532 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment