### PR TITLE
Add a stdin onramp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Update to simd-json 0.4
 * Add tests covering basic operations and string interpolation for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721) 
 * Add offramp and onramp for [NATS.io](https://nats.io/).
+* Add a stdin onramp.
 
 ### Fixes
 

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -17,8 +17,8 @@ use crate::pipeline;
 use crate::repository::ServantId;
 use crate::source::prelude::*;
 use crate::source::{
-    blaster, cb, crononome, discord, file, kafka, metronome, nats, otel, postgres, rest, tcp, udp,
-    ws,
+    blaster, cb, crononome, discord, file, kafka, metronome, nats, otel, postgres, rest, stdin,
+    tcp, udp, ws,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};
@@ -77,6 +77,7 @@ pub(crate) fn lookup(
         "postgres" => postgres::Postgres::from_config(id, config),
         "metronome" => metronome::Metronome::from_config(id, config),
         "crononome" => crononome::Crononome::from_config(id, config),
+        "stdin" => stdin::Stdin::from_config(id, config),
         "udp" => udp::Udp::from_config(id, config),
         "tcp" => tcp::Tcp::from_config(id, config),
         "rest" => rest::Rest::from_config(id, config),

--- a/src/source.rs
+++ b/src/source.rs
@@ -46,6 +46,7 @@ pub(crate) mod otel;
 pub(crate) mod postgres;
 pub(crate) mod prelude;
 pub(crate) mod rest;
+pub(crate) mod stdin;
 pub(crate) mod tcp;
 pub(crate) mod udp;
 pub(crate) mod ws;

--- a/src/source/stdin.rs
+++ b/src/source/stdin.rs
@@ -1,0 +1,105 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![cfg(not(tarpaulin_include))]
+
+use crate::{source::prelude::*, url::TremorUrl};
+use async_std::io;
+
+const INPUT_SIZE_BYTES: usize = 8192;
+
+pub struct Stdin {
+    onramp_id: TremorUrl,
+}
+
+pub struct Int {
+    onramp_id: TremorUrl,
+    origin_uri: EventOriginUri,
+    stdin: io::Stdin,
+}
+
+impl std::fmt::Debug for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "stdin")
+    }
+}
+
+impl Int {
+    async fn new(uid: u64, onramp_id: TremorUrl) -> Result<Self> {
+        let stdin = io::stdin();
+        let origin_uri = EventOriginUri {
+            uid,
+            scheme: "tremor-stdin".to_string(),
+            host: hostname(),
+            port: None,
+            path: vec![],
+        };
+        Ok(Self {
+            onramp_id,
+            origin_uri,
+            stdin,
+        })
+    }
+}
+
+impl onramp::Impl for Stdin {
+    fn from_config(id: &TremorUrl, _config: &Option<YamlValue>) -> Result<Box<dyn Onramp>> {
+        Ok(Box::new(Self {
+            onramp_id: id.clone(),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Onramp for Stdin {
+    async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
+        let source = Int::new(config.onramp_uid, self.onramp_id.clone()).await?;
+        SourceManager::start(source, config).await
+    }
+
+    fn default_codec(&self) -> &str {
+        "string"
+    }
+}
+
+#[async_trait::async_trait()]
+impl Source for Int {
+    fn id(&self) -> &TremorUrl {
+        &self.onramp_id
+    }
+
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
+        let mut input = vec![0; INPUT_SIZE_BYTES];
+        if let Ok(len) = self.stdin.read(&mut input).await {
+            if len == 0 {
+                Ok(SourceReply::StateChange(SourceState::Disconnected))
+            } else {
+                Ok(SourceReply::Data {
+                    origin_uri: self.origin_uri.clone(),
+                    // ALLOW: len cannot be > INPUT_SIZE_BYTES
+                    data: input[0..len].to_vec(),
+                    meta: None,
+                    codec_override: None,
+                    stream: 0,
+                })
+            }
+        } else {
+            error!("[Source::{}] Failed to read from stdin.", self.onramp_id);
+            Ok(SourceReply::Empty(0))
+        }
+    }
+
+    async fn init(&mut self) -> Result<SourceState> {
+        Ok(SourceState::Connected)
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>

# Pull request

## Description
Add an onramp which takes inputs from stdin.
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #509 
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/99)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


