### PR TITLE
Correctly forward docker image args to tremor binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Fix CI runners to work with caching
 * Fix dependencies for `tremor-value` and `tremor-common`
-
+* Fix docker entrypoint not forwarding arguments to tremor binary, unless `--` is used before them
 
 ## 0.11.0
 
@@ -41,7 +41,7 @@
 * Add Delete and Update to ES sink [#822](https://github.com/tremor-rs/tremor-runtime/issues/822)
 * Add more metadata to Kafka source [#874](https://github.com/tremor-rs/tremor-runtime/issues/874)
 * Update to simd-json 0.4
-* Add tests covering basic operations and string interpolation for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721) 
+* Add tests covering basic operations and string interpolation for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
 * Add offramp and onramp for [NATS.io](https://nats.io/).
 * Add a stdin onramp.
 * Add tests covering arrays and records for tremor-script[#721](https://github.com/tremor-rs/tremor-runtime/issues/721)

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ COPY docker/logger.yaml /etc/tremor/logger.yaml
 
 ENV TREMOR_PATH=/opt/local/tremor/lib
 
-ENTRYPOINT ["tini", "/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -63,4 +63,4 @@ else
 fi
 
 # IMPORTANT: do not quote ARGS, no matter what shellcheck tells you
-exec /tremor ${ARGS}
+exec /usr/bin/tini /tremor -- ${ARGS}


### PR DESCRIPTION
Signed-off-by: Matthias Wahl <mwahl@wayfair.com>

# Pull request

## Description

Due to a stupidly set up docker entrypoint, when specifying any flags on the command line, those were forwarded to `tini`, not `tremor`. You would have to prefix your arguments with `--`. This is fixed with this PR.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


