### PR TITLE
Changes for successful tide upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,9 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "tide"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c4c4e35f5a89ed08cbb59b6e4e1d648e563d6f8daa804002f3557d11d3c8f9"
+checksum = "c832ca099a0645f6446b6c8900b09e3b76978dedc0d7383438698b32ff07f734"
 dependencies = [
  "async-h1",
  "async-session",
@@ -4940,8 +4940,10 @@ dependencies = [
  "async-trait",
  "femme",
  "futures-util",
+ "http-client",
  "http-types",
  "kv-log-macro",
+ "log",
  "pin-project-lite",
  "route-recognizer",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ grok = "1"
 #openssl = { version = "0.10" }
 
 # rest onramp
-tide = "0.13"
+tide = "0.15"
 
 [dependencies.tungstenite]
 default-features = false

--- a/tremor-api/Cargo.toml
+++ b/tremor-api/Cargo.toml
@@ -14,6 +14,6 @@ serde = "1"
 serde_derive = "1"
 serde_yaml = "0.8"
 hashbrown = { version = "0.9", features = ["serde"] }
-tide = "0.13"
+tide = "0.15"
 http-types = "2.8"
 simd-json = "0.3"

--- a/tremor-api/src/api/binding.rs
+++ b/tremor-api/src/api/binding.rs
@@ -54,16 +54,16 @@ pub async fn publish_artefact(req: Request) -> Result<Response> {
 }
 
 pub async fn unpublish_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["binding", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["binding", id])?;
     let repo = &req.state().world.repo;
     let result = repo.unpublish_binding(&url).await?;
     reply(req, result.binding, true, StatusCode::Ok).await
 }
 
 pub async fn get_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["binding", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["binding", id])?;
 
     let repo = &req.state().world.repo;
     let result = repo
@@ -84,9 +84,9 @@ pub async fn get_artefact(req: Request) -> Result<Response> {
 }
 
 pub async fn get_servant(req: Request) -> Result<Response> {
-    let a_id: String = req.param("aid").unwrap_or_default();
-    let s_id: String = req.param("sid").unwrap_or_default();
-    let url = build_url(&["binding", &a_id, &s_id])?;
+    let a_id = req.param("aid").unwrap_or_default();
+    let s_id = req.param("sid").unwrap_or_default();
+    let url = build_url(&["binding", a_id, s_id])?;
 
     let registry = &req.state().world.reg;
     let result = registry
@@ -102,9 +102,9 @@ pub async fn get_servant(req: Request) -> Result<Response> {
 pub async fn link_servant(req: Request) -> Result<Response> {
     let (req, decoded_data): (_, HashMap<String, String, _>) = decode(req).await?;
 
-    let a_id: String = req.param("aid").unwrap_or_default();
-    let s_id: String = req.param("sid").unwrap_or_default();
-    let url = build_url(&["binding", &a_id, &s_id])?;
+    let a_id = req.param("aid").unwrap_or_default();
+    let s_id = req.param("sid").unwrap_or_default();
+    let url = build_url(&["binding", a_id, s_id])?;
     let world = &req.state().world;
 
     let result = world.link_binding(&url, decoded_data).await?.binding;
@@ -114,9 +114,9 @@ pub async fn link_servant(req: Request) -> Result<Response> {
 
 #[allow(clippy::implicit_hasher)]
 pub async fn unlink_servant(req: Request) -> Result<Response> {
-    let a_id: String = req.param("aid").unwrap_or_default();
-    let s_id: String = req.param("sid").unwrap_or_default();
-    let url = build_url(&["binding", &a_id, &s_id])?;
+    let a_id = req.param("aid").unwrap_or_default();
+    let s_id = req.param("sid").unwrap_or_default();
+    let url = build_url(&["binding", a_id, s_id])?;
 
     let world = &req.state().world;
     let result = world.unlink_binding(&url, HashMap::new()).await?.binding;

--- a/tremor-api/src/api/offramp.rs
+++ b/tremor-api/src/api/offramp.rs
@@ -39,16 +39,16 @@ pub async fn publish_artefact(req: Request) -> Result<Response> {
 }
 
 pub async fn unpublish_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["offramp", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["offramp", id])?;
     let repo = &req.state().world.repo;
     let result = repo.unpublish_offramp(&url).await?;
     reply(req, result, true, StatusCode::Ok).await
 }
 
 pub async fn get_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["offramp", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["offramp", id])?;
     let repo = &req.state().world.repo;
     let result = repo
         .find_offramp(&url)

--- a/tremor-api/src/api/onramp.rs
+++ b/tremor-api/src/api/onramp.rs
@@ -40,16 +40,16 @@ pub async fn publish_artefact(req: Request) -> Result<Response> {
 }
 
 pub async fn unpublish_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["onramp", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["onramp", id])?;
     let repo = &req.state().world.repo;
     let result = repo.unpublish_onramp(&url).await?;
     reply(req, result, true, StatusCode::Ok).await
 }
 
 pub async fn get_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["onramp", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["onramp", id])?;
     let repo = &req.state().world.repo;
     let result = repo.find_onramp(&url).await?.ok_or_else(Error::not_found)?;
     let result = OnRampWrap {

--- a/tremor-api/src/api/pipeline.rs
+++ b/tremor-api/src/api/pipeline.rs
@@ -119,8 +119,8 @@ pub async fn reply_trickle_instanced(
 }
 
 pub async fn unpublish_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["pipeline", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["pipeline", id])?;
     let repo = &req.state().world.repo;
     let result = repo
         .unpublish_pipeline(&url)
@@ -130,8 +130,8 @@ pub async fn unpublish_artefact(req: Request) -> Result<Response> {
 }
 
 pub async fn get_artefact(req: Request) -> Result<Response> {
-    let id: String = req.param("aid").unwrap_or_default();
-    let url = build_url(&["pipeline", &id])?;
+    let id = req.param("aid").unwrap_or_default();
+    let url = build_url(&["pipeline", id])?;
     let repo = &req.state().world.repo;
     let result = repo
         .find_pipeline(&url)

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -37,7 +37,7 @@ serde_yaml = "0.8"
 simd-json = {version = "0.3", features = ["known-key"]}
 snmalloc-rs = {version = "0.2", optional = false}
 surf = "=2.1.0"
-tide = "0.13"
+tide = "0.15"
 tremor-api = {path = "../tremor-api"}
 tremor-common = {path = "../tremor-common"}
 tremor-pipeline = {path = "../tremor-pipeline"}


### PR DESCRIPTION
# Pull request

Assist dependabot, by accounting for tide api changes and ensuring that our tests pass.

Replaces https://github.com/tremor-rs/tremor-runtime/pull/589.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment