### PR TITLE
Add band, bxor and string interpolation eqc tests

### DIFF
--- a/.github/workflows/eqc-tremor-script.yaml
+++ b/.github/workflows/eqc-tremor-script.yaml
@@ -1,0 +1,24 @@
+name: EQC Tests for tremor-script
+
+on: [push]
+
+jobs:
+  eqc-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: gleam-lang/setup-erlang@v1.1.2
+        with:
+          otp-version: 23.1
+      - name: Install deps
+        run: sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
+      - name: install EQC
+        run: curl -O http://quviq-licencer.com/downloads/eqcR21.zip && unzip eqcR21.zip && cd Quviq* && sudo erl -noshell -eval 'eqc_install:install()' -eval 'init:stop()'
+      - name: Activate EQC
+        run: erl -noshell -eval 'eqc:registration("${{secrets.EQC_LICENSE}}")' -eval "eqc:start()" -eval "init:stop()"
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal    
+      - name: Run
+        run: make -C tremor-script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add Delete and Update to ES sink [#822](https://github.com/tremor-rs/tremor-runtime/issues/822)
 * Add more metadata to Kafka source [#874](https://github.com/tremor-rs/tremor-runtime/issues/874)
 * Update to simd-json 0.4
+* Add tests covering basic operations and string interpolation for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721) 
 
 ### Fixes
 

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -74,3 +74,4 @@ tempfile = "3"
 
 [features]
 fns = []
+erlang-float-testing = []

--- a/tremor-script/Makefile
+++ b/tremor-script/Makefile
@@ -1,2 +1,13 @@
-run-eqc:
-	LD_LIBRARY_PATH="../target/debug:$$LD_LIBRARY_PATH" rebar3 as eqc eqc
+run-eqc: compile 
+	LD_LIBRARY_PATH="../target/debug:$LD_LIBRARY_PATH" rebar3 as eqc eqc -n 1000
+
+simple:	compile
+	LD_LIBRARY_PATH="../target/debug:$LD_LIBRARY_PATH" rebar3 as eqc eqc --properties prop_simple_expr -n 1000
+
+compile:
+	cargo build -p tremor-script --features erlang-float-testing
+
+clean:
+	make -C c_src clean
+	rm -rf _build
+	rm -r priv 

--- a/tremor-script/eqc/gen_script.erl
+++ b/tremor-script/eqc/gen_script.erl
@@ -24,6 +24,8 @@ gen_({'-', A, B}) ->  ["(", gen_(A), " - ", gen_(B), ")"];
 gen_({'/', A, B}) ->  ["(", gen_(A), " / ", gen_(B), ")"];
 gen_({'*', A, B}) ->  ["(", gen_(A), " * ", gen_(B), ")"];
 gen_({'%', A, B}) ->  ["(", gen_(A), " % ", gen_(B), ")"];
+gen_({'band', A, B}) ->  ["(", gen_(A), " & ", gen_(B), ")"];
+gen_({'bxor', A, B}) ->  ["(", gen_(A), " ^ ", gen_(B), ")"];
 
 gen_({'==', A, B}) ->  ["(", gen_(A), " == ", gen_(B), ")"];
 gen_({'!=', A, B}) ->  ["(", gen_(A), " != ", gen_(B), ")"];
@@ -36,6 +38,7 @@ gen_({'or', A, B}) ->  ["(", gen_(A), " or ", gen_(B), ")"];
 gen_({'not', A}) ->  ["not (", gen_(A), ")"];
 gen_({'+', A})  -> ["(+ ", gen_(A), ")"];
 gen_({'-', A}) -> ["(- ", gen_(A), ")"];
+gen_({'#',String1, String2, Sub}) -> ["(", string:trim(gen_(String1), trailing, "\""), "#{", gen(Sub), "}", string:trim(gen_(String2), leading, "\""), ")"];
 gen_({'let', Path, Expr}) -> ["let ", gen_(Path), " = ", gen_(Expr)];
 gen_({local, Path}) -> Path;
 gen_({emit, A}) -> ["emit (", gen_(A), ")"];

--- a/tremor-script/eqc/model.erl
+++ b/tremor-script/eqc/model.erl
@@ -25,6 +25,14 @@ resolve(#state{locals = L}, {local, _} = K) ->
 -spec ast_eval(#vars{}, {}) -> {#vars{},
 				integer() | float() | boolean() | binary()}.
 
+ast_eval(#vars{} = S, {'#',A, B, Expr}) ->
+    {S1, Expr1} = ast_eval(S, Expr),
+    case Expr1 of
+        Expr1 when is_binary(Expr1) ->
+        {S1, <<A/binary, Expr1/binary, B/binary>>};
+        Expr1 ->
+        {S1, <<A/binary, (jsx:encode(util:unfloat(Expr1)))/binary, B/binary>>}
+    end;
 ast_eval(#vars{} = S, {'+', A, B})
     when is_binary(A) andalso is_binary(B) ->
     {S, <<A/binary, B/binary>>};
@@ -86,6 +94,14 @@ ast_eval(#vars{} = S, {'or', A, B}) ->
     {S2, A1 orelse B1};
 ast_eval(#vars{} = S, {'not', A}) ->
     {S1, A1} = ast_eval(S, A), {S1, not A1};
+ast_eval(#vars{} = S, {'band', A, B}) ->
+    {S1, A1} = ast_eval(S, A),
+    {S2, B1} = ast_eval(S1, B),
+    {S2, A1 band B1};
+ast_eval(#vars{} = S, {'bxor', A, B}) ->
+    {S1, A1} = ast_eval(S, A),
+    {S2, B1} = ast_eval(S1, B),
+    {S2, A1 bxor B1};
 ast_eval(#vars{} = S, {'+', A}) ->
     {S1, A1} = ast_eval(S, A), {S1, A1};
 ast_eval(#vars{} = S, {'-', A}) ->

--- a/tremor-script/eqc/util.erl
+++ b/tremor-script/eqc/util.erl
@@ -15,7 +15,7 @@
 
 -module(util).
 
--export([clamp/2, mod/2, round/2]).
+-export([clamp/2, mod/2, round/2, unfloat/1]).
 
 mod(X, Y) when X > 0 -> X rem Y;
 mod(X, Y) when X < 0 -> Y + X rem Y;
@@ -27,7 +27,7 @@ round(Number, Precision) ->
 clamp(Number, Precision) when is_float(Number) ->
     list_to_float(float_to_list(round(Number,
 				      Precision + 1),
-				[{decimals, 10}]));
+				[{decimals, Precision}]));
 clamp({K, V}, Precision) -> {K, clamp(V, Precision)};
 clamp(#{<<"emit">> := V}, Precision) ->
     #{<<"emit">> => clamp(V, Precision)};
@@ -36,3 +36,15 @@ clamp(#{<<"drop">> := V}, Precision) ->
 clamp(L, Precision) when is_list(L) ->
     [clamp(E, Precision) || E <- L];
 clamp(Number, _) -> Number.
+
+%% replaces all floats with 42
+unfloat(Number) when is_float(Number) ->
+    42;
+unfloat({K, V}) -> {K, unfloat(V)};
+unfloat(#{<<"emit">> := V}) ->
+    #{<<"emit">> => unfloat(V)};
+unfloat(#{<<"drop">> := V}) ->
+    #{<<"drop">> => unfloat(V)};
+unfloat(L) when is_list(L) ->
+    [unfloat(E) || E <- L];
+unfloat(Number) -> Number. 

--- a/tremor-script/src/interpreter/imut_expr.rs
+++ b/tremor-script/src/interpreter/imut_expr.rs
@@ -135,10 +135,27 @@ where
                 for e in elements {
                     match e {
                         crate::ast::StrLitElement::Lit(l) => out.push_str(l),
+                        #[cfg(not(feature = "erlang-float-testing"))]
                         crate::ast::StrLitElement::Expr(e) => {
                             let r = e.run(opts, env, event, state, meta, local)?;
                             if let Some(s) = r.as_str() {
                                 out.push_str(&s);
+                            } else {
+                                out.push_str(r.encode().as_str());
+                            };
+                        }
+                        // TODO: The float scenario is different in erlang and rust
+                        // We knowingly excluded float correctness in string interpolation
+                        // as we don't want to over engineer and write own format functions.
+                        // any suggestions are welcome
+                        #[cfg(feature = "erlang-float-testing")]
+                        #[cfg(not(tarpaulin_include))]
+                        crate::ast::StrLitElement::Expr(e) => {
+                            let r = e.run(opts, env, event, state, meta, local)?;
+                            if let Some(s) = r.as_str() {
+                                out.push_str(&s);
+                            } else if let Some(_f) = r.as_f64() {
+                                out.push_str("42");
                             } else {
                                 out.push_str(r.encode().as_str());
                             };


### PR DESCRIPTION

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->
- Update Makefile with commonly used commands
- Add SHRINKING feature to produce simple errors
- Kept string interpolation as a feature, only used when required.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

<!-- * [RFC](https://rfcs.tremor.rs/0000-.../) -->
* Related Issues:  #721
<!-- * Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000) -->

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behaviour
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

--> The changes are mostly focused on covering testing in tremor-script, I don't think it affects any performance. Although, we found some bugs in the middle which might be useful when used but not necessarily performance related.


