### PR TITLE
Add payload to elastic error response event in every case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 * Ensure blaster sends all events from the source [#759](https://github.com/tremor-rs/tremor-runtime/pull/759)
 * Allow the use of const and custom functions using const in select queries [#749](https://github.com/tremor-rs/tremor-runtime/issues/749)
 * Print hygenic errors when invalid `trickle` files are loaded in `server run -f ...` [#761](https://github.com/tremor-rs/tremor-runtime/issues/761)
-* Ensure `elastic` sink does not issue empty bulk requests.
+* Ensure `elastic` offramp does not issue empty bulk requests.
 * Avoid sending empty batches from the `batch` operator.
+* Ensure `elastic` offramp includes event `payload` in every error response.
 
 ### New features
 


### PR DESCRIPTION
# Pull request

<!-- One sentence high-level abstract of the goal of this PR -->

## Description

We missed the error response in some error cases:

* unable to build ES bulk request payload
* event rejected as i overflowed the configured concurrency

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
