### PR TITLE
Cleanup metrics logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add performance section to PR template.
 * Fix markdown for discord link.
 * Fix lalrpop builds when extra folders exist.
+* Refactor operator metrics collection to eliminate clones in most cases.
 
 ## 0.10.2
 

--- a/tremor-pipeline/src/op.rs
+++ b/tremor-pipeline/src/op.rs
@@ -116,7 +116,7 @@ pub trait Operator: std::fmt::Debug + Send {
     /// Returns metrics for this operator, defaults to no extra metrics.
     fn metrics(
         &self,
-        _tags: HashMap<Cow<'static, str>, Value<'static>>,
+        _tags: &HashMap<Cow<'static, str>, Value<'static>>,
         _timestamp: u64,
     ) -> Result<Vec<Value<'static>>> {
         // Make the trait signature nicer

--- a/tremor-pipeline/src/op/trickle/operator.rs
+++ b/tremor-pipeline/src/op/trickle/operator.rs
@@ -114,7 +114,7 @@ impl Operator for TrickleOperator {
 
     fn metrics(
         &self,
-        tags: HashMap<Cow<'static, str>, Value<'static>>,
+        tags: &HashMap<Cow<'static, str>, Value<'static>>,
         timestamp: u64,
     ) -> Result<Vec<Value<'static>>> {
         self.op.metrics(tags, timestamp)


### PR DESCRIPTION
# Pull request

## Description

This refactors the metrics logic slightly to eliminate a clone
for operators that do not supply custom metrics (this is most of
them).

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes or other observable changes in behavior
