### PR TITLE
Add non binding UDP sink support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 * Add tests covering basic operations and string interpolation for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721) 
 * Add offramp and onramp for [NATS.io](https://nats.io/).
 * Add a stdin onramp.
-* Add tests covering arrays and records for tremor-script[#721]
+* Add tests covering arrays and records for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
+* Support for non caching UDP sink [#900](https://github.com/tremor-rs/tremor-runtime/issues/900)
 
 ### Fixes
 

--- a/src/sink/udp.rs
+++ b/src/sink/udp.rs
@@ -88,6 +88,7 @@ impl Sink for Udp {
                     if self.config.bound {
                         socket.send(&processed).await?;
                     } else {
+                        // reaquire the destination to handle DNS changes or multi IP dns entries
                         socket
                             .send_to(
                                 &processed,

--- a/src/sink/udp.rs
+++ b/src/sink/udp.rs
@@ -42,7 +42,14 @@ pub struct Config {
     pub port: u16,
     pub dst_host: String,
     pub dst_port: u16,
+    #[serde(default = "t")]
+    pub bound: bool,
 }
+
+fn t() -> bool {
+    true
+}
+
 impl ConfigImpl for Config {}
 
 impl offramp::Impl for Udp {
@@ -78,7 +85,16 @@ impl Sink for Udp {
                 let raw = codec.encode(value)?;
                 for processed in postprocess(&mut self.postprocessors, ingest_ns, raw)? {
                     //TODO: Error handling
-                    socket.send(&processed).await?;
+                    if self.config.bound {
+                        socket.send(&processed).await?;
+                    } else {
+                        socket
+                            .send_to(
+                                &processed,
+                                (self.config.dst_host.as_str(), self.config.dst_port),
+                            )
+                            .await?;
+                    }
                 }
             }
         } else {
@@ -121,9 +137,11 @@ impl Sink for Udp {
     async fn on_signal(&mut self, signal: Event) -> ResultVec {
         if self.socket.is_none() {
             let socket = UdpSocket::bind((self.config.host.as_str(), self.config.port)).await?;
-            socket
-                .connect((self.config.dst_host.as_str(), self.config.dst_port))
-                .await?;
+            if self.config.bound {
+                socket
+                    .connect((self.config.dst_host.as_str(), self.config.dst_port))
+                    .await?;
+            }
             self.socket = Some(socket);
             Ok(Some(vec![sink::Reply::Insight(Event::cb_restore(
                 signal.ingest_ns,


### PR DESCRIPTION
Signed-off-by: Heinz N. Gies <heinz@licenser.net>

# Pull request

## Description

Introduce the `bound` option to the UDP sink which can be set to `false` to let the sink re-acquire the connection to a target for every package

## Related

* Related Issues: fixes #900
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/108)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

only sink changes