### PR TITLE
ci: remove vsn.sh and replace it with --locked flag

### DIFF
--- a/.github/checks/vsn.sh
+++ b/.github/checks/vsn.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-LOCK_DIFF="$(git diff Cargo.lock | wc -l)"
-
-if [ "${LOCK_DIFF}" -ne "0" ]
-then
-  echo "Build changed the lock file"
-  exit 1
-fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,8 @@ jobs:
         with:
           override: true
           profile: minimal
-      - name: Run tests
-        run: cargo test --all
-      - name: Validate lockfile
-        run: .github/checks/vsn.sh
+      - name: Run tests and validate lockfile
+        run: cargo test --all --locked
   code-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Removed the vsn.sh script which checks if the lockfile is up to date and replaces it with the --locked flag [#798](https://github.com/tremor-rs/tremor-runtime/pull/798)
 * Allow using '_' as seperators in numeric literals [#645](https://github.com/tremor-rs/tremor-runtime/issues/645)
 * Add support for Kafka message headers, available through the `$kafka_headers` metadata variable.
 * Add the `cb` offramp for testing upstream circuit breaker behaviour [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)


### PR DESCRIPTION
Signed-off-by: Akshat Agarwal <humancalico@disroot.org>

# Pull request

## Description
removes the vsn.sh script which checks if the lockfile is up to date and replaces it with the --locked flag.

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No code changes