### PR TITLE
Post release cleanup II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix CI runners to work with caching
 * Fix dependencies for `tremor-value` and `tremor-common`
 * Fix docker entrypoint not forwarding arguments to tremor binary, unless `--` is used before them
+* Fix match default clause only executing the last statement in the block.
 
 ## 0.11.0
 

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -213,7 +213,7 @@ impl ConsumerContext for LoggingConsumerContext {
         match result {
             Ok(_) => {
                 if offsets.count() > 0 {
-                    info!(
+                    debug!(
                         "[Source::{}] Offsets committed successfully",
                         self.onramp_id
                     );

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -154,6 +154,7 @@ test_cases!(
     // TODO
     // const_in_const_lookup,
     // INSERT
+    match_multiple_exprs,
     xz_compressed_fixtures,
     match_assign,
     match_reorder1,

--- a/tests/scripts/match_multiple_exprs/in
+++ b/tests/scripts/match_multiple_exprs/in
@@ -1,0 +1,4 @@
+{}
+{"snot": "badger"}
+{"snot": "moo"}
+{"something": "completely different"}

--- a/tests/scripts/match_multiple_exprs/out
+++ b/tests/scripts/match_multiple_exprs/out
@@ -1,0 +1,4 @@
+{"i_tell_you_what_i_want": "what I really, really want","no_badger":"sad"}
+{"if_you_wanna_be_my_lover":"you gotta get with my friends","snot": "badger","badger_is_snot":true}
+{"snot": "moo","i_tell_you_what_i_want": "what I really, really want","no_badger":"sad"}
+{"something": "completely different","i_tell_you_what_i_want": "what I really, really want","no_badger":"sad"}

--- a/tests/scripts/match_multiple_exprs/script.tremor
+++ b/tests/scripts/match_multiple_exprs/script.tremor
@@ -1,0 +1,9 @@
+match event of
+  case %{ snot == "badger" } =>
+    let event.if_you_wanna_be_my_lover = "you gotta get with my friends",
+    let event.badger_is_snot = true
+  default =>
+    let event.i_tell_you_what_i_want = "what I really, really want",
+    let event.no_badger = "sad"
+end;
+event

--- a/tremor-script/src/ast/raw.rs
+++ b/tremor-script/src/ast/raw.rs
@@ -2361,7 +2361,7 @@ where
             let mut last = Ex::Target::null_lit();
             std::mem::swap(exprs, &mut es);
             std::mem::swap(last_expr, &mut last);
-            if exprs.is_empty() {
+            if es.is_empty() {
                 if last.is_null_lit() {
                     DefaultCase::Null
                 } else {


### PR DESCRIPTION
# Pull request

## Description

Multiple thingies:
* Fix match default clause only executing the last statement in its block
* Fix kafka onramp logging on info level for every successful offset commit (noisy) - moved to debug
* 
## Related


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


