### PR TITLE
fix(cli): mark the benchmarks as failing when they fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Do not crash when we can not execute a config file [#792](https://github.com/tremor-rs/tremor-runtime/issues/792)
 * Sort the artefacts while running the benchmarks so that the benchmark run is more deterministic [#825](https://github.com/tremor-rs/tremor-runtime/issues/825)
 * Remove the bench_pipe_passthrough_csv benchmark [#825](https://github.com/tremor-rs/tremor-runtime/issues/825)
+* Fix a bug in the `test bench` command that was giving false negatives when the benchmarks were failing [#816](https://github.com/tremor-rs/tremor-runtime/pull/816)
 
 ## 0.10.2
 

--- a/tremor-cli/src/report.rs
+++ b/tremor-cli/src/report.rs
@@ -16,7 +16,7 @@ use crate::test::stats;
 use std::collections::HashMap;
 
 /// A test run is a collection of test reports that
-/// have executed int he context of a test run
+/// have executed in the context of a test run
 ///
 #[derive(Serialize, Debug, Clone)]
 pub(crate) struct TestRun {

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -71,8 +71,12 @@ fn suite_bench(
                 status::tags(&tags, Some(&matched), Some(&by_tag.1))?;
                 let test_report = process::run_process("bench", base, root, &tags)?;
                 status::duration(test_report.duration, "  ")?;
+                if test_report.stats.is_pass() {
+                    stats.pass();
+                } else {
+                    stats.fail();
+                }
                 suite.push(test_report);
-                stats.pass(); // TODO invent a better way of capturing benchmark status
             } else {
                 stats.skip();
                 status::h1(


### PR DESCRIPTION
Signed-off-by: Akshat Agarwal <humancalico@disroot.org>

# Pull request

## Description
Fix a bug in the `test bench` command that was giving false positives when the benchmarks were failing.
This still doesn't give the proper error trace when a benchmark run fails

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: Ref #815

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


