### PR TITLE
Modify Kafka sink/source meta to include message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Allow using '_' as seperators in numeric literals [#645](https://github.com/tremor-rs/tremor-runtime/issues/645)
+* Add support for Kafka message headers, available through the `$kafka_headers` metadata variable.
 
 ## 0.10.2
 


### PR DESCRIPTION
# Pull request


## Description
Include Kafka message headers as a meta variable for the Kafka source and sink.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #737 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
