### PR TITLE
Improve default visibility of tremor info logs from packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Emit error events to the `err` port on exceeding concurrent requests limit for `rest` and `elastic` offramps.
 * Add the `max_groups` and `emit_empty_windows` settings on window definitions [#828](https://github.com/tremor-rs/tremor-runtime/pull/828)
 * Restrict event and event metadata references in the `SELECT` clause of a windowed select statement [#828](https://github.com/tremor-rs/tremor-runtime/pull/828)
+* Improve default visibility of tremor info logs from packages [#850](https://github.com/tremor-rs/tremor-runtime/pull/850)
 
 ### Fixes
 

--- a/packaging/distribution/etc/tremor/logger.yaml
+++ b/packaging/distribution/etc/tremor/logger.yaml
@@ -23,3 +23,8 @@ loggers:
     appenders:
       - file
     additive: false
+  tremor:
+    level: info
+    appenders:
+      - file
+    additive: false


### PR DESCRIPTION
## Description

Ensure info logs under the `tremor` namespace appear by default when tremor is run from our packages. This improves the debuggability for those tremor runs.

This behavior is aligned with the docker image's logger configuration: https://github.com/tremor-rs/tremor-runtime/blob/main/docker/logger.yaml 

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

May lead to more logs being written to file by default but the effects on performance should be negligible.


