### PR TITLE
Add hygienic runtime-error feedback for `tremor run`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,8 +22,8 @@
       "args": [
         //"server",
         "run",
-        //"temp/end.tremor",
-        "tests/scripts/heredoc_interpolation_quotes/script.tremor"
+        "temp/sample.trickle",
+        //"tests/scripts/heredoc_interpolation_quotes/script.tremor"
         //"-f",
         //"../tremor-www-docs/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/config/config.yaml",
         // "../tremor-www-docs/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/config/request_handling.trickle",

--- a/tests/query_errors/pp_embed_unrecognized_token2/error.txt
+++ b/tests/query_errors/pp_embed_unrecognized_token2/error.txt
@@ -3,5 +3,3 @@ Error:
     2 | script
     3 |   use foo :: ";
       |              ^^ It looks like you forgot to terminate a string with a closing '"'
-    4 | end;
-    5 |

--- a/tests/query_errors/pp_unrecognized_token2/error.txt
+++ b/tests/query_errors/pp_unrecognized_token2/error.txt
@@ -1,4 +1,3 @@
 Error: 
     1 | use foo :: ";
       |            ^^ It looks like you forgot to terminate a string with a closing '"'
-    2 |

--- a/tremor-cli/src/debug.rs
+++ b/tremor-cli/src/debug.rs
@@ -159,9 +159,7 @@ where
         "Lexical token stream after preprocessing",
     )?;
 
-    let lexemes: Vec<_> = Tokenizer::new(&opts.raw)
-        .filter_map(std::result::Result::ok)
-        .collect();
+    let lexemes: Vec<_> = Tokenizer::new(&opts.raw).tokenize_until_err().collect();
 
     dbg_tokens(h, lexemes)?;
 

--- a/tremor-cli/src/util.rs
+++ b/tremor-cli/src/util.rs
@@ -290,7 +290,7 @@ pub(crate) fn highlight(is_pretty: bool, value: &Value) -> Result<()> {
         }
     );
     let lexed_tokens: Vec<_> = lexer::Tokenizer::new(&result)
-        .filter_map(std::result::Result::ok)
+        .tokenize_until_err()
         .collect();
 
     let mut h = TermHighlighter::default();

--- a/tremor-script/src/lexer.rs
+++ b/tremor-script/src/lexer.rs
@@ -738,6 +738,16 @@ impl<'input> Tokenizer<'input> {
             pos: span(start, end, start, end),
         }
     }
+
+    /// Turn this Tokenizer into an `Iterator` of tokens that are produced until the first error is hit
+    ///
+    /// The purpose of this method is to not accidentally consume tokens after an error,
+    /// which might be completely incorrect, but would still show up in the resulting iterator if
+    /// used with `filter_map(Result::ok)` for example.
+    pub fn tokenize_until_err(self) -> impl Iterator<Item = Spanned<Token<'input>>> {
+        // i wanna use map_while here, but it is still unstable :(
+        self.scan((), |_, item| item.ok()).fuse()
+    }
 }
 
 impl<'input> Iterator for Tokenizer<'input> {

--- a/tremor-script/src/pos.rs
+++ b/tremor-script/src/pos.rs
@@ -98,7 +98,7 @@ pub struct Spanned<T> {
 #[derive(
     Copy, Clone, Default, Eq, PartialEq, Debug, Hash, Ord, PartialOrd, Serialize, Deserialize,
 )]
-pub struct Range(pub(crate) Location, pub(crate) Location);
+pub struct Range(pub Location, pub Location);
 impl Range {
     pub(crate) fn expand_lines(&self, lines: usize) -> Self {
         let mut new = *self;

--- a/tremor-script/src/query.rs
+++ b/tremor-script/src/query.rs
@@ -165,7 +165,7 @@ where
         let mut script = script.to_string();
         script.push('\n');
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
-            .filter_map(Result::ok)
+            .tokenize_until_err()
             .collect();
         h.highlight(None, &tokens)
     }
@@ -180,7 +180,7 @@ where
         script.push('\n');
 
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
-            .filter_map(Result::ok)
+            .tokenize_until_err()
             .collect();
         match e.context() {
             (Some(Range(start, end)), _) => {
@@ -202,7 +202,7 @@ where
         warnings.dedup();
         for w in &warnings {
             let tokens: Vec<_> = lexer::Tokenizer::new(&self.source)
-                .filter_map(Result::ok)
+                .tokenize_until_err()
                 .collect();
             h.highlight_runtime_error(None, &tokens, w.outer.0, w.outer.1, Some(w.into()))?;
         }

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -152,7 +152,7 @@ where
     #[cfg(not(tarpaulin_include))]
     pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H) -> io::Result<()> {
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
-            .filter_map(Result::ok)
+            .tokenize_until_err()
             .collect();
         h.highlight(None, &tokens)?;
         io::Result::Ok(())
@@ -229,14 +229,13 @@ where
             if cu == 0 {
                 // i wanna use map_while here, but it is still unstable :(
                 let tokens: Vec<_> = lexer::Tokenizer::new(&script)
-                    .scan((), |_, item| item.ok())
-                    .fuse()
+                    .tokenize_until_err()
                     .collect();
                 h.highlight_runtime_error(None, &tokens, start, end, Some(error.into()))?;
             } else if let Some(cu) = cus.get(cu) {
                 let script = std::fs::read_to_string(cu.file_path())?;
                 let tokens: Vec<_> = lexer::Tokenizer::new(&script)
-                    .filter_map(Result::ok)
+                    .tokenize_until_err()
                     .collect();
                 h.highlight_runtime_error(
                     cu.file_path().to_str(),
@@ -261,7 +260,7 @@ where
         warnings.dedup();
         for w in &warnings {
             let tokens: Vec<_> = lexer::Tokenizer::new(&self.source)
-                .filter_map(Result::ok)
+                .tokenize_until_err()
                 .collect();
             h.highlight_runtime_error(None, &tokens, w.outer.0, w.outer.1, Some(w.into()))?;
         }


### PR DESCRIPTION
where ever possible.

# Pull request

In #588 we discovered that at runtime we don't get good hygienic errors.
This PR adds hygienic runtime error output to `tremor run`, one small part of #587.


## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: #588

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment