### PR TITLE
Add tremor_value `literal` macro

### DIFF
--- a/src/connectors/otel/common.rs
+++ b/src/connectors/otel/common.rs
@@ -15,12 +15,12 @@
 use crate::connectors::pb;
 use crate::errors::Result;
 use halfbrown::HashMap;
-use simd_json::{json, StaticNode};
 use tremor_otelapis::opentelemetry::proto::common::v1::{
     any_value, AnyValue, ArrayValue, InstrumentationLibrary, KeyValue, KeyValueList, StringKeyValue,
 };
+use tremor_value::StaticNode;
 
-use tremor_value::Value;
+use tremor_value::{literal, Value};
 use value_trait::ValueAccess;
 
 pub(crate) fn any_value_to_json<'event>(
@@ -182,11 +182,10 @@ pub(crate) fn maybe_instrumentation_library_to_json<'event>(
     match pb {
         None => Value::Static(StaticNode::Null),
         // TODO This is going to be pretty slow going from Owned -> Value - consider json! for borrowed
-        Some(il) => json!({
+        Some(il) => literal!({
             "name": il.name,
             "version": il.version,
-        })
-        .into(),
+        }),
     }
 }
 
@@ -337,7 +336,7 @@ mod tests {
         };
         let json = any_value_to_json(pb.clone())?;
         let back_again = any_value_to_pb(&json);
-        let expected: Value = json!(["snot"]).into();
+        let expected: Value = literal!(["snot"]);
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
 
@@ -346,7 +345,7 @@ mod tests {
         };
         let json = any_value_to_json(pb.clone())?;
         let back_again = any_value_to_pb(&json);
-        let expected: Value = json!([]).into();
+        let expected: Value = literal!([]);
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
         Ok(())
@@ -367,7 +366,7 @@ mod tests {
         };
         let json = any_value_to_json(pb.clone())?;
         let back_again = any_value_to_pb(&json);
-        let expected: Value = json!({"badger": "snot"}).into();
+        let expected: Value = literal!({"badger": "snot"});
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
 
@@ -378,7 +377,7 @@ mod tests {
         };
         let json = any_value_to_json(pb.clone())?;
         let back_again = any_value_to_pb(&json);
-        let expected: Value = json!({}).into();
+        let expected: Value = literal!({});
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
 
@@ -396,7 +395,7 @@ mod tests {
         }];
         let json = key_value_list_to_json(pb.clone())?;
         let back_again = maybe_key_value_list_to_pb(Some(&json))?;
-        let expected: Value = json!({"snot": "snot"}).into();
+        let expected: Value = literal!({"snot": "snot"});
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
         Ok(())
@@ -410,7 +409,7 @@ mod tests {
         }];
         let json = string_key_value_to_json(pb.clone());
         let back_again = string_key_value_to_pb(Some(&json))?;
-        let expected: Value = json!({"snot": "badger"}).into();
+        let expected: Value = literal!({"snot": "badger"});
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);
         Ok(())
@@ -424,7 +423,7 @@ mod tests {
         };
         let json = maybe_instrumentation_library_to_json(Some(pb.clone()));
         let back_again = maybe_instrumentation_library_to_pb(Some(&json))?;
-        let expected: Value = json!({"name": "name", "version": "v0.1.2"}).into();
+        let expected: Value = literal!({"name": "name", "version": "v0.1.2"});
         assert_eq!(expected, json);
         assert_eq!(Some(pb), back_again);
         Ok(())

--- a/src/connectors/otel/common.rs
+++ b/src/connectors/otel/common.rs
@@ -181,7 +181,6 @@ pub(crate) fn maybe_instrumentation_library_to_json<'event>(
 ) -> Value<'event> {
     match pb {
         None => Value::Static(StaticNode::Null),
-        // TODO This is going to be pretty slow going from Owned -> Value - consider json! for borrowed
         Some(il) => literal!({
             "name": il.name,
             "version": il.version,

--- a/src/connectors/otel/id.rs
+++ b/src/connectors/otel/id.rs
@@ -14,8 +14,8 @@
 
 use crate::errors::Result;
 use rand::Rng;
-use simd_json::StaticNode;
 use tremor_script::Value;
+use tremor_value::StaticNode;
 
 pub(crate) fn random_span_id_bytes(ingest_ns_seed: u64) -> Vec<u8> {
     let mut rng = tremor_common::rand::make_prng(ingest_ns_seed);

--- a/src/connectors/otel/resource.rs
+++ b/src/connectors/otel/resource.rs
@@ -15,21 +15,18 @@
 use super::common;
 use crate::connectors::pb;
 use crate::errors::Result;
-use simd_json::json;
 use tremor_otelapis::opentelemetry::proto::resource::v1::Resource;
+use tremor_value::literal;
 use tremor_value::Value;
 
 pub(crate) fn resource_to_json<'event>(pb: Option<Resource>) -> Result<Value<'event>> {
     if let Some(data) = pb {
-        // TODO This is going to be pretty slow going from Owned -> Value - consider json! for borrowed
-        Ok(json!({
+        Ok(literal!({
             "attributes": common::key_value_list_to_json(data.attributes)?,
             "dropped_attributes_count": data.dropped_attributes_count,
-        })
-        .into())
+        }))
     } else {
-        // TODO This is going to be pretty slow going from Owned -> Value - consider json! for borrowed
-        Ok(json!({ "attributes": {}, "dropped_attributes_count": 0 }).into())
+        Ok(literal!({ "attributes": {}, "dropped_attributes_count": 0 }))
     }
 }
 
@@ -71,11 +68,10 @@ mod tests {
         };
         let json = resource_to_json(Some(pb.clone()))?;
         let back_again = maybe_resource_to_pb(Some(&json))?;
-        let expected: Value = json!({
+        let expected: Value = literal!({
             "attributes": { "snot": "badger" },
             "dropped_attributes_count": 9
-        })
-        .into();
+        });
 
         assert_eq!(expected, json);
         assert_eq!(pb, back_again);

--- a/src/connectors/pb.rs
+++ b/src/connectors/pb.rs
@@ -27,11 +27,13 @@ pub(crate) fn maybe_string_to_pb(data: Option<&Value<'_>>) -> Result<String> {
 }
 
 pub(crate) fn maybe_int_to_pbu64(data: Option<&Value<'_>>) -> Result<u64> {
-    if let Some(data) = data {
-        data.as_u64().ok_or(Error::from("not coercable to u64"))
-    } else {
-        Err("Expected an json u64 to convert to pb u64".into())
-    }
+    data.map_or_else(
+        || Err("Expected an json u64 to convert to pb u64".into()),
+        |data| {
+            data.as_u64()
+                .ok_or_else(|| Error::from("not coercable to u64"))
+        },
+    )
 }
 
 pub(crate) fn maybe_int_to_pbi32(data: Option<&Value<'_>>) -> Result<i32> {

--- a/tremor-value/Cargo.toml
+++ b/tremor-value/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.13"
 beef = "0.5"
 halfbrown = { version = "0.1", features = ["fxhash"] }
 serde = "1.0"
-simd-json = "0.4"
+simd-json = "0.4.3"
 simd-json-derive = "0.2"
 value-trait = { version = "0.2", features = ["custom-types"] }
 

--- a/tremor-value/Cargo.toml
+++ b/tremor-value/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.3.0"
 base64 = "0.13"
 beef = "0.5"
 halfbrown = { version = "0.1", features = ["fxhash"] }
+halfbrown = { version = "0.1", features = [ "fxhash" ] }
 serde = "1.0"
 simd-json = "0.4"
 simd-json-derive = "0.2"

--- a/tremor-value/Cargo.toml
+++ b/tremor-value/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.3.0"
 base64 = "0.13"
 beef = "0.5"
 halfbrown = { version = "0.1", features = ["fxhash"] }
-halfbrown = { version = "0.1", features = [ "fxhash" ] }
 serde = "1.0"
 simd-json = "0.4"
 simd-json-derive = "0.2"

--- a/tremor-value/src/lib.rs
+++ b/tremor-value/src/lib.rs
@@ -35,18 +35,22 @@ extern crate serde as serde_ext;
 
 mod error;
 mod known_key;
+mod macros;
 /// Prelude module
 pub mod prelude;
 mod serde;
-mod value;
+/// The value modules defines a structural module of tremor supported types
+pub mod value;
 pub use error::*;
 pub use known_key::{Error as KnownKeyError, KnownKey};
-pub use simd_json::{json, AlignedBuf, StaticNode};
+pub use simd_json::{json, json_typed, AlignedBuf, StaticNode};
+pub use value::from::*;
 pub use value::{parse_to_value, parse_to_value_with_buffers, to_value, Object, Value};
 
 use simd_json::Node;
 use simd_json_derive::{Deserialize, Serialize, Tape};
 use value_trait::Writable;
+
 impl<'value> Serialize for Value<'value> {
     fn json_write<W>(&self, writer: &mut W) -> std::io::Result<()>
     where

--- a/tremor-value/src/macros.rs
+++ b/tremor-value/src/macros.rs
@@ -92,7 +92,8 @@ macro_rules! value_internal {
 
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
-        let _x = $object.insert(($($key)+).into(), $value);
+        // ALLOW: let _
+        let _ = $object.insert(($($key)+).into(), $value);
         value_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
@@ -103,7 +104,8 @@ macro_rules! value_internal {
 
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
-        let _x = $object.insert(($($key)+).into(), $value);
+        // ALLOW: let _
+        let _ = $object.insert(($($key)+).into(), $value);
     };
 
     // Next value is `null`.

--- a/tremor-value/src/macros.rs
+++ b/tremor-value/src/macros.rs
@@ -1,0 +1,331 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! value_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: value_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        value_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        value_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)* value_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        value_internal!(@array [$($elems,)* value_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        value_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: value_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        value_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        value_internal!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        value_internal!(@object $object [$($key)+] (value_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        value_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        value_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        value_internal!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        value_internal!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        value_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: value_internal!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::value::Value::Static($crate::StaticNode::Null)
+    };
+
+    (true) => {
+        $crate::value::Value::Static($crate::StaticNode::Bool(true))
+    };
+
+    (false) => {
+        $crate::value::Value::Static($crate::StaticNode::Bool(false))
+    };
+
+    ([]) => {
+        $crate::value::Value::Array(value_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::value::Value::Array(value_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        {
+            use value_trait::Builder;
+            $crate::value::Value::object()
+        }
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::value::Value::from({
+            let mut object = $crate::value::Object::new();
+            value_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $other.into()
+    };
+}
+
+// The value_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to $crate::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! value_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! value_unexpected {
+    () => {};
+}
+
+/// Convenience to generate tremor-value from json literals
+///
+/// Note that this literal macro does not support binary syntax literals
+/// at this time.
+///
+/// Adapted from: <https://github.com/serde-rs/json/blob/5b5f95831d9e0d769367b30b76a686339bffd209/src/macros.rs>
+/// Constructs a `tremor_value::Value` from a JSON literal.
+///
+/// Create a value literal of the form:
+///
+/// ```edition2018
+/// # use tremor_value::{literal, Value};
+/// #
+/// let value: Value = literal!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///         "features": [
+///             "serde",
+///             "json"
+///         ]
+///     }
+/// });
+/// ```
+///
+///
+/// Variables or expressions can be interpolated into the literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into an object key must
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `literal!` macro will panic.
+///
+/// ```edition2018
+/// # use tremor_value::literal;
+/// #
+/// let code = 200;
+/// let features = vec!["serde", "json"];
+///
+/// let value = literal!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         features[0]: features[1]
+///     }
+/// });
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```edition2018
+/// # use tremor_value::literal;
+/// #
+/// let value = literal!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+/// ````
+#[macro_export(local_inner_macros)]
+macro_rules! literal {
+    ($($value:tt)+) => {
+        value_internal!($($value)+)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Value;
+
+    #[test]
+    fn value_macro() {
+        let v = literal!({ "snot": "badger"});
+        assert_eq!(literal!({ "snot": "badger"}), v);
+    }
+
+    #[test]
+    fn array() {
+        let v: Value = literal!(vec![1]);
+        assert_eq!(Value::from(vec![1_u64]), v);
+        let v: Value = literal!([1]);
+        assert_eq!(Value::from(vec![1_u64]), v);
+        let v: Value = literal!([]);
+        assert_eq!(Value::Array(vec![]), v);
+    }
+}

--- a/tremor-value/src/macros.rs
+++ b/tremor-value/src/macros.rs
@@ -92,7 +92,7 @@ macro_rules! value_internal {
 
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
-        let _ = $object.insert(($($key)+).into(), $value);
+        let _x = $object.insert(($($key)+).into(), $value);
         value_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
@@ -103,7 +103,7 @@ macro_rules! value_internal {
 
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
-        let _ = $object.insert(($($key)+).into(), $value);
+        let _x = $object.insert(($($key)+).into(), $value);
     };
 
     // Next value is `null`.

--- a/tremor-value/src/prelude.rs
+++ b/tremor-value/src/prelude.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub use super::Value;
+pub use crate::value_internal;
 pub use value_trait::{
     Builder as BuilderTrait, Mutable as MutableTrait, Value as ValueTrait,
     ValueAccess as ValueAccessTrait, Writable as WritableTrait,

--- a/tremor-value/src/serde.rs
+++ b/tremor-value/src/serde.rs
@@ -29,6 +29,7 @@ pub use self::value::*;
 mod test {
     use crate::Value;
     use simd_json::json;
+    use simd_json::json_typed;
 
     #[test]
     fn de_se() {
@@ -37,6 +38,18 @@ mod test {
         assert_eq!(
             v,
             json!({"value": {"array": [1, 1.0, true, ()], "string": "badger"}})
+        );
+        assert_eq!(s, serde_json::to_string(&v).unwrap());
+
+        assert_eq!(
+            v,
+            json_typed!(owned, {"value": {"array": [1, 1.0, true, ()], "string": "badger"}})
+        );
+        assert_eq!(s, serde_json::to_string(&v).unwrap());
+
+        assert_eq!(
+            v,
+            json_typed!(borrowed, {"value": {"array": [1, 1.0, true, ()], "string": "badger"}})
         );
         assert_eq!(s, serde_json::to_string(&v).unwrap());
     }

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 mod cmp;
-mod from;
+/// Conversions from other types to the value type
+pub mod from;
 mod serialize;
 
 use crate::{Error, Result};
@@ -86,6 +87,13 @@ pub enum Value<'value> {
 }
 
 impl<'value> Eq for Value<'value> {}
+
+impl<'value> Value<'value> {
+    /// Creates an empty array value
+    pub fn array() -> Self {
+        Value::Array(vec![])
+    }
+}
 
 #[derive(PartialEq)]
 struct Static(StaticNode);
@@ -613,11 +621,12 @@ mod test {
     use super::*;
     use proptest::proptest;
     use simd_json::json;
+    use simd_json::json_typed;
 
     #[test]
     fn obj_eq() {
-        let o1: Value = json!({"k": 1, "v":2}).into();
-        let o2: Value = json!({"k": 1, "v":2}).into();
+        let o1: Value = json_typed!(borrowed, {"k": 1, "v":2}).into();
+        let o2: Value = json_typed!(borrowed, {"k": 1, "v":2}).into();
         assert_eq!(o1, o2);
         assert_eq!(o2, o1);
         let o1: Value = json!({"k": (), "v":()}).into();

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -90,6 +90,7 @@ impl<'value> Eq for Value<'value> {}
 
 impl<'value> Value<'value> {
     /// Creates an empty array value
+    #[must_use]
     pub fn array() -> Self {
         Value::Array(vec![])
     }

--- a/tremor-value/src/value/from.rs
+++ b/tremor-value/src/value/from.rs
@@ -66,7 +66,7 @@ impl<'value> From<&'value str> for Value<'value> {
     #[inline]
     #[must_use]
     fn from(s: &'value str) -> Self {
-        Value::String(Cow::from(s))
+        Self::String(Cow::from(s))
     }
 }
 
@@ -74,7 +74,7 @@ impl<'value> From<std::borrow::Cow<'value, str>> for Value<'value> {
     #[inline]
     #[must_use]
     fn from(c: std::borrow::Cow<'value, str>) -> Self {
-        Value::String(c.into())
+        Self::String(c.into())
     }
 }
 
@@ -90,7 +90,7 @@ impl<'value> From<String> for Value<'value> {
     #[inline]
     #[must_use]
     fn from(s: String) -> Self {
-        Value::String(s.into())
+        Self::String(s.into())
     }
 }
 
@@ -264,19 +264,27 @@ impl<'value> From<Object<'value>> for Value<'value> {
 #[cfg(test)]
 mod test {
     use crate::Value;
-    use simd_json::{json, BorrowedValue};
+    use simd_json::{json_typed, BorrowedValue, OwnedValue};
 
     #[test]
-    fn borrowed_value() {
-        let j_o = json!({
+    fn value_variations() {
+        // simd-json native variants
+        let j_b: BorrowedValue = json_typed!(borrowed, {
             "string": "something",
             "object": {
                 "array": [1, 1.2]
             }
         });
-        let j_b: BorrowedValue = j_o.clone().into();
-        let v_o = Value::from(j_o);
-        let v_b = Value::from(j_b);
+        let j_o: OwnedValue = json_typed!(owned, {
+            "string": "something",
+            "object": {
+                "array": [1, 1.2]
+            }
+        });
+
+        // tremor variant
+        let v_b: Value = Value::from(j_b);
+        let v_o: Value = Value::from(j_o);
 
         assert_eq!(v_o, v_b);
     }


### PR DESCRIPTION
# Pull request

## Description

Adds a `tremor_value::literal` macro which provides a `json!` like macro but for
the tremor_value variant.

## Related

This feature requires at least v0.4.1 of simd-json

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

The introduction of `tremor_value::literal!` replaces occurances of `simd_json::json!(...).into()` which
first creates an OwnedValue and then transforms these to borrowed values. The new macro avoids the
redundant transient copies ab initio.