### PR TITLE
Fix off-by on in qos::wal operator and change config reqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Change `qos::wal` operator to only require one of `max_elements` or `max_bytes` (using both is still possible).
+
 ### Fixes
 
 * Fix CI runners to work with caching
@@ -11,6 +13,7 @@
 * Fix docker entrypoint not forwarding arguments to tremor binary, unless `--` is used before them
 * Fix match default clause only executing the last statement in the block.
 * Kafka back to async with a timeout on waiting
+* Fix `qos::wal` operator never cleaning up the last event from its storage
 
 ## 0.11.0
 

--- a/tremor-pipeline/src/op/qos/wal.rs
+++ b/tremor-pipeline/src/op/qos/wal.rs
@@ -272,7 +272,7 @@ impl Wal {
             event.transactional = true;
             events.push((OUT, event))
         }
-        if events.len() > 0 {
+        if !events.is_empty() {
             // track the last read event
             if let Err(e) = self.state_tree.insert(Self::READ, self.read) {
                 error!("WAL: failed to persist read state: {}", e);

--- a/tremor-pipeline/src/op/qos/wal.rs
+++ b/tremor-pipeline/src/op/qos/wal.rs
@@ -335,6 +335,8 @@ impl Operator for Wal {
                         // This is not for us
                         return;
                     };
+
+                trace!("WAL confirm: {}", event_id);
                 let confirmed = if let Some(confirmed) = self.confirmed.as_mut() {
                     confirmed.set(event_id);
                     confirmed
@@ -354,7 +356,6 @@ impl Operator for Wal {
                     .ok()
                     .and_then(maybe_parse_ivec)
                 {
-                    debug!("WAL confirm: {}", event_id);
                     insight.id.track(&e.id);
                 }
             }
@@ -366,6 +367,7 @@ impl Operator for Wal {
                         // This is not for us
                         return;
                     };
+                trace!("WAL fail: {}", event_id);
                 self.read.set_min(event_id);
 
                 if let Some(e) = self.confirmed.and_then(|confirmed| {
@@ -374,7 +376,6 @@ impl Operator for Wal {
                         .ok()
                         .and_then(maybe_parse_ivec)
                 }) {
-                    debug!("WAL fail: {}", event_id);
                     insight.id.track(&e.id);
                 }
 
@@ -410,8 +411,6 @@ impl Operator for Wal {
     ) -> Result<EventAndInsights> {
         let now = signal.ingest_ns;
         // Are we currently full?
-        trace!("WAL cnt: {}", self.cnt);
-        trace!("WAL bytes: {}", self.wal.size_on_disk()?);
         let now_full = self.limit_reached()?;
         // If we just became full or we went from full to non full
         // update the CB status

--- a/tremor-pipeline/src/op/qos/wal.rs
+++ b/tremor-pipeline/src/op/qos/wal.rs
@@ -340,9 +340,9 @@ impl Operator for Wal {
                     confirmed
                 } else {
                     self.confirmed = Some(Idx::from(event_id));
-                    // ALLOW: we just set it upstairs
                     self.confirmed
                         .as_ref()
+                        // ALLOW: we just set it upstairs
                         .expect("`confirmed` not Some, although just set above, weird!")
                 };
                 if let Err(e) = self.state_tree.insert(Self::READ, confirmed) {
@@ -385,9 +385,9 @@ impl Operator for Wal {
                         event_id, c
                     );
                     self.confirmed = Some(Idx::from(event_id));
-                    // ALLOW we just set `self.confirmed` above
                     if let Err(e) = self.state_tree.insert(
                         Self::READ,
+                        // ALLOW: we just set `self.confirmed` above
                         self.confirmed.expect("we just set this above, weird!?"),
                     ) {
                         error!("Failed to persist confirm state: {}", e);


### PR DESCRIPTION
# Pull request

## Description

* Change `qos::wal` operator to only require one of `max_elements` or `max_bytes` (using both is still possible).
* Fix `qos::wal` operator never cleaning up the last event from its storage

<!-- please add a description of what the goal of this pull request is -->

## Related

* [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/115)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


