### PR TITLE
Add KV connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for Kafka message headers, available through the `$kafka_headers` metadata variable.
 * Add the `cb` offramp for testing upstream circuit breaker behaviour [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
 * Add the `kafka` onramp config `retry_failed_events` to acoid retrying failed events, and `polling_interval` to control how often kafka is polled for new messages if none were available previously [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
+* Add `kv` connector (`put`, `get`, `delete`, `scan`, `cas`)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add support for Kafka message headers, available through the `$kafka_headers` metadata variable.
 * Add the `cb` offramp for testing upstream circuit breaker behaviour [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
 * Add the `kafka` onramp config `retry_failed_events` to acoid retrying failed events, and `polling_interval` to control how often kafka is polled for new messages if none were available previously [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
-* Add `kv` connector (`put`, `get`, `delete`, `scan`, `cas`)
+* Add `kv` connector with the supported operations `put`, `get`, `delete`, `scan`, `cas`.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "serenity",
  "simd-json",
  "simd-json-derive",
+ "sled",
  "snap",
  "surf",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ tide = "0.16"
 # discord
 serenity = {version = "0.10", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"]}
 
+# kv
+sled = "0.34"
+
+
 [dependencies.tungstenite]
 default-features = false
 version = "0.13"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,12 @@ impl Clone for Error {
     }
 }
 
+impl From<sled::transaction::TransactionError<()>> for Error {
+    fn from(e: sled::transaction::TransactionError<()>) -> Self {
+        Self::from(format!("Sled Transaction Error: {:?}", e))
+    }
+}
+
 impl From<hdr_s::DeserializeError> for Error {
     fn from(e: hdr_s::DeserializeError) -> Self {
         Self::from(format!("{:?}", e))
@@ -146,6 +152,7 @@ error_chain! {
         CronError(cron::error::Error);
         Postgres(postgres::Error);
         Common(tremor_common::Error);
+        Sled(sled::Error);
     }
 
     errors {

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -26,6 +26,7 @@ pub(crate) mod elastic;
 pub(crate) mod exit;
 pub(crate) mod file;
 pub(crate) mod kafka;
+pub(crate) mod kv;
 pub(crate) mod newrelic;
 pub(crate) mod postgres;
 pub(crate) mod prelude;
@@ -59,7 +60,7 @@ pub(crate) trait Sink {
     async fn on_event(
         &mut self,
         input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec;
@@ -164,7 +165,7 @@ where
 
     async fn on_event(
         &mut self,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         codec_map: &HashMap<String, Box<dyn Codec>>,
         input: &str,
         event: Event,

--- a/src/sink/blackhole.rs
+++ b/src/sink/blackhole.rs
@@ -106,7 +106,7 @@ impl Sink for Blackhole {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/debug.rs
+++ b/src/sink/debug.rs
@@ -57,7 +57,7 @@ impl Sink for Debug {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/elastic.rs
+++ b/src/sink/elastic.rs
@@ -506,7 +506,7 @@ impl Sink for Elastic {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {

--- a/src/sink/exit.rs
+++ b/src/sink/exit.rs
@@ -39,7 +39,7 @@ impl Sink for Exit {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/file.rs
+++ b/src/sink/file.rs
@@ -72,7 +72,7 @@ impl Sink for File {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -233,7 +233,7 @@ impl Sink for Kafka {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {

--- a/src/sink/kv.rs
+++ b/src/sink/kv.rs
@@ -1,0 +1,275 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Add correlation of reads and replies.
+
+#![cfg(not(tarpaulin_include))]
+use crate::sink::{prelude::*, Reply};
+use crate::source::prelude::*;
+use async_channel::Sender;
+use halfbrown::HashMap;
+use serde::Deserialize;
+use sled::{CompareAndSwapError, IVec};
+use std::boxed::Box;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Config {
+    dir: String,
+}
+pub struct Kv {
+    sink_url: TremorURL,
+    event_origin_uri: EventOriginUri,
+    db: sled::Db,
+}
+
+fn decode(mut v: Option<IVec>, codec: &mut dyn Codec, ingest_ns: u64) -> Result<Value<'static>> {
+    if let Some(v) = v.as_mut() {
+        let data: &mut [u8] = v;
+        // TODO: We could optimize this
+        Ok(codec
+            .decode(data, ingest_ns)?
+            .unwrap_or_default()
+            .into_static())
+    } else {
+        Ok(Value::null())
+    }
+}
+
+fn ok(v: Value<'static>) -> Value<'static> {
+    let mut reply = Value::object_with_capacity(1);
+    if reply.insert("ok", v).is_ok() {
+        reply
+    } else {
+        // ALLOW: We know this never can happen since `reply` is created as an object
+        unreachable!()
+    }
+}
+
+impl Kv {
+    fn execute(
+        &self,
+        cmd: Command,
+        codec: &mut dyn Codec,
+        ingest_ns: u64,
+    ) -> Result<Value<'static>> {
+        match cmd {
+            Command::Get { key } => decode(self.db.get(key)?, codec, ingest_ns).map(ok),
+            Command::Put { key, value } => {
+                decode(self.db.insert(key, codec.encode(value)?)?, codec, ingest_ns).map(ok)
+            }
+            Command::Delete { key } => decode(self.db.remove(key)?, codec, ingest_ns).map(ok),
+            Command::Cas { key, old, new } => {
+                if let Err(CompareAndSwapError { current, proposed }) = self.db.compare_and_swap(
+                    key,
+                    old.map(|v| codec.encode(v)).transpose()?,
+                    new.map(|v| codec.encode(v)).transpose()?,
+                )? {
+                    let mut err = Value::object_with_capacity(2);
+                    err.insert(
+                        "current",
+                        current.map(|v| {
+                            let v: &[u8] = &v;
+                            Value::Bytes(Cow::from(Vec::from(v)))
+                        }),
+                    )?;
+                    err.insert(
+                        "proposed",
+                        proposed.map(|v| {
+                            let v: &[u8] = &v;
+                            Value::Bytes(Cow::from(Vec::from(v)))
+                        }),
+                    )?;
+                    let mut reply = Value::object_with_capacity(1);
+                    reply.insert("error", err)?;
+                    Ok(reply)
+                } else {
+                    Ok(ok(Value::null()))
+                }
+            }
+            Command::Scan { start, end } => {
+                let i = match (start, end) {
+                    (None, None) => self.db.range::<Vec<u8>, _>(..),
+                    (Some(start), None) => self.db.range(start..),
+                    (None, Some(end)) => self.db.range(..end),
+                    (Some(start), Some(end)) => self.db.range(start..end),
+                };
+                let mut res = Vec::with_capacity(32);
+                for e in i {
+                    let mut kv = Value::object_with_capacity(2);
+
+                    let (key, e) = e?;
+                    let key: &[u8] = &key;
+                    kv.insert("key", Value::Bytes(key.to_vec().into()))?;
+                    kv.insert("value", decode(Some(e), codec, ingest_ns)?)?;
+                    res.push(kv)
+                }
+                Ok(Value::from(res))
+            }
+        }
+    }
+}
+
+impl offramp::Impl for Kv {
+    fn from_config(config: &Option<OpConfig>) -> Result<Box<dyn Offramp>> {
+        if let Some(config) = config {
+            let config: Config = serde_yaml::from_value(config.clone())?;
+
+            let db = sled::open(&config.dir)?;
+            let event_origin_uri = EventOriginUri {
+                uid: 0,
+                scheme: "tremor-kv".to_string(),
+                host: "localhost".to_string(),
+                port: None,
+                path: config.dir.split('/').map(ToString::to_string).collect(),
+            };
+
+            Ok(SinkManager::new_box(Kv {
+                sink_url: TremorURL::from_onramp_id("kv")?, // dummy value
+                event_origin_uri,
+                db,
+            }))
+        } else {
+            Err("[KV Offramp] Offramp requires a config".into())
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Command<'v> {
+    /// ```json
+    /// {"get": {"key": "the-key"}}
+    /// ```
+    Get { key: Vec<u8> },
+    /// ```json
+    /// {"put": {"key": "the-key", "value": "the-value"}}
+    /// ```
+    Put { key: Vec<u8>, value: &'v Value<'v> },
+    /// ```json
+    /// {"delete": {"key": "the-key"}}
+    /// ```
+    Delete { key: Vec<u8> },
+    /// ```json
+    /// {"scan": {
+    ///    "start": "key1",
+    ///    "end": "key2",
+    /// }
+    /// ```
+    Scan {
+        start: Option<Vec<u8>>,
+        end: Option<Vec<u8>>,
+    },
+    /// ```json
+    /// {"cas": {
+    ///    "key": "key"
+    ///    "old": "<value|null|not-se>",
+    ///    "new": "<value|null|not-set>",
+    /// }
+    /// ```
+    Cas {
+        key: Vec<u8>,
+        old: Option<&'v Value<'v>>,
+        new: Option<&'v Value<'v>>,
+    },
+}
+
+#[async_trait::async_trait]
+impl Sink for Kv {
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        codec: &mut dyn Codec,
+        _codec_map: &HashMap<String, Box<dyn Codec>>,
+        event: Event,
+    ) -> ResultVec {
+        let mut r = Vec::with_capacity(10);
+        let ingest_ns = tremor_common::time::nanotime();
+
+        let cmds = event.value_iter().filter_map(|v| {
+            if let Some(g) = v.get("get") {
+                Some(Command::Get {
+                    key: g.get_bytes("key")?.to_vec(),
+                })
+            } else if let Some(p) = v.get("put") {
+                Some(Command::Put {
+                    key: p.get_bytes("key")?.to_vec(),
+                    value: p.get("value")?,
+                })
+            } else if let Some(c) = v.get("cas") {
+                Some(Command::Cas {
+                    key: c.get_bytes("key")?.to_vec(),
+                    old: c.get("old"),
+                    new: c.get("new"),
+                })
+            } else if let Some(d) = v.get("delete") {
+                Some(Command::Delete {
+                    key: d.get_bytes("key")?.to_vec(),
+                })
+            } else if let Some(s) = v.get("scan") {
+                Some(Command::Scan {
+                    start: s.get_bytes("start").map(|v| v.to_vec()),
+                    end: s.get_bytes("end").map(|v| v.to_vec()),
+                })
+            } else {
+                error!("failed to decode command: {}", v);
+                None
+            }
+        });
+
+        for c in cmds {
+            println!("command: {:?}", c);
+            let data = self.execute(c, codec, ingest_ns)?;
+            let e = Event {
+                data: data.into(),
+                origin_uri: Some(self.event_origin_uri.clone()),
+                ..Event::default()
+            };
+            r.push(Reply::Response(OUT, e))
+        }
+        Ok(Some(r))
+    }
+
+    async fn on_signal(&mut self, _signal: Event) -> ResultVec {
+        Ok(None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn init(
+        &mut self,
+        sink_uid: u64,
+        sink_url: &TremorURL,
+        _codec: &dyn Codec,
+        _codec_map: &HashMap<String, Box<dyn Codec>>,
+        _processors: Processors<'_>,
+        _is_linked: bool,
+        _reply_channel: Sender<sink::Reply>,
+    ) -> Result<()> {
+        self.event_origin_uri.uid = sink_uid;
+        self.sink_url = sink_url.clone();
+        Ok(())
+    }
+
+    fn is_active(&self) -> bool {
+        true
+    }
+
+    fn auto_ack(&self) -> bool {
+        true
+    }
+
+    fn default_codec(&self) -> &str {
+        "json"
+    }
+
+    async fn terminate(&mut self) {}
+}

--- a/src/sink/kv.rs
+++ b/src/sink/kv.rs
@@ -227,7 +227,6 @@ impl Sink for Kv {
         });
 
         for c in cmds {
-            println!("command: {:?}", c);
             let data = self.execute(c, codec, ingest_ns)?;
             let e = Event {
                 data: data.into(),

--- a/src/sink/newrelic.rs
+++ b/src/sink/newrelic.rs
@@ -103,7 +103,7 @@ impl Sink for NewRelic {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/postgres.rs
+++ b/src/sink/postgres.rs
@@ -74,7 +74,7 @@ impl Sink for Postgres {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -310,7 +310,7 @@ impl Sink for Rest {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {
@@ -1018,7 +1018,7 @@ mod test {
     #[test]
     fn deserialize_from_object() -> Result<()> {
         let config_s = r#"
-            endpoint: 
+            endpoint:
                 host: example.org
                 query: via=tremor
             concurrency: 4

--- a/src/sink/stderr.rs
+++ b/src/sink/stderr.rs
@@ -66,7 +66,7 @@ impl Sink for StdErr {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/stdout.rs
+++ b/src/sink/stdout.rs
@@ -67,7 +67,7 @@ impl Sink for StdOut {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {

--- a/src/sink/tcp.rs
+++ b/src/sink/tcp.rs
@@ -78,7 +78,7 @@ impl Sink for Tcp {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {

--- a/src/sink/udp.rs
+++ b/src/sink/udp.rs
@@ -64,7 +64,7 @@ impl Sink for Udp {
     async fn on_event(
         &mut self,
         _input: &str,
-        codec: &dyn Codec,
+        codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {

--- a/src/sink/ws.rs
+++ b/src/sink/ws.rs
@@ -492,7 +492,7 @@ impl Sink for Ws {
     async fn on_event(
         &mut self,
         _input: &str,
-        _codec: &dyn Codec,
+        _codec: &mut dyn Codec,
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         event: Event,
     ) -> ResultVec {
@@ -692,7 +692,7 @@ mod test {
         let (reply_tx, reply_rx) = bounded(1000);
 
         let url = TremorURL::parse("/offramp/ws/instance")?;
-        let codec: Box<dyn Codec> = Box::new(crate::codec::json::JSON::default());
+        let mut codec: Box<dyn Codec> = Box::new(crate::codec::json::JSON::default());
         let config = Config {
             url: "http://idonotexist:65535/path".to_string(),
             binary: true,
@@ -730,7 +730,7 @@ mod test {
         // lets try to send an event
         let mut event = Event::default();
         event.id = EventId::new(1, 1, 1);
-        sink.on_event("in", codec.as_ref(), &HashMap::new(), event)
+        sink.on_event("in", codec.as_mut(), &HashMap::new(), event)
             .await?;
 
         while let Ok(msg) = reply_rx.try_recv() {


### PR DESCRIPTION
# Pull request

## Description

This adds a `kv` connector. It allows issuing 'commands' such as `put`, `get`, `delete`, `cas`, and `scan` with replies being sent back `out` of the connector.

## Related

* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/82)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
