### PR TITLE
Add user 'tremor' with home directory to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN strip target/release/tremor
 
 FROM debian:buster-slim
 
+RUN useradd -ms /bin/bash tremor
+
 RUN apt-get update \
     && apt-get install -y libssl1.1 libcurl4 libatomic1 \
     #

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -34,6 +34,8 @@ RUN cargo build --release --all
 
 FROM debian:buster-slim
 
+RUN useradd -ms /bin/bash tremor
+
 RUN apt-get update \
     && apt-get install -y libssl1.1 libcurl4 libatomic1 \
     #


### PR DESCRIPTION
# Pull request

The docker images need a user with a home directory to run tremor without permissions issues.

## Description

When running tremor in kubernetes while running as root is disallowed, we need a user that we can run as. Existing users on the image don't have home directories. This causes tremor to try to create a `.tremor` directory under `/usr/sbin`, which is disallowed. Tremor fails to start.

`strace` output:
```
statx(AT_FDCWD, "/usr/sbin/.tremor", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7fff8fbdf140) = -1 ENOENT (No such file or directory)                     
mkdir("/usr/sbin/.tremor", 0777)        = -1 EACCES (Permission denied)                                                                            
write(2, "Permission denied", 17Permission denied)       = 17     
```

## Related

N/A

## Checklist

* [ ] ~~The RFC, if required, has been submitted and approved~~ - N/A
* [ ] ~~Any user-facing impact of the changes is reflected in docs.tremor.rs~~ - N/A
* [x] The code is tested
* [ ] ~~Use of unsafe code is reasoned about in a comment~~ - N/A
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
