### PR TITLE
Let Docker handle signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add the `kafka` onramp config `retry_failed_events` to acoid retrying failed events, and `polling_interval` to control how often kafka is polled for new messages if none were available previously [#779](https://github.com/tremor-rs/tremor-runtime/pull/779)
 * Add `kv` connector with the supported operations `put`, `get`, `delete`, `scan`, `cas`.
 * Add discord badge to README.md.
+* Handle signals and terminate properly on Ctrl+C in docker [#806](https://github.com/tremor-rs/tremor-runtime/pull/806)
 
 ### Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM debian:buster-slim
 RUN useradd -ms /bin/bash tremor
 
 RUN apt-get update \
-    && apt-get install -y libssl1.1 libcurl4 libatomic1 \
+    && apt-get install -y libssl1.1 libcurl4 libatomic1 tini \
     #
     # Clean up
     && apt-get autoremove -y \
@@ -65,4 +65,4 @@ COPY docker/logger.yaml /etc/tremor/logger.yaml
 
 ENV TREMOR_PATH=/opt/local/tremor/lib
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["tini", "/entrypoint.sh"]

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -16,7 +16,7 @@
 * Update tests in tremor-cli/tests/ that match against the current version number
 * Create a PR with those changes
 * Pull the PR once accepted and merged
-* `git tag -a -m"Release v<MAJOR>.<MINOR>.<BUGFIX>" <COMMIT>`
+* `git tag -a -m"Release v<MAJOR>.<MINOR>.<BUGFIX>" v<MAJOR>.<MINOR>.<BUGFIX> <COMMIT>`
 * `git push origin --tag`
 * Draft a new release on github
   - This will trigger the docker image build jobs
@@ -30,6 +30,9 @@
     - ./tremor-script
 * Release https://github.com/tremor-rs/tremor-language-server
   - Bump version and update dependency `tremor-script` to the new version.
+  - Create a github tag and draft a release from it:
+    - `git tag -a -m"Release v<MAJOR>.<MINOR>.<BUGFIX>" v<MAJOR>.<MINOR>.<BUGFIX> <COMMIT>`
+    - `git push origin --tag`
   - Execute `cargo publish` from the language server repository root.
   - Verify new language server installation via `cargo install tremor-language-server`
 * Wait for the docker image to build and publish


### PR DESCRIPTION
# Pull request

## Description

Enable signals in docker by not running as PID1, but let [tini](https://github.com/krallin/tini) do the work.

We could achieve the same by always using `--init` on each `docker run` call, but it is more convenient to do it here for every user.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->


* Related Issues: fixes #734


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


