### PR TITLE
Add verbose flag to codecov action for debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
           file: ./cobertura.xml
+          verbose: true


### PR DESCRIPTION
# Pull request

CI changes only, for debugging

## Description

context: https://community.codecov.io/t/codecov-commit-status-check-missing-for-pr-when-using-codecov-action/1813/19

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment