### PR TITLE
Move from memmap to mapr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix panic upon usage of postgres ramps due to incompatbility with tokio and async-std runtime. [#641](https://github.com/tremor-rs/tremor-runtime/pull/641)
+
 ## 0.9.3
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mapr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,16 +2937,6 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "memoffset"
@@ -5749,8 +5749,8 @@ dependencies = [
  "log",
  "log4rs 0.13.0",
  "lz4",
+ "mapr",
  "matches",
- "memmap",
  "pin-project-lite 0.2.0",
  "postgres",
  "postgres-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
+ "tokio 0.3.4",
 ]
 
 [[package]]
@@ -5285,6 +5286,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio 0.7.6",
+ "num_cpus",
  "pin-project-lite 0.2.0",
  "slab",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ async-channel = "1"
 async-compat = "0.1"
 async-compression = {version = "0.3", features = ["xz", "futures-bufread", "stream"]}
 async-io = "1.3"
-async-std = {version = "1.7.0", features = ["unstable", "attributes"]}
+async-std = {version = "1.7.0", features = ["unstable", "attributes", "tokio03"]}
 async-trait = "0.1"
 async-tungstenite = {version = "0.10.0", features = ["async-std-runtime"]}
 base64 = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ snap = "1"
 tremor-influx = {path = "tremor-influx"}
 tremor-script = {path = "tremor-script"}
 
-memmap = {version = "0.7.0"}
+mapr = "0.8"
 tempfile = {version = "3.1"}
 
 # blaster / blackhole

--- a/src/ramp.rs
+++ b/src/ramp.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::errors::Result;
-use memmap::MmapOptions;
+use mapr::MmapOptions;
 use simd_json::prelude::*;
 use std::cmp;
 use std::fs::OpenOptions;
@@ -31,12 +31,12 @@ pub trait KV {
 
 pub struct MmapFile {
     pub config: Config,
-    pub store: memmap::MmapMut,
+    pub store: mapr::MmapMut,
     pub len: usize,
     pub end: usize,
 }
 pub struct MmapAnon {
-    pub store: memmap::MmapMut,
+    pub store: mapr::MmapMut,
     pub end: usize,
     pub len: usize,
 }


### PR DESCRIPTION
# Pull request

## Description

* Move from memmap to mapr

I decided to go with mapr as it is backed by a github org (filecoin), not a single person and has more recent changes.

* Fix compatibility between async-std and tokio 0.3 needed for postgres ramps

This was tested by running the workshop examples involving postgres.

## Related


* Related Issues: fixes #630 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
