### PR TITLE
Update tremor-cli docs tool to work with unified module path env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * CNCF OpenTelemetry source, sink and `cncf::otel` tremor-script library adds log, trace, metrics OpenTelemetry support
+* Fixes module path function resolution for `tremor-cli doc` tool to use unified path resolution
 * Removed the vsn.sh script which checks if the lockfile is up to date and replaces it with the --locked flag [#798](https://github.com/tremor-rs/tremor-runtime/pull/798)
 * Allow using '_' as seperators in numeric literals [#645](https://github.com/tremor-rs/tremor-runtime/issues/645)
 * Refactor kafka metadata variables to be under a single record `$kafka`.

--- a/tremor-cli/src/doc.rs
+++ b/tremor-cli/src/doc.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::env;
 use crate::errors::{Error, Result};
 use crate::util::visit_path_str;
 use clap::ArgMatches;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use tremor_script::path::load as load_module_path;
-use tremor_script::registry;
-use tremor_script::registry::Registry;
 use tremor_script::script::Script;
 
 fn gen_doc(
@@ -37,9 +35,7 @@ fn gen_doc(
     let mut input = crate::open_file(path, None)?;
     input.read_to_string(&mut raw)?;
 
-    let reg: Registry = registry::registry();
-
-    let mp = load_module_path();
+    let env = env::setup()?;
     let name = rel_path
         .to_string_lossy()
         .to_string()
@@ -50,7 +46,7 @@ fn gen_doc(
 
     let path = path.to_str().ok_or_else(|| Error::from("Bad path"))?;
 
-    let runnable = Script::parse(&mp, &path, raw, &reg)?;
+    let runnable = Script::parse(&env.module_path, &path, raw, &env.fun)?;
     let docs = runnable.docs();
     let consts = &docs.consts;
     let fns = &docs.fns;

--- a/tremor-script/lib/cncf/otel.tremor
+++ b/tremor-script/lib/cncf/otel.tremor
@@ -1,4 +1,15 @@
-### `CNCF OpenTelemetry` utility functions
+### <p align=center>
+###   <img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/tremor/horizontal/color/tremor-horizontal-color.png" width='35%'>
+###   <img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opentelemetry/horizontal/color/opentelemetry-horizontal-color.png" width='35%'>
+### </p>
+### <p align=center><a href="https://landscape.cncf.io/selected=tremor">CNCF Early Stage Sandbox Project</a></p>
+### <p align=center><a href="https://landscape.cncf.io/category=streaming-messaging&format=card-mode&grouping=category">CNCF Streaming &amp; Messaging</a></p>
+###
+### <hr/>
+###
+###
+### # `CNCF OpenTelemetry` utility functions
+###
 ###
 ###
 ### * [span_id](otel/span_id.md) - OpenTelemetry Span Id utilities

--- a/tremor-script/lib/cncf/otel.tremor
+++ b/tremor-script/lib/cncf/otel.tremor
@@ -2,8 +2,8 @@
 ###
 ###
 ### * [span_id](otel/span_id.md) - OpenTelemetry Span Id utilities
-### * [trace_id](otel/base64.md) - OpenTelemetry Trace Id utilities
-### * [logs](std/logs.md) - OpenTelemetry log event utilities
+### * [trace_id](otel/trace_id.md) - OpenTelemetry Trace Id utilities
+### * [logs](otel/logs.md) - OpenTelemetry log event utilities
 ### * [metrics](otel/metrics.md) - OpenTelemetry metrics event utilities
 ### * [trace](otel/trace.md) - OpenTelemetry trace event utilities
 

--- a/tremor-script/lib/cncf/otel.tremor
+++ b/tremor-script/lib/cncf/otel.tremor
@@ -1,12 +1,8 @@
 ### <p align=center>
-###   <img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/tremor/horizontal/color/tremor-horizontal-color.png" width='35%'>
 ###   <img src="https://raw.githubusercontent.com/cncf/artwork/master/projects/opentelemetry/horizontal/color/opentelemetry-horizontal-color.png" width='35%'>
 ### </p>
-### <p align=center><a href="https://landscape.cncf.io/selected=tremor">CNCF Early Stage Sandbox Project</a></p>
-### <p align=center><a href="https://landscape.cncf.io/category=streaming-messaging&format=card-mode&grouping=category">CNCF Streaming &amp; Messaging</a></p>
 ###
 ### <hr/>
-###
 ###
 ### # `CNCF OpenTelemetry` utility functions
 ###

--- a/tremor-script/lib/cncf/otel.tremor
+++ b/tremor-script/lib/cncf/otel.tremor
@@ -1,6 +1,11 @@
 ### `CNCF OpenTelemetry` utility functions
 ###
 ###
+### * [span_id](otel/span_id.md) - OpenTelemetry Span Id utilities
+### * [trace_id](otel/base64.md) - OpenTelemetry Trace Id utilities
+### * [logs](std/logs.md) - OpenTelemetry log event utilities
+### * [metrics](otel/metrics.md) - OpenTelemetry metrics event utilities
+### * [trace](otel/trace.md) - OpenTelemetry trace event utilities
 
 use cncf::otel::span_id;
 use cncf::otel::trace_id;

--- a/tremor-script/lib/cncf/otel/logs.tremor
+++ b/tremor-script/lib/cncf/otel/logs.tremor
@@ -1,2 +1,7 @@
+### CNCF OpenTelemetry Log event utilities
+###
+### * [severity](logs/severity.md) - Log severity
+### * [traceflags](logs/traceflags.md) - Log trace flags
+
 use cncf::otel::logs::severity;
 use cncf::otel::logs::traceflags;

--- a/tremor-script/lib/cncf/otel/metrics.tremor
+++ b/tremor-script/lib/cncf/otel/metrics.tremor
@@ -1,1 +1,5 @@
+### CNCF OpenTelemetry Metrics event utilities
+###
+### * [temporality](metrics/temporality.md) - Metrics aggregation temporality
+
 use cncf::otel::metrics::temporality;

--- a/tremor-script/lib/cncf/otel/trace.tremor
+++ b/tremor-script/lib/cncf/otel/trace.tremor
@@ -1,2 +1,7 @@
+### CNCF OpenTelemetry Trace event utilities
+###
+### * [spankind](trace/spankind.md) - Trace span kind
+### * [status](trace/status.md) - Trace status
+
 use cncf::otel::trace::spankind;
 use cncf::otel::trace::status;

--- a/tremor-script/lib/std.tremor
+++ b/tremor-script/lib/std.tremor
@@ -15,7 +15,6 @@
 ### * [test](std/test.md) - test related functions
 ### * [type](std/type.md) - functions dealing with strings
 ### * [url](std/url.md) - url decoding/encoding functions
-### * [otel](std/otel.md) - CNCF OpenTelemetry functions
 
 use std::array;
 use std::base64;
@@ -32,4 +31,3 @@ use std::string;
 use std::test;
 use std::type;
 use std::url;
-use std::otel;


### PR DESCRIPTION
Signed-off-by: Darach Ennis <darach@gmail.com>

# Pull request

## Description

Minor fix to `tremor-cli` doc tool. We ordinarily only run this upon release
but testing document generation for the new `cncf::otel` modules turned up
these issues. This ticket evidences a bug ( and provides the fix! )

## Related

None

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

None

