### PR TITLE
Grate HOME usage to where it is required, fixes #782

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Fix `kafka` onramp hanging with no message in the queue, leading to delayed offset commits [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
 * Fail the `kafka` onramp if any of the configured topics could not be subscribed to [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
+* Tremor no longer requires a home dir for operations that do not need a config [#782](https://github.com/tremor-rs/tremor-runtime/issues/782)
 
 ## 0.10.2
 

--- a/tremor-cli/src/api.rs
+++ b/tremor-cli/src/api.rs
@@ -23,19 +23,19 @@ use tremor_script::prelude::*;
 
 use crate::util::{accept, content_type, load, save_config, ser, TremorApp};
 
-pub(crate) async fn run_cmd(app: &mut TremorApp, cmd: &ArgMatches) -> Result<()> {
+pub(crate) async fn run_cmd(mut app: TremorApp, cmd: &ArgMatches) -> Result<()> {
     if let Some(matches) = cmd.subcommand_matches("version") {
-        conductor_version_cmd(app, &matches).await
+        conductor_version_cmd(&app, &matches).await
     } else if let Some(matches) = cmd.subcommand_matches("binding") {
-        conductor_binding_cmd(app, &matches).await
+        conductor_binding_cmd(&app, &matches).await
     } else if let Some(matches) = cmd.subcommand_matches("pipeline") {
-        conductor_pipeline_cmd(app, &matches).await
+        conductor_pipeline_cmd(&app, &matches).await
     } else if let Some(matches) = cmd.subcommand_matches("onramp") {
-        conductor_onramp_cmd(app, &matches).await
+        conductor_onramp_cmd(&app, &matches).await
     } else if let Some(matches) = cmd.subcommand_matches("offramp") {
-        conductor_offramp_cmd(app, &matches).await
+        conductor_offramp_cmd(&app, &matches).await
     } else if let Some(matches) = cmd.subcommand_matches("target") {
-        conductor_target_cmd(app, &matches).await
+        conductor_target_cmd(&mut app, &matches).await
     } else {
         Err(Error::from("Invalid command"))
     }

--- a/tremor-cli/src/main.rs
+++ b/tremor-cli/src/main.rs
@@ -124,11 +124,6 @@ fn run(mut app: App, cmd: &ArgMatches) -> Result<()> {
         _ => FormatKind::Yaml,
     };
 
-    let mut config = TremorApp {
-        format,
-        config: load_config()?,
-    };
-
     match cmd
         .subcommand_name()
         .map(|name| (name, cmd.subcommand_matches(name)))
@@ -138,7 +133,13 @@ fn run(mut app: App, cmd: &ArgMatches) -> Result<()> {
         Some(("server", Some(matches))) => server::run_cmd(app, matches),
         Some(("run", Some(matches))) => run::run_cmd(&matches),
         Some(("doc", Some(matches))) => doc::run_cmd(&matches),
-        Some(("api", Some(matches))) => task::block_on(api::run_cmd(&mut config, &matches)),
+        Some(("api", Some(matches))) => task::block_on(api::run_cmd(
+            TremorApp {
+                format,
+                config: load_config()?,
+            },
+            &matches,
+        )),
         Some(("dbg", Some(matches))) => debug::run_cmd(&matches),
         Some(("test", Some(matches))) => test::run_cmd(&matches),
         _ => app


### PR DESCRIPTION
Signed-off-by: Heinz N. Gies <heinz@licenser.net>

# Pull request


## Description

Limit the use of `$HOME` to the commands that access it

## Related

* Related Issues: fixes #782

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
