### PR TITLE
Fix gelf preprocessor to accept valid unchunked gelf messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (in branch main)
+
+* Fix gelf preprocessor to accept valid (unchunked) gelf messages [#628](https://github.com/tremor-rs/tremor-runtime/pull/628)
+
 ## 0.9.2
 
 ### New Features

--- a/src/preprocessor/gelf.rs
+++ b/src/preprocessor/gelf.rs
@@ -104,7 +104,7 @@ fn decode_gelf(bin: &[u8]) -> Result<GELFSegment> {
                 data: rest.to_vec(),
             })
         }
-        [b'{', _] => Ok(GELFSegment {
+        [b'{', _, ..] => Ok(GELFSegment {
             id: 0,
             seq: 0,
             count: 1,
@@ -269,7 +269,10 @@ mod test {
         assert!(decode_gelf(&d).is_err());
         let d = vec![b'{'];
         assert!(decode_gelf(&d).is_err());
+
         let d = vec![b'{', b'}'];
         assert!(decode_gelf(&d).is_ok());
+        let d = br#"{"snot": "badger"}"#;
+        assert!(decode_gelf(d).is_ok());
     }
 }


### PR DESCRIPTION
# Pull request

Fix gelf preprocessor to accept valid unchunked gelf messages.

## Related

* Related Issues: fixes https://github.com/tremor-rs/tremor-runtime/issues/626

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
