### PR TITLE
Add textual-length-prefix pre and postprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Allow insights/contraflow events to traverse through multiple connected pipelines
 
 * Add GCP Cloud Storage linked sink connector.
+* Add textual-length-prefix pre and postprocessor.
 
 ### Fixes
 

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -899,6 +899,7 @@ components:
         - lz4
         - remove-empty
         - snappy
+        - textual-length-prefix
         - xz
         - zlib
 
@@ -913,5 +914,6 @@ components:
         - lines
         - lz4
         - snappy
+        - textual-length-prefix
         - xz
         - zlib


### PR DESCRIPTION

# Pull request

## Description

add support for the RFC 5425 transport protocol (textual length prefix)


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)


<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


