### PR TITLE
Ensure transactional events send acks/fails in every case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Fix match default clause only executing the last statement in the block.
 * Kafka back to async with a timeout on waiting
 * Fix `qos::wal` operator never cleaning up the last event from its storage
+* Fix `generic::batch` operator swallowing the `transactional` status of an Event
+* Fix windowed select queries not tracking the `transactional` status of an Event
+* Fix windowed select queries not tracking the Events that constitute an outgoing aggregated event
+* Avoid several offramps to swallow fail insights.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add DNS sink
 * Add syslog codec.
 * Add `$udp.host` and `$udp.port` to allow controling udp packet destinations on a per event basis.
-* Depricate `udp.dst_*` config, introduce `udp.bind.*` config instead.
+* Deprecate `udp.dst_*` config, introduce `udp.bind.*` config instead.
 
 ### Fixes
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -272,5 +272,9 @@ error_chain! {
             description("Data can't be decompressed")
                 display("The data did not contain a known magic header to identify a supported compression")
         }
+        NoSocket {
+            description("No socket available")
+                display("No socket available")
+        }
     }
 }

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -272,10 +272,6 @@ impl Manager {
                                 // this will prevent fail insights being swallowed here
                                 // sinks need to take care of sending acks themselves. Deal with it.
                                 if (fail || offramp.auto_ack()) && transactional {
-                                    debug!(
-                                        "[Offramp::{}] send auto ack fail: {}",
-                                        offramp_url, fail
-                                    );
                                     let e = Event::ack_or_fail(!fail, ingest_ns, ids);
                                     send_to_pipelines(&offramp_url, &mut pipelines, e).await;
                                 }

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -256,6 +256,7 @@ impl Manager {
                                 metrics_reporter.increment_in();
 
                                 let c: &mut dyn Codec = codec.borrow_mut();
+                                // FIXME: also report error metrics for a fail insight
                                 let fail = if let Err(err) =
                                     offramp.on_event(c, &codec_map, input.borrow(), event).await
                                 {

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -272,6 +272,10 @@ impl Manager {
                                 // this will prevent fail insights being swallowed here
                                 // sinks need to take care of sending acks themselves. Deal with it.
                                 if (fail || offramp.auto_ack()) && transactional {
+                                    debug!(
+                                        "[Offramp::{}] send auto ack fail: {}",
+                                        offramp_url, fail
+                                    );
                                     let e = Event::ack_or_fail(!fail, ingest_ns, ids);
                                     send_to_pipelines(&offramp_url, &mut pipelines, e).await;
                                 }

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -256,7 +256,6 @@ impl Manager {
                                 metrics_reporter.increment_in();
 
                                 let c: &mut dyn Codec = codec.borrow_mut();
-                                // FIXME: also report error metrics for a fail insight
                                 let fail = if let Err(err) =
                                     offramp.on_event(c, &codec_map, input.borrow(), event).await
                                 {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -287,8 +287,7 @@ async fn pipeline_task(
     let cf = cf_rx.map(M::C);
     let mf = mgmt_rx.map(M::M);
 
-    // priotirize management flow over contra flow over forward event flow
-
+    // prioritize management flow over contra flow over forward event flow
     let mut s = PriorityMerge::new(mf, PriorityMerge::new(cf, ff));
     while let Some(msg) = s.next().await {
         match msg {

--- a/src/sink/elastic.rs
+++ b/src/sink/elastic.rs
@@ -415,7 +415,7 @@ impl Elastic {
                 // send response events
                 for response in responses {
                     if let Err(e) = response_tx.send(response).await {
-                        error!("Failed to send bulk item response: {}", e);
+                        error!("[Sink::ES] Failed to send bulk item response: {}", e);
                     }
                 }
 

--- a/src/sink/tcp.rs
+++ b/src/sink/tcp.rs
@@ -115,7 +115,7 @@ impl Sink for Tcp {
             }
             // for TCP we always trigger the CB for IO/socket related errors
             Err(e @ Error(ErrorKind::Io(_), _)) | Err(e @ Error(ErrorKind::NoSocket, _)) => {
-                debug!("[Source::TCP] Error sending event: {}.", e);
+                debug!("[Sink::TCP] Error sending event: {}.", e);
                 if event.transactional {
                     Some(vec![
                         sink::Reply::Insight(event.to_fail()),
@@ -128,7 +128,7 @@ impl Sink for Tcp {
             // all other errors (codec/peprocessor etc.) just result in a fail
             Err(e) => {
                 // regular error, no reason for CB
-                debug!("[Source::TCP] Error sending event: {}", e);
+                debug!("[Sink::TCP] Error sending event: {}", e);
 
                 if event.transactional {
                     Some(vec![sink::Reply::Insight(event.to_fail())])

--- a/src/sink/udp.rs
+++ b/src/sink/udp.rs
@@ -111,6 +111,35 @@ impl offramp::Impl for Udp {
     }
 }
 
+impl Udp {
+    /// serialize event and send each serialized packet
+    async fn send_event(&mut self, codec: &mut dyn Codec, event: &Event) -> Result<()> {
+        let socket = self
+            .socket
+            .as_ref()
+            .ok_or_else(|| Error::from(ErrorKind::NoSocket))?;
+        let ingest_ns = event.ingest_ns;
+        for (value, meta) in event.value_meta_iter() {
+            let raw = codec.encode(value)?;
+            for processed in postprocess(&mut self.postprocessors, ingest_ns, raw)? {
+                let udp = meta.get("udp");
+                if let Some((host, port)) = udp.get_str("host").zip(udp.get_u16("port")) {
+                    socket.send_to(&processed, (host, port)).await?;
+                } else if self.config.bound {
+                    socket.send(&processed).await?;
+                } else {
+                    warn!("using `bound` in the UDP sink config is deprecated please use $udp.host and $udp.port instead!");
+                    // reaquire the destination to handle DNS changes or multi IP dns entries
+                    socket
+                        .send_to(&processed, (self.config.host.as_str(), self.config.port))
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
 impl Sink for Udp {
     #[allow(clippy::cast_possible_truncation)]
@@ -121,41 +150,43 @@ impl Sink for Udp {
         _codec_map: &HashMap<String, Box<dyn Codec>>,
         mut event: Event,
     ) -> ResultVec {
-        let mut success = true;
         let processing_start = Instant::now();
-        if let Some(socket) = &mut self.socket {
-            let ingest_ns = event.ingest_ns;
-            for (value, meta) in event.value_meta_iter() {
-                let raw = codec.encode(value)?;
-                for processed in postprocess(&mut self.postprocessors, ingest_ns, raw)? {
-                    let udp = meta.get("udp");
-                    if let Some((host, port)) = udp.get_str("host").zip(udp.get_u16("port")) {
-                        socket.send_to(&processed, (host, port)).await?;
-                    } else if self.config.bound {
-                        socket.send(&processed).await?;
-                    } else {
-                        warn!("using `bound` in the UDP sink config is deprecated please use $udp.host and $udp.port instead!");
-                        // reaquire the destination to handle DNS changes or multi IP dns entries
-                        socket
-                            .send_to(&processed, (self.config.host.as_str(), self.config.port))
-                            .await?;
-                    }
+
+        // TODO: how to properly report error metrics if we dont raise an error here?
+        let replies = match self.send_event(codec, &event).await {
+            Ok(()) => {
+                // success
+                if event.transactional {
+                    Some(vec![sink::Reply::Insight(event.insight_ack_with_timing(
+                        processing_start.elapsed().as_millis() as u64,
+                    ))])
+                } else {
+                    None
                 }
             }
-        } else {
-            success = false
+            Err(Error(ErrorKind::NoSocket, _)) => {
+                // trigger CB
+                debug!("[Source::UDP] Error sending event: socket not available");
+                if event.transactional {
+                    Some(vec![
+                        sink::Reply::Insight(event.to_fail()),
+                        sink::Reply::Insight(event.insight_trigger()),
+                    ])
+                } else {
+                    Some(vec![sink::Reply::Insight(event.insight_trigger())]) // we always send a trigger
+                }
+            }
+            Err(e) => {
+                // regular error, no reason for CB
+                debug!("[Source::UDP] Error sending event: {}", e);
+                if event.transactional {
+                    Some(vec![sink::Reply::Insight(event.to_fail())])
+                } else {
+                    None
+                }
+            }
         };
-        Ok(match (success, event.transactional) {
-            (true, true) => Some(vec![sink::Reply::Insight(
-                event.insight_ack_with_timing(processing_start.elapsed().as_millis() as u64),
-            )]),
-            (true, false) => None, // no need to send acks
-            (false, true) => Some(vec![
-                sink::Reply::Insight(event.to_fail()),
-                sink::Reply::Insight(event.insight_trigger()),
-            ]),
-            (false, false) => Some(vec![sink::Reply::Insight(event.insight_trigger())]), // we always send a trigger
-        })
+        Ok(replies)
     }
     fn default_codec(&self) -> &str {
         "json"

--- a/src/source/cb.rs
+++ b/src/source/cb.rs
@@ -36,6 +36,10 @@ pub struct Config {
     // timeout in millis
     #[serde(default = "default_timeout")]
     timeout: u64,
+
+    // only expect the latest event to be acked, the earliest to be failed
+    #[serde(default = "default_expect_batched")]
+    expect_batched: bool,
 }
 
 /// 10 seconds
@@ -43,11 +47,14 @@ fn default_timeout() -> u64 {
     10_000
 }
 
+fn default_expect_batched() -> bool {
+    false
+}
+
 impl ConfigImpl for Config {}
 
 pub struct Cb {
     onramp_id: TremorUrl,
-    origin_uri: EventOriginUri,
     config: Config,
 }
 
@@ -57,12 +64,6 @@ impl onramp::Impl for Cb {
             let config: Config = Config::new(config)?;
             Ok(Box::new(Self {
                 onramp_id: id.clone(),
-                origin_uri: EventOriginUri {
-                    uid: 0, // will be filled in start
-                    scheme: "tremor-cb".to_owned(),
-                    host: hostname(),
-                    ..EventOriginUri::default()
-                },
                 config,
             }))
         } else {
@@ -84,43 +85,40 @@ impl ReceivedCbs {
         self.ack.len() + self.fail.len()
     }
 
-    fn missing_ids(&self) -> Vec<u64> {
-        let mut all_ids: Vec<u64> = self.ack.iter().chain(self.fail.iter()).copied().collect();
-        all_ids.sort_unstable();
-
-        all_ids
-            .windows(2)
-            .filter_map(|window| match window {
-                [low, hi] if hi - low > 1 => Some((low + 1)..*hi),
-                _ => None,
-            })
-            .flatten()
-            .collect()
+    fn max(&self) -> Option<u64> {
+        self.ack
+            .iter()
+            .copied()
+            .max()
+            .max(self.fail.iter().copied().max())
     }
 }
 
 #[derive(Debug)]
 struct Int {
     id: TremorUrl,
+    uid: u64,
     num_sent: usize,
     last_sent: u64, // we assume we have an increasing run of ids without gap, so we only store the latest
     received_cbs: ReceivedCbs,
     lines: Lines<BufReader<FSFile>>,
-    timeout: u64,
+    config: Config,
     finished: bool,
 }
 
 impl Int {
-    async fn from_config(_uid: u64, onramp_id: TremorUrl, config: Config) -> Result<Self> {
+    async fn from_config(uid: u64, onramp_id: TremorUrl, config: Config) -> Result<Self> {
+        info!("[Source::{}] started with uid {}", onramp_id, uid);
         let f = file::open(&config.source).await?;
         let lines = BufReader::new(f).lines();
         Ok(Self {
             id: onramp_id,
+            uid,
             num_sent: 0,
             last_sent: 0,
             received_cbs: ReceivedCbs::default(),
             lines,
-            timeout: config.timeout,
+            config,
             finished: false,
         })
     }
@@ -135,7 +133,7 @@ impl Source for Int {
                 self.last_sent = self.last_sent.max(id);
                 Ok(SourceReply::Data {
                     origin_uri: EventOriginUri {
-                        uid: 0,
+                        uid: self.uid,
                         scheme: "tremor-cb".to_owned(),
                         host: hostname(),
                         ..EventOriginUri::default()
@@ -150,12 +148,19 @@ impl Source for Int {
             None => {
                 let wait = 100;
                 if self.finished {
-                    if self.timeout == 0 {
+                    if self.config.timeout == 0 {
                         // timeout reached check if we received all cb events
-                        let status = if self.received_cbs.count() < self.num_sent {
+                        let max_cb_received = self.received_cbs.max().unwrap_or_default();
+                        let cbs_missing = if self.config.expect_batched {
+                            max_cb_received < self.last_sent
+                        } else {
+                            self.received_cbs.count() < self.num_sent
+                        };
+                        let status = if cbs_missing {
                             // report failures to stderr and exit with 1
-                            let missing_ids = self.received_cbs.missing_ids();
-                            eprintln!("Missing CB insights for events: {:?}", missing_ids);
+                            eprintln!("Expected CB events up to id {}.", self.last_sent);
+                            eprintln!("Got acks: {:?}", self.received_cbs.ack);
+                            eprintln!("Got fails: {:?}", self.received_cbs.fail);
                             1
                         } else {
                             0
@@ -164,7 +169,7 @@ impl Source for Int {
                         // ALLOW: this is the supposed to exit
                         std::process::exit(status);
                     } else {
-                        self.timeout = self.timeout.saturating_sub(wait);
+                        self.config.timeout = self.config.timeout.saturating_sub(wait);
                     }
                 } else {
                     self.finished = true;
@@ -193,14 +198,28 @@ impl Source for Int {
 
     fn ack(&mut self, id: u64) {
         self.received_cbs.ack.push(id);
-        if self.finished && self.received_cbs.count() == self.num_sent {
+        if self.finished && self.received_cbs.count() == self.num_sent
+            || (self.config.expect_batched
+                && self
+                    .received_cbs
+                    .max()
+                    .map(|m| m == self.last_sent)
+                    .unwrap_or_default())
+        {
             eprintln!("All required CB events received.");
         }
     }
 
     fn fail(&mut self, id: u64) {
         self.received_cbs.fail.push(id);
-        if self.finished && self.received_cbs.count() == self.num_sent {
+        if self.finished && self.received_cbs.count() == self.num_sent
+            || (self.config.expect_batched
+                && self
+                    .received_cbs
+                    .max()
+                    .map(|m| m == self.last_sent)
+                    .unwrap_or_default())
+        {
             eprintln!("All required CB events received.");
         }
     }
@@ -213,7 +232,6 @@ impl Source for Int {
 #[async_trait::async_trait]
 impl Onramp for Cb {
     async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
-        self.origin_uri.uid = config.onramp_uid;
         let source = Int::from_config(
             config.onramp_uid,
             self.onramp_id.clone(),

--- a/tremor-cli/tests/integration/elastic-verify-gd/after.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/after.json
@@ -1,0 +1,9 @@
+{
+    "run": "tests/integration/elastic",
+    "cmd": "docker",
+    "args": [
+        "rm",
+        "-f",
+        "tremor-elasticsearch-integration-blabla-unique"
+    ]
+}

--- a/tremor-cli/tests/integration/elastic-verify-gd/assert.yaml
+++ b/tremor-cli/tests/integration/elastic-verify-gd/assert.yaml
@@ -1,0 +1,11 @@
+status: 0
+name: elastic-verify-gd
+asserts:
+  - source: err.log
+    equals_file: expected_err.json
+  - source: ok.log
+    equals_file: expected_ok.json
+  - source: fg.err.log
+    contains:
+      - |
+        All required CB events received.

--- a/tremor-cli/tests/integration/elastic-verify-gd/before.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/before.json
@@ -1,0 +1,22 @@
+{
+    "run": "tests/integrations/elastic",
+    "cmd": "docker",
+    "args": [
+        "run",
+        "--name",
+        "tremor-elasticsearch-integration-blabla-unique",
+        "-p127.0.0.1:9200:9200",
+        "-p9300:9300",
+        "-e",
+        "discovery.type=single-node",
+        "-e",
+        "action.auto_create_index=true",
+        "elasticsearch:7.10.1"
+    ],
+    "await": {
+        "http-ok": [
+            "http://127.0.0.1:9200/"
+        ]
+    },
+    "max-await-secs": 120
+}

--- a/tremor-cli/tests/integration/elastic-verify-gd/config.yaml
+++ b/tremor-cli/tests/integration/elastic-verify-gd/config.yaml
@@ -1,0 +1,44 @@
+onramp:
+  - id: input
+    type: cb
+    codec: json
+    config:
+      source: "in.json"
+      timeout: 10000
+      expect_batched: true
+
+offramp:
+  - id: elastic
+    type: elastic
+    linked: true
+    config:
+      nodes:
+        - "http://127.0.0.1:9200/"
+  - id: errfile
+    type: file
+    codec: json
+    config:
+      file: "err.log"
+  - id: okfile
+    type: file
+    codec: json
+    config:
+      file: "ok.log"
+
+
+binding:
+  - id: elastic_integration
+    links:
+      "/onramp/input/{instance}/out": ["/pipeline/main/{instance}/in"]
+      "/pipeline/main/{instance}/out": ["/offramp/elastic/{instance}/in"]
+
+      "/offramp/elastic/{instance}/out": ["/pipeline/response_handling/{instance}/in"]
+      "/pipeline/response_handling/{instance}/out": ["/offramp/okfile/{instance}/in"]
+
+      "/offramp/elastic/{instance}/err": ["/pipeline/response_handling/{instance}/in"]
+      "/pipeline/response_handling/{instance}/err": ["/offramp/errfile/{instance}/in"]
+
+
+mapping:
+  "/binding/elastic_integration/01":
+    instance: "01"

--- a/tremor-cli/tests/integration/elastic-verify-gd/expected_err.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/expected_err.json
@@ -1,0 +1,1 @@
+{"payload":{"tremor":12,"snot":"tons","cause":"this one has a different type underneath the same key and thus will fail elastic","action":null},"success":false,"index":"my_little_index","doc":"my_little_doc","correlation":"tons"}

--- a/tremor-cli/tests/integration/elastic-verify-gd/expected_ok.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/expected_ok.json
@@ -1,0 +1,5 @@
+{"success":true,"payload":{"snot":"badger","action":null},"index":"my_little_index","doc":"my_little_doc","correlation":"badger"}
+{"success":true,"payload":{"snot":"racoon","tremor":[true,true,true,false],"action":null},"index":"my_little_index","doc":"my_little_doc","correlation":"racoon"}
+{"success":true,"payload":{"doc_id":"badger","snot":"badger","action":"delete"},"index":"my_little_index","doc":"my_little_doc","correlation":"badger"}
+{"success":true,"payload":{"doc_id":"badger","snot":"badger","action":"index"},"index":"my_little_index","doc":"my_little_doc","correlation":"badger"}
+{"success":true,"payload":{"doc_id":"badger","snot":"badger","action":"update"},"index":"my_little_index","doc":"my_little_doc","correlation":"badger"}

--- a/tremor-cli/tests/integration/elastic-verify-gd/in.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/in.json
@@ -1,0 +1,6 @@
+{"snot": "badger", "action": null}
+{"snot": "racoon", "tremor": [true, true, true, false], "action": null}
+{"snot": "tons", "tremor": 12, "cause": "this one has a different type underneath the same key and thus will fail elastic", "action": null}
+{"snot": "badger", "action": "delete", "doc_id": "badger"}
+{"snot": "badger", "action": "index", "doc_id": "badger"}
+{"snot": "badger", "action": "update", "doc_id": "badger"}

--- a/tremor-cli/tests/integration/elastic-verify-gd/main.trickle
+++ b/tremor-cli/tests/integration/elastic-verify-gd/main.trickle
@@ -1,0 +1,26 @@
+define script my_little_script
+script
+  # setting required metadata for elastic
+  let $elastic = {
+    "_index": "my_little_index",
+    "_type": "my_little_doc",
+    "action": event.action
+  };
+  let $correlation = event.snot;
+  match event of
+    case %{present doc_id} => let $elastic["_id"] = event.doc_id
+    default => null
+  end;
+  event
+end;
+create script my_little_script;
+
+define generic::batch operator batch with
+  count = 6
+end;
+create operator batch;
+
+select event from in into my_little_script;
+select event from my_little_script into batch;
+select event from batch into out;
+select event from my_little_script/err into err;

--- a/tremor-cli/tests/integration/elastic-verify-gd/response_handling.trickle
+++ b/tremor-cli/tests/integration/elastic-verify-gd/response_handling.trickle
@@ -1,0 +1,17 @@
+select {
+  "success": event.success,
+  "payload": event.payload,
+  "index": $elastic.index,
+  "doc": $elastic.doc_type,
+  "correlation": $correlation
+}
+from in where event.success into out;
+
+select {
+  "payload": event.payload,
+  "success": event.success,
+  "index": $elastic.index,
+  "doc": $elastic.doc_type,
+  "correlation": $correlation
+}
+from in where not event.success into err;

--- a/tremor-cli/tests/integration/elastic-verify-gd/tags.json
+++ b/tremor-cli/tests/integration/elastic-verify-gd/tags.json
@@ -1,0 +1,1 @@
+["elastic", "linked", "cb", "gd", "docker"]

--- a/tremor-cli/tests/integration/select-window-gd/assert.yaml
+++ b/tremor-cli/tests/integration/select-window-gd/assert.yaml
@@ -1,0 +1,7 @@
+status: 0
+name: select-window-gd
+asserts:
+  - source: fg.err.log
+    contains:
+      - |
+        All required CB events received.

--- a/tremor-cli/tests/integration/select-window-gd/config.yaml
+++ b/tremor-cli/tests/integration/select-window-gd/config.yaml
@@ -1,0 +1,22 @@
+onramp:
+  - id: input
+    type: cb
+    config:
+      source: "in.json"
+      timeout: 1000
+      expect_batched: true
+
+offramp:
+  - id: output
+    type: cb
+
+binding:
+  - id: gd
+    links:
+      "/onramp/input/{instance}/out": ["/pipeline/main/{instance}/in"]
+      "/pipeline/main/{instance}/out": ["/offramp/output/{instance}/in"]
+      "/pipeline/main/{instance}/err": ["/offramp/system::stderr/{instance}/in"]
+
+mapping:
+  /binding/gd/01:
+    instance: "01"

--- a/tremor-cli/tests/integration/select-window-gd/in.json
+++ b/tremor-cli/tests/integration/select-window-gd/in.json
@@ -1,0 +1,4 @@
+{"cb":"ack"}
+{"cb":"fail"}
+{"cb":"ack"}
+{"cb":"fail"}

--- a/tremor-cli/tests/integration/select-window-gd/in.json
+++ b/tremor-cli/tests/integration/select-window-gd/in.json
@@ -1,4 +1,5 @@
-{"cb":"ack"}
+
 {"cb":"fail"}
 {"cb":"ack"}
 {"cb":"fail"}
+{"cb":"ack"}

--- a/tremor-cli/tests/integration/select-window-gd/main.trickle
+++ b/tremor-cli/tests/integration/select-window-gd/main.trickle
@@ -1,0 +1,7 @@
+define tumbling window my_window
+with
+  size = 2
+end;
+
+# verify that a grouped select honours our cb/gs guarantees
+select aggr::win::last(event) from in[my_window] group by event.cb into out;

--- a/tremor-cli/tests/integration/select-window-gd/tags.json
+++ b/tremor-cli/tests/integration/select-window-gd/tags.json
@@ -1,0 +1,1 @@
+["gd", "select", "window"]

--- a/tremor-pipeline/src/event.rs
+++ b/tremor-pipeline/src/event.rs
@@ -180,14 +180,27 @@ impl Event {
     }
 
     /// Creates a CB fail insight from the given `event` (the cause of this fail)
-    /// and with the given `data`
     #[must_use]
     pub fn to_fail(&self) -> Self {
         Event {
             id: self.id.clone(),
             ingest_ns: self.ingest_ns,
             op_meta: self.op_meta.clone(),
+            origin_uri: self.origin_uri.clone(),
             cb: CbAction::Fail,
+            ..Event::default()
+        }
+    }
+
+    /// Create a CB ack insight from the given `event` (the cause of this ack)
+    #[must_use]
+    pub fn to_ack(&self) -> Self {
+        Event {
+            id: self.id.clone(),
+            ingest_ns: self.ingest_ns,
+            op_meta: self.op_meta.clone(),
+            origin_uri: self.origin_uri.clone(),
+            cb: CbAction::Ack,
             ..Event::default()
         }
     }

--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -728,18 +728,14 @@ pub fn influx_value(
     count: u64,
     timestamp: u64,
 ) -> Value<'static> {
-    let mut res = Value::object_with_capacity(4);
-    let mut fields = Value::object_with_capacity(1);
-    if let Some(fields) = fields.as_object_mut() {
-        fields.insert(COUNT, count.into());
-    };
-    if let Some(obj) = res.as_object_mut() {
-        obj.insert(MEASUREMENT, metric_name.into());
-        obj.insert(TAGS, Value::from(tags));
-        obj.insert(FIELDS, fields);
-        obj.insert(TIMESTAMP, timestamp.into());
-    }
-    res
+    literal!({
+        MEASUREMENT: metric_name,
+        TAGS: tags,
+        FIELDS: {
+            COUNT: count
+        },
+        TIMESTAMP: timestamp
+    })
 }
 
 pub(crate) type ConfigGraph = graph::DiGraph<NodeConfig, u8>;

--- a/tremor-pipeline/src/op/generic/batch.rs
+++ b/tremor-pipeline/src/op/generic/batch.rs
@@ -93,26 +93,17 @@ impl Operator for Batch {
             data,
             move |this: &mut ValueAndMeta<'static>, other: ValueAndMeta<'static>| -> Result<()> {
                 if let Some(ref mut a) = this.value_mut().as_array_mut() {
-                    let mut e = Object::with_capacity(7);
-                    // {"id":1,
-                    // e.insert_nocheck("id".into(), id.into());
-                    //  "data": {
-                    //      "value": "snot", "meta":{}
-                    //  },
-                    let mut data = Object::with_capacity(2);
                     let (value, meta) = other.into_parts();
-                    data.insert_nocheck("value".into(), value);
-                    data.insert_nocheck("meta".into(), meta);
-                    e.insert_nocheck("data".into(), Value::from(data));
-                    //  "ingest_ns":1,
-                    e.insert_nocheck("ingest_ns".into(), ingest_ns.into());
-                    //  "kind":null,
-                    // kind is always null on events
-                    e.insert_nocheck("kind".into(), Value::null());
-                    //  "is_batch":false
-                    e.insert_nocheck("is_batch".into(), is_batch.into());
-                    // }
-                    a.push(Value::from(e))
+                    let e = literal!({
+                        "data": {
+                            "value": value,
+                            "meta": meta,
+                            "ingest_ns": ingest_ns,
+                            "kind": Value::null(),
+                            "is_batch": is_batch
+                        }
+                    });
+                    a.push(e)
                 };
                 Ok(())
             },

--- a/tremor-pipeline/src/op/generic/batch.rs
+++ b/tremor-pipeline/src/op/generic/batch.rs
@@ -39,7 +39,7 @@ pub struct Batch {
     /// the resulting id will be a new distinct id and will be tracking
     /// all event ids (min and max) in the batched event
     batch_event_id: EventId,
-    has_transactional: bool,
+    is_transactional: bool,
     event_id_gen: EventIdGenerator,
 }
 
@@ -60,7 +60,7 @@ if let Some(map) = &node.config {
         first_ns: 0,
         id: node.id.clone(),
         batch_event_id: idgen.next_id(),
-        has_transactional: false,
+        is_transactional: false,
         event_id_gen: idgen,
     }))
 } else {
@@ -88,7 +88,7 @@ impl Operator for Batch {
             ..
         } = event;
         self.batch_event_id.track(&id);
-        self.has_transactional = self.has_transactional || transactional;
+        self.is_transactional = self.is_transactional || transactional;
         self.data.consume(
             data,
             move |this: &mut ValueAndMeta<'static>, other: ValueAndMeta<'static>| -> Result<()> {
@@ -127,10 +127,10 @@ impl Operator for Batch {
                 data,
                 ingest_ns: self.first_ns,
                 is_batch: true,
-                transactional: self.has_transactional,
+                transactional: self.is_transactional,
                 ..Event::default()
             };
-            self.has_transactional = false;
+            self.is_transactional = false;
             swap(&mut self.batch_event_id, &mut event.id);
             Ok(event.into())
         } else {
@@ -165,10 +165,10 @@ impl Operator for Batch {
                             data,
                             ingest_ns: self.first_ns,
                             is_batch: true,
-                            transactional: self.has_transactional,
+                            transactional: self.is_transactional,
                             ..Event::default()
                         };
-                        self.has_transactional = false;
+                        self.is_transactional = false;
                         swap(&mut self.batch_event_id, &mut event.id);
                         EventAndInsights::from(event)
                     } else {
@@ -201,7 +201,7 @@ mod test {
             len: 0,
             id: "badger".into(),
             batch_event_id: idgen.next_id(),
-            has_transactional: false,
+            is_transactional: false,
             event_id_gen: idgen,
         };
         let event1 = Event {
@@ -340,7 +340,7 @@ mod test {
             len: 0,
             id: "badger".into(),
             batch_event_id: idgen.next_id(),
-            has_transactional: false,
+            is_transactional: false,
             event_id_gen: idgen,
         };
         let event1 = Event {
@@ -416,7 +416,7 @@ mod test {
             len: 0,
             id: "badger".into(),
             batch_event_id: idgen.next_id(),
-            has_transactional: false,
+            is_transactional: false,
             event_id_gen: idgen,
         };
 

--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -542,10 +542,12 @@ fn execute_select_and_having(
         Event {
             id: event_id,
             ingest_ns: event.ingest_ns,
-            // TODO avoid origin_uri clone here
             origin_uri,
+            op_meta: event.op_meta.clone(),
             is_batch: false,
             data: (result.into_static(), event_meta.clone_static()).into(),
+            // FIXME: this needs to be tracked in the select somewhere and not extracted from the last event
+            transactional: event.transactional,
             ..Event::default()
         },
     )))
@@ -625,6 +627,7 @@ fn get_or_create_group<'window>(
 }
 
 impl Operator for TrickleSelect {
+    // FIXME: where to track transactional state for outgoing events?
     #[allow(
         mutable_transmutes,
         clippy::transmute_ptr_to_ptr,

--- a/tremor-script/src/ast/query.rs
+++ b/tremor-script/src/ast/query.rs
@@ -62,6 +62,27 @@ pub enum Stmt<'script> {
 /// array of aggregate functions
 pub type Aggregates<'a> = Vec<InvokeAggrFn<'a>>;
 
+/// Scratch data for efficiently merging window states in a tilt-frame without additional allocations at runtime.
+/// This is basically what needs to be dragged through
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct AggregateScratch<'script> {
+    /// aggregate states
+    pub aggregates: Aggregates<'script>,
+    /// transactional state for the outgoing event from a window
+    pub transactional: bool,
+}
+
+impl<'script> AggregateScratch<'script> {
+    /// constructor
+    #[must_use]
+    pub fn new(aggregates: Aggregates<'script>) -> Self {
+        Self {
+            aggregates,
+            transactional: false,
+        }
+    }
+}
+
 /// A Select statement
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SelectStmt<'script> {
@@ -71,7 +92,7 @@ pub struct SelectStmt<'script> {
     pub aggregates: Aggregates<'script>,
     /// scratches needed when executing multiple windows
     /// only necessary if we have multiple windows, otherwise empty
-    pub aggregate_scratches: Option<(Aggregates<'script>, Aggregates<'script>)>,
+    pub aggregate_scratches: Option<(AggregateScratch<'script>, AggregateScratch<'script>)>,
     /// Constants
     pub consts: Consts<'script>,
     /// Number of locals

--- a/tremor-script/src/ast/query/raw.rs
+++ b/tremor-script/src/ast/query/raw.rs
@@ -15,8 +15,11 @@
 // We want to keep the names here
 #![allow(clippy::module_name_repetitions)]
 
-use super::super::raw::{
-    reduce2, BaseExpr, ExprRaw, IdentRaw, ImutExprRaw, ModuleRaw, ScriptRaw, WithExprsRaw,
+use super::{
+    super::raw::{
+        reduce2, BaseExpr, ExprRaw, IdentRaw, ImutExprRaw, ModuleRaw, ScriptRaw, WithExprsRaw,
+    },
+    AggregateScratch,
 };
 use super::{
     error_generic, error_no_consts, error_no_locals, AggrRegistry, GroupBy, GroupByInt, HashMap,
@@ -150,7 +153,10 @@ impl<'script> Upable<'script> for StmtRaw<'script> {
                 helper.swap(&mut aggregates, &mut locals);
                 // only allocate scratches if they are really needed - when we have multiple windows
                 let aggregate_scratches = if stmt.windows.len() > 1 {
-                    Some((aggregates.clone(), aggregates.clone()))
+                    Some((
+                        AggregateScratch::new(aggregates.clone()),
+                        AggregateScratch::new(aggregates.clone()),
+                    ))
                 } else {
                     None
                 };


### PR DESCRIPTION
# Pull request

## Description

First stab at fixing an error condition that was triggered by a pipeline from kafka onramp via `qos::wal` operator to UDP offramp. The `qos::wal` operator was quickly growing full as the UDP offramp didnt sent `CBAction::fail` insights back when it was failing (failed to send).

We fixed this for all offramps by sending `fail` insights in every case if we had an error in `on_event`. This might lead to double `fail` insights in some edge cases, but 1) should hurt any operator or onramp and 2) is better than swallowing it completely.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


