### PR TITLE
Allow insights/contraflow events to traverse through multiple connected pipelines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add syslog codec.
 * Add `$udp.host` and `$udp.port` to allow controling udp packet destinations on a per event basis.
 * Deprecate `udp.dst_*` config, introduce `udp.bind.*` config instead.
+* Allow insights/contraflow events to traverse through multiple connected pipelines
 
 ### Fixes
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -89,6 +89,12 @@ impl<T> From<async_channel::SendError<T>> for Error {
     }
 }
 
+impl<T> From<async_channel::TrySendError<T>> for Error {
+    fn from(e: async_channel::TrySendError<T>) -> Self {
+        Self::from(format!("{:?}", e))
+    }
+}
+
 impl From<tremor_script::errors::CompilerError> for Error {
     fn from(e: tremor_script::errors::CompilerError) -> Self {
         e.error().into()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,11 +106,11 @@ impl RampReporter {
         if let Some((metrics_input, metrics_addr)) = &self.metrics_pipeline {
             if let Some(input) = metrics_input.instance_port() {
                 for event in events {
-                    if !metrics_addr.try_send(pipeline::Msg::Event {
+                    if let Err(e) = metrics_addr.try_send(pipeline::Msg::Event {
                         input: input.to_string().into(),
                         event,
                     }) {
-                        error!("Failed to send to system metrics pipeline");
+                        error!("Failed to send to system metrics pipeline: {}", e);
                     }
                 }
             }

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -280,8 +280,7 @@ impl Manager {
                                     send_to_pipelines(&offramp_url, &mut pipelines, e).await;
                                 }
                             }
-                            Msg::Connect { port, mut id, addr } => {
-                                id.trim_to_instance();
+                            Msg::Connect { port, id, addr } => {
                                 if port.eq_ignore_ascii_case(IN.as_ref()) {
                                     // connect incoming pipeline
                                     info!(
@@ -332,8 +331,7 @@ impl Manager {
                                     }
                                 }
                             }
-                            Msg::Disconnect { port, mut id, tx } => {
-                                id.trim_to_instance();
+                            Msg::Disconnect { port, id, tx } => {
                                 info!(
                                     "[Offramp::{}] Disconnecting pipeline {} on port {}",
                                     offramp_url, id, port

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -229,8 +229,7 @@ impl Manager {
         let c_rx = cf_rx.map(OfframpMsg::Reply);
         let mut to_and_from_offramp_rx = PriorityMerge::new(c_rx, m_rx);
 
-        let mut offramp_url = id.clone();
-        offramp_url.trim_to_instance();
+        let offramp_url = id.clone();
         let offramp_addr = msg_tx.clone();
 
         task::spawn::<_, Result<()>>(async move {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,8 +74,8 @@ impl Addr {
         Ok(self.addr.send(msg).await?)
     }
 
-    pub(crate) fn try_send(&self, msg: Msg) -> bool {
-        self.addr.try_send(msg).is_ok()
+    pub(crate) fn try_send(&self, msg: Msg) -> Result<()> {
+        Ok(self.addr.try_send(msg)?)
     }
 
     pub(crate) async fn send_mgmt(&self, msg: MgmtMsg) -> Result<()> {

--- a/src/url.rs
+++ b/src/url.rs
@@ -306,6 +306,15 @@ impl TremorUrl {
     pub fn scope(&self) -> Scope {
         self.scope
     }
+
+    /// returns true if `self` and `other` refer to the same instance, ignoring the port
+    #[must_use]
+    pub fn same_instance_as(&self, other: &Self) -> bool {
+        self.host == other.host
+            && self.resource_type == other.resource_type
+            && self.artefact == other.artefact
+            && self.instance == other.instance
+    }
 }
 
 impl<'de> Deserialize<'de> for TremorUrl {

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/assert.yaml
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/assert.yaml
@@ -1,0 +1,7 @@
+status: 0
+name: cb_pipeline_to_pipeline
+asserts:
+  - source: fg.err.log
+    contains:
+      - |
+        All required CB events received.

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/config.yaml
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/config.yaml
@@ -1,0 +1,25 @@
+onramp:
+  - id: input
+    type: cb
+    codec: json
+    config:
+      source: "in.json"
+      timeout: 1000
+offramp:
+  - id: cb_out
+    type: cb
+binding:
+  - id: p2p
+    links:
+      "/onramp/input/{i}/out":
+        - "/pipeline/main1/{i}/in"
+      "/pipeline/main1/{i}/out":
+        - "/pipeline/main2/{i}/in"
+      "/pipeline/main2/{i}/out":
+        - "/offramp/cb_out/{i}/in"
+mapping:
+  /binding/p2p/01:
+    i: "01"
+
+
+

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/in.json
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/in.json
@@ -1,0 +1,4 @@
+{"cb":"fail"}
+{"cb":"ack"}
+{"cb":"fail"}
+{"cb":"ack"}

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/main1.trickle
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/main1.trickle
@@ -1,0 +1,1 @@
+select event from in into out;

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/main2.trickle
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/main2.trickle
@@ -1,0 +1,1 @@
+select event from in into out;

--- a/tremor-cli/tests/integration/cb_pipeline_to_pipeline/tags.json
+++ b/tremor-cli/tests/integration/cb_pipeline_to_pipeline/tags.json
@@ -1,0 +1,1 @@
+["gd", "cb", "multiple_pipelines"]


### PR DESCRIPTION
# Pull request

## Description

This is still an experimental feature. This fixes the issue of insights/contraflow events not being forwarded across two connected pipelines, this breaks onramps/operators that require ack/fail insights (e.g. kafka onramps with `enable.auto.commit: false`).

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


