### PR TITLE
Allow using err for errors in tremor run

### DIFF
--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -179,7 +179,7 @@ impl Egress {
             Ok(Return::Drop) => Ok(()),
             Ok(Return::Emit { value, port }) => {
                 match port.unwrap_or_else(|| String::from("out")).as_str() {
-                    "error" | "stderr" => {
+                    "err" | "error" | "stderr" => {
                         self.buffer
                             .write_all(format!("{}\n", value.encode()).as_bytes())?;
                         self.buffer.flush()?;


### PR DESCRIPTION
# Pull request

## Description

Allow using `err` as a target for `tremor run` pipelines

## Related

* Related Issues: fixes #591 

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment