### PR TITLE
Emit warning when emit_empty_windows is used unguarded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Restrict event and event metadata references in the `SELECT` clause of a windowed select statement [#828](https://github.com/tremor-rs/tremor-runtime/pull/828)
 * Improve default visibility of tremor info logs from packages [#850](https://github.com/tremor-rs/tremor-runtime/pull/850)
 * Include the request info of a response for a linked rest offramp, available through the `$response.request` metadata variable.
+* Emit warnings when a window with `emit_empty_windows` without guards is used.
 
 ### Fixes
 

--- a/tests/query_error.rs
+++ b/tests/query_error.rs
@@ -44,6 +44,7 @@ macro_rules! test_cases {
 
     ($($file:ident),* ,) => {
         $(
+            #[cfg(not(tarpaulin_include))]
             #[test]
             fn $file() -> Result<()> {
 

--- a/tests/query_warning.rs
+++ b/tests/query_warning.rs
@@ -1,0 +1,106 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use pretty_assertions::assert_eq;
+use regex::Regex;
+use std::io::prelude::*;
+use std::path::Path;
+use tremor_common::file;
+use tremor_pipeline;
+use tremor_pipeline::query::Query;
+use tremor_pipeline::FN_REGISTRY;
+use tremor_runtime;
+use tremor_runtime::errors::*;
+use tremor_script::highlighter::{Dumb, Highlighter};
+use tremor_script::path::ModulePath;
+
+fn to_query(module_path: &ModulePath, file_name: &str, query: &str) -> Result<Query> {
+    let aggr_reg = tremor_script::aggr_registry();
+    let cus = vec![];
+    Ok(Query::parse(
+        module_path,
+        query,
+        file_name,
+        cus,
+        &*FN_REGISTRY.lock()?,
+        &aggr_reg,
+    )?)
+}
+
+macro_rules! test_cases {
+
+    ($($file:ident),* ,) => {
+        $(
+            #[test]
+            fn $file() -> Result<()> {
+
+                tremor_runtime::functions::load()?;
+                let query_dir = concat!("tests/query_warnings/", stringify!($file), "/").to_string();
+                let query_file = concat!("tests/query_warnings/", stringify!($file), "/query.trickle");
+                let warning_file = concat!("tests/query_warnings/", stringify!($file), "/warning.txt");
+                let warning_re_file = concat!("tests/query_warnings/", stringify!($file), "/warning.re");
+                let module_path = &ModulePath { mounts: vec![query_dir, "tremor-script/lib/".to_string()] };
+
+                println!("Loading query: {}", query_file);
+                let mut file = file::open(query_file)?;
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
+
+                if Path::new(warning_re_file).exists() {
+                    println!("Loading warning: {}", warning_re_file);
+                    let mut file = file::open(warning_re_file)?;
+                    let mut warning = String::new();
+                    file.read_to_string(&mut warning)?;
+                    let warning = warning.trim();
+                    let re = Regex::new(warning)?;
+
+                    let s = to_query(&module_path, warning_re_file, &contents);
+                    if let Err(e) = s {
+                        println!("{} ~ {}", warning, format!("{}", e));
+                        assert!(re.is_match(&format!("{}", e)));
+                    } else {
+                        println!("Expected error, but got succeess");
+                        assert!(false);
+                    }
+                } else {
+                    println!("Loading error: {}", warning_file);
+                    let mut file = file::open(warning_file)?;
+                    let mut warning = String::new();
+                    file.read_to_string(&mut warning)?;
+                    let warning = warning.trim();
+
+                    match to_query(&module_path, warning_file, &contents) {
+                        Ok(query) => {
+                            let mut h = Dumb::new();
+                            query.0.format_warnings_with(&mut h)?;
+                            h.finalize()?;
+                            let got = h.to_string();
+                            let got = got.trim();
+                            println!("{}", got);
+                            assert_eq!(warning, got);
+                        }
+                        Err(e) => {
+                            assert!(false, "Expected successful parse to Query with warnings, got Error: {}", e);
+                        }
+                    };
+                };
+                Ok(())
+            }
+        )*
+    };
+}
+
+test_cases!(
+    emit_empty_windows,
+    // INSERT
+);

--- a/tests/query_warning.rs
+++ b/tests/query_warning.rs
@@ -41,6 +41,7 @@ macro_rules! test_cases {
 
     ($($file:ident),* ,) => {
         $(
+            #[cfg(not(tarpaulin_include))]
             #[test]
             fn $file() -> Result<()> {
 

--- a/tests/query_warning.rs
+++ b/tests/query_warning.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use pretty_assertions::assert_eq;
-use regex::Regex;
+//use regex::Regex;
 use std::io::prelude::*;
-use std::path::Path;
+//use std::path::Path;
 use tremor_common::file;
 use tremor_pipeline;
 use tremor_pipeline::query::Query;
@@ -49,7 +49,7 @@ macro_rules! test_cases {
                 let query_dir = concat!("tests/query_warnings/", stringify!($file), "/").to_string();
                 let query_file = concat!("tests/query_warnings/", stringify!($file), "/query.trickle");
                 let warning_file = concat!("tests/query_warnings/", stringify!($file), "/warning.txt");
-                let warning_re_file = concat!("tests/query_warnings/", stringify!($file), "/warning.re");
+                //let warning_re_file = concat!("tests/query_warnings/", stringify!($file), "/warning.re");
                 let module_path = &ModulePath { mounts: vec![query_dir, "tremor-script/lib/".to_string()] };
 
                 println!("Loading query: {}", query_file);
@@ -57,6 +57,8 @@ macro_rules! test_cases {
                 let mut contents = String::new();
                 file.read_to_string(&mut contents)?;
 
+                // commented out to save coverage, not needed now anyways
+                /*
                 if Path::new(warning_re_file).exists() {
                     println!("Loading warning: {}", warning_re_file);
                     let mut file = file::open(warning_re_file)?;
@@ -73,28 +75,28 @@ macro_rules! test_cases {
                         println!("Expected error, but got succeess");
                         assert!(false);
                     }
-                } else {
-                    println!("Loading error: {}", warning_file);
-                    let mut file = file::open(warning_file)?;
-                    let mut warning = String::new();
-                    file.read_to_string(&mut warning)?;
-                    let warning = warning.trim();
+                } else {*/
+                println!("Loading expected warning: {}", warning_file);
+                let mut file = file::open(warning_file)?;
+                let mut warning = String::new();
+                file.read_to_string(&mut warning)?;
+                let warning = warning.trim();
 
-                    match to_query(&module_path, warning_file, &contents) {
-                        Ok(query) => {
-                            let mut h = Dumb::new();
-                            query.0.format_warnings_with(&mut h)?;
-                            h.finalize()?;
-                            let got = h.to_string();
-                            let got = got.trim();
-                            println!("{}", got);
-                            assert_eq!(warning, got);
-                        }
-                        Err(e) => {
-                            assert!(false, "Expected successful parse to Query with warnings, got Error: {}", e);
-                        }
-                    };
+                match to_query(&module_path, warning_file, &contents) {
+                    Ok(query) => {
+                        let mut h = Dumb::new();
+                        query.0.format_warnings_with(&mut h)?;
+                        h.finalize()?;
+                        let got = h.to_string();
+                        let got = got.trim();
+                        println!("{}", got);
+                        assert_eq!(warning, got);
+                    }
+                    Err(e) => {
+                        assert!(false, "Expected successful parse to Query with warnings, got Error: {}", e);
+                    }
                 };
+                //};
                 Ok(())
             }
         )*

--- a/tests/query_warnings/_template/query.trickle
+++ b/tests/query_warnings/_template/query.trickle
@@ -1,0 +1,1 @@
+select event from in into out;

--- a/tests/query_warnings/_template/warning.txt
+++ b/tests/query_warnings/_template/warning.txt
@@ -1,0 +1,1 @@
+UPDATE ME

--- a/tests/query_warnings/emit_empty_windows/query.trickle
+++ b/tests/query_warnings/emit_empty_windows/query.trickle
@@ -1,0 +1,7 @@
+define tumbling window my_window
+with
+  interval = core::datetime::with_seconds(2),
+  emit_empty_windows = true
+end;
+
+select aggr::win::last(event) from in[my_window] into out;

--- a/tests/query_warnings/emit_empty_windows/warning.txt
+++ b/tests/query_warnings/emit_empty_windows/warning.txt
@@ -1,0 +1,7 @@
+Warning: 
+    1 | define tumbling window my_window
+    2 | with
+    3 |   interval = core::datetime::with_seconds(2),
+    4 |   emit_empty_windows = true
+    5 | end;
+      | ^^^ Using `emit_empty_windows` without guard is potentially dangerous. Consider limiting the amount of groups maintained internally by using `max_groups` and/or `eviction_period`.

--- a/tests/query_warnings/new.sh
+++ b/tests/query_warnings/new.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -ex
+BASEDIR=$(dirname "$0")
+TEST_SUITE_FILE="${BASEDIR}/../query_warning.rs"
+TMPDIR="${BASEDIR}/tmp"
+
+if [ -z "${1}" ]
+then
+	echo "Usage: $0 TEST_NAME";
+	exit 1
+fi
+
+NAME="${1}"
+TARGET="${BASEDIR}/${1}"
+
+if [ -d "${TARGET}" ]
+then
+	echo "A test dir with that name already exists.";
+	exit 1
+fi
+
+cp -r ${BASEDIR}/_template ${TARGET}
+git add ${TARGET}
+
+sed -e '/^    \/\/ INSERT/a\
+'"${NAME}," "${TEST_SUITE_FILE}" > "${TMPDIR}" && mv "${TMPDIR}" "${TEST_SUITE_FILE}"
+
+for f in ${TARGET}/*
+do
+    echo "$f"
+done

--- a/tests/script_warnings/recordpattern_presence_and_extractor/warning.txt
+++ b/tests/script_warnings/recordpattern_presence_and_extractor/warning.txt
@@ -1,11 +1,11 @@
-Warning:
+Warning: 
     1 | match event of
     2 |   case %{ present key, key ~= re|snot| } => true
       |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The field key is checked with both present and another extractor, this is redundant as extractors imply presence. It may also overwrite the result of the extractor.
     3 |   case %{ key ~= re|snot|, present key } => true
     4 |   default => true
 
-Warning:
+Warning: 
     1 | match event of
     2 |   case %{ present key, key ~= re|snot| } => true
     3 |   case %{ key ~= re|snot|, present key } => true

--- a/tests/script_warnings/recordpattern_presence_and_extractor/warning.txt
+++ b/tests/script_warnings/recordpattern_presence_and_extractor/warning.txt
@@ -1,14 +1,14 @@
-Warning: 
+Warning:
     1 | match event of
     2 |   case %{ present key, key ~= re|snot| } => true
-      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The field key is checked with both present and another extractor, this is redundant as extractors imply presence. It may also overwrite the result of th extractor.
+      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The field key is checked with both present and another extractor, this is redundant as extractors imply presence. It may also overwrite the result of the extractor.
     3 |   case %{ key ~= re|snot|, present key } => true
     4 |   default => true
 
-Warning: 
+Warning:
     1 | match event of
     2 |   case %{ present key, key ~= re|snot| } => true
     3 |   case %{ key ~= re|snot|, present key } => true
-      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The field key is checked with both present and another extractor, this is redundant as extractors imply presence. It may also overwrite the result of th extractor.
+      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The field key is checked with both present and another extractor, this is redundant as extractors imply presence. It may also overwrite the result of the extractor.
     4 |   default => true
     5 | end

--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -1522,7 +1522,6 @@ impl Operator for TrickleSelect {
                     }
                 }
             }
-            // lets reset the
             Ok(res)
         } else {
             Ok(EventAndInsights::default())
@@ -1596,7 +1595,7 @@ mod test {
         }
     }
 
-    use std::sync::Arc;
+    use std::{collections::BTreeSet, sync::Arc};
 
     fn test_select(
         uid: u64,
@@ -2028,7 +2027,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2069,7 +2068,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2111,7 +2110,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2147,7 +2146,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2188,7 +2187,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2234,7 +2233,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =
@@ -2292,7 +2291,7 @@ mod test {
             query: query_rental,
             locals: 0,
             source: script,
-            warnings: vec![],
+            warnings: BTreeSet::new(),
         };
 
         let stmt_rental =

--- a/tremor-pipeline/src/query.rs
+++ b/tremor-pipeline/src/query.rs
@@ -359,8 +359,7 @@ impl Query {
                     };
                     let id = pipe_graph.add_node(node.clone());
 
-                    let mut ww: HashMap<String, WindowImpl> =
-                        HashMap::with_capacity(query.windows.len());
+                    let mut ww = HashMap::with_capacity(query.windows.len());
                     for (name, decl) in &query.windows {
                         ww.insert(name.clone(), window_decl_to_impl(&decl, &that)?);
                     }

--- a/tremor-script/src/ast/query.rs
+++ b/tremor-script/src/ast/query.rs
@@ -246,6 +246,17 @@ pub struct WindowDecl<'script> {
 impl_expr_mid!(WindowDecl);
 
 impl<'script> WindowDecl<'script> {
+    /// `emit_empty_windows` setting
+    pub const EMIT_EMPTY_WINDOWS: &'static str = "emit_empty_windows";
+    /// `eviction_period` setting
+    pub const EVICTION_PERIOD: &'static str = "eviction_period";
+    /// `max_groups` setting
+    pub const MAX_GROUPS: &'static str = "max_groups";
+    /// `interval` setting
+    pub const INTERVAL: &'static str = "interval";
+    /// `size` setting
+    pub const SIZE: &'static str = "size";
+
     /// Calculate the fully qualified window name
     #[must_use]
     pub fn fqwn(&self, module: &[String]) -> String {

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -252,7 +252,7 @@ where
 
     /// Format warnings with the given `Highligher`.
     pub fn format_warnings_with<H: Highlighter>(&self, h: &mut H) -> io::Result<()> {
-        for w in &self.warnings {
+        for w in self.warnings() {
             let tokens: Vec<_> = lexer::Tokenizer::new(&self.source)
                 .tokenize_until_err()
                 .collect();


### PR DESCRIPTION
And also rework the warnings api for the parser a bit.

This was an oversight from #828 

# Pull request

## Description

We now create a warning like this when only `emit_empty_windows` is specified without guards like `max_groups` or `eviction_period`:

```
Warning: 
    1 | define tumbling window my_window
    2 | with
    3 |   interval = core::datetime::with_seconds(2),
    4 |   emit_empty_windows = true
    5 | end;
      | ^^^ Using `emit_empty_windows` without guard is potentially dangerous. Consider limiting the amount of groups maintained internally by using `max_groups` and/or `eviction_period`
```

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


