### PR TITLE
Add topic, offset, partition and timestamp to kafka Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Remove warnings for match w/o default if a `_` case or a `v = _` case exists
 * Add `--exprs-only` to `dbg ast` to not show metadata
 * Add Delete and Update to ES sink [#822](https://github.com/tremor-rs/tremor-runtime/issues/822)
+* Add more metadata to Kafka source [#874](https://github.com/tremor-rs/tremor-runtime/issues/874)
 
 ### Fixes
 

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -293,12 +293,18 @@ impl Source for Int {
                         }
                         meta_headers = Some(key_val);
                     }
-                    let mut meta_data = Value::object_with_capacity(2);
+                    let mut meta_data = Value::object_with_capacity(6);
                     if let Some(meta_key) = meta_key {
                         meta_data.insert("key", Value::Bytes(Vec::from(meta_key).into()))?;
                     }
                     if let Some(meta_headers) = meta_headers {
                         meta_data.insert("headers", meta_headers)?;
+                    }
+                    meta_data.insert("topic", m.topic().to_string())?;
+                    meta_data.insert("offset", m.offset())?;
+                    meta_data.insert("partition", m.partition())?;
+                    if let Some(t) = m.timestamp().to_millis() {
+                        meta_data.insert("timestamp", t)?;
                     }
                     kafka_meta_data.insert("kafka", meta_data)?;
 


### PR DESCRIPTION
# Pull request

## Description

Add topic, offset, partition and timestamp to kafka Metadata

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: closes #874 
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/97)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

this only changes the kafka source


