### PR TITLE
README update for docker resources on build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,12 +898,12 @@ dependencies = [
 
 [[package]]
 name = "cidr-utils"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b926222810dca24b177606653e09ebf34310c23c60931d630d408486e341335c"
+checksum = "8b2b344c64cf961a8f49c371acef86abf758bc292f645bd61779e1bb1edc9d87"
 dependencies = [
  "debug-helper",
- "num-bigint 0.3.2",
+ "num-bigint 0.4.0",
  "num-traits",
  "once_cell",
  "regex",
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -126,11 +126,7 @@ pub fn lookup(name: &str, config: &Option<OpConfig>) -> Result<Box<dyn Offramp>>
         "tcp" => tcp::Tcp::from_config(config),
         "udp" => udp::Udp::from_config(config),
         "ws" => ws::Ws::from_config(config),
-<<<<<<< HEAD
-=======
-        "otel" => otel::OpenTelemetry::from_config(config),
         "gcs" => gcs::GoogleCloudStorage::from_config(config),
->>>>>>> c749f4ff (Initial draft of Google Cloud Storage connector)
         _ => Err(format!("Offramp {} not known", name).into()),
     }
 }


### PR DESCRIPTION
# Pull request

## Description
Update language re: building with docker to call out errors folks may face if they build with less-than-recommended resources (which I totally didn't do heh)
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

## Checklist

<!--
Please fill out the checklist below.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->
no impact (purely cosmetic change)

