### PR TITLE
Allow err on a pipeline output for run

### DIFF
--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -179,7 +179,7 @@ impl Egress {
             Ok(Return::Drop) => Ok(()),
             Ok(Return::Emit { value, port }) => {
                 match port.unwrap_or_else(|| String::from("out")).as_str() {
-                    "error" | "stderr" => {
+                    "err" | "error" | "stderr" => {
                         self.buffer
                             .write_all(format!("{}\n", value.encode()).as_bytes())?;
                         self.buffer.flush()?;

--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -210,7 +210,7 @@ impl Egress {
             }
             Ok(Return::EmitEvent { port }) => {
                 match port.unwrap_or_else(|| String::from("out")).as_str() {
-                    "error" | "stderr" => {
+                    "err" | "error" | "stderr" => {
                         eprintln!("{}", event.encode());
                     }
                     _ => {


### PR DESCRIPTION
# Pull request


## Description

Allow err on as pipeline output for run

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment