### PR TITLE
No longer panic on bad config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix lalrpop builds when extra folders exist.
 * Refactor operator metrics collection to eliminate clones in most cases.
 * Fix systemd spec file to load tremor files in `/etc/tremor/config` [#784](https://github.com/tremor-rs/tremor-runtime/issues/784)
+* Do not crash when we can not execute a config file [#792](https://github.com/tremor-rs/tremor-runtime/issues/792)
 
 ## 0.10.2
 

--- a/demo/configs/tremor/config/config.yaml
+++ b/demo/configs/tremor/config/config.yaml
@@ -41,8 +41,11 @@ offramp:
     type: rest
     codec: influx
     config:
-      nodes:
-        - http://influx:8086/write?db=tremor
+      endpoint:
+        host: influx
+        port: 8086
+        path: /write
+        query: db=tremor
       headers:
         "Client": "Tremor"
 

--- a/tremor-cli/src/errors.rs
+++ b/tremor-cli/src/errors.rs
@@ -17,6 +17,7 @@
 #![allow(missing_docs)]
 #![allow(clippy::large_enum_variant)]
 
+use crate::util::SourceKind;
 use error_chain::error_chain;
 
 impl From<http_types::Error> for Error {
@@ -60,6 +61,14 @@ error_chain! {
         TestFailures(stats: crate::test::stats::Stats) {
             description("Some tests failed")
                 display("{} out of {} tests failed.", stats.fail, stats.skip + stats.pass)
+        }
+        FileLoadError(file: String, error: tremor_runtime::errors::Error) {
+            description("Failed to load config file")
+                display("An error occurred while loading the file `{}`: {}", file, error)
+        }
+        UnsupportedFileType(file: String, file_type: SourceKind, expected: &'static str) {
+            description("Unsupported file type")
+                display("The file `{}` has the type `{}`, but tremor expected: {}", file, file_type, expected)
         }
     }
 }

--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -424,14 +424,10 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
         .ok_or_else(|| Error::from("No script file provided"))?;
     let script_file = script_file.to_string();
     match get_source_kind(&script_file) {
-        SourceKind::Tremor | SourceKind::Json | SourceKind::Default => {
-            run_tremor_source(&matches, script_file)
-        }
+        SourceKind::Tremor | SourceKind::Json => run_tremor_source(&matches, script_file),
         SourceKind::Trickle => run_trickle_source(&matches, script_file),
-        SourceKind::Unsupported => {
-            eprintln!("Error: Unable to execute source: {}", &script_file);
-            // ALLOW: main.rs
-            std::process::exit(1);
+        SourceKind::Unsupported(_) | SourceKind::Yaml => {
+            Err(format!("Error: Unable to execute source: {}", &script_file).into())
         }
     }
 }

--- a/tremor-cli/src/util.rs
+++ b/tremor-cli/src/util.rs
@@ -261,23 +261,28 @@ pub(crate) fn visit_path<'a>(base: &Path, path: &Path, visitor: &'a PathVisitor)
     Ok(())
 }
 
-#[derive(Clone, PartialEq)]
-pub(crate) enum SourceKind {
+#[derive(Clone, PartialEq, Debug)]
+pub enum SourceKind {
+    /// A tremor source file
     Tremor,
+    /// A trickle source file
     Trickle,
+    /// A json file
     Json,
-    Unsupported(Option<String>),
+    /// A yaml file
     Yaml,
+    /// An unsuported file
+    Unsupported(Option<String>),
 }
 impl fmt::Display for SourceKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match self {
             SourceKind::Tremor => write!(f, "tremor"),
             SourceKind::Trickle => write!(f, "trickle"),
-            SourceKind::Json => write!(f, "JSON"),
+            SourceKind::Json => write!(f, "json"),
             SourceKind::Unsupported(None) => write!(f, "<NONE>"),
             SourceKind::Unsupported(Some(ext)) => write!(f, "{}", ext),
-            SourceKind::Yaml => write!(f, "YAML"),
+            SourceKind::Yaml => write!(f, "yaml"),
         }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This prevents crashing when bad config files are provided. Instead an error is printed and the server starts with the remaining config.

While this fixes the crash issue we should consider if we want to act this way.

An argument can be made that when a file is provided as a command-line argument the server should fail to start as the user should be shown this very explicitly to avoid confusion.

At the same time, an argument can be made that since tremor is a server and configuration can be loaded and unloaded at any point in its runtime, an invalid config is no reason to stop the service and prevent other pipelines/connectors to run.

Perhaps an alternative would be to exit 'nicely' when a config fails to load and just not panic?

## Related

* Related Issues: fixes #792

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

This change only touches control plane code, there is no impact on the data plane and performance.