### PR TITLE
Update cargo deny to only check license related issues

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check bans licenses sources #we do not check advisories here as they get filed as issues from a different action

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ unlicensed= "deny"
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
-    "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
     "BSL-1.0",
     "ISC",


### PR DESCRIPTION
# Pull request

## Description

This removes advisory checks from the license check CI task. We have those checks separately as filed issues and it does not provide value to fail the license check because there is an advisory open.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior ( left this out since it is only CI changes no changes that affect the code, users, contributors or tremor )
* [x] The performance impact of the change is measured (see below)

## Performance

No code changes