### PR TITLE
ci: deny warnings in ci only

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -37,27 +37,27 @@ jobs:
       - name: Build test runner
         run: cargo build -p tremor-cli
         env:
-          RUSTFLAGS: "-C target-feature=${{ matrix.target_feature }}"
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
       - name: Run Integration Tests
         run: cargo run -p tremor-cli -- test integration tremor-cli/tests ${{ matrix.exclude_tests }}
         env:
           TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib"
-          RUSTFLAGS: "-C target-feature=${{ matrix.target_feature }}"
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
       - name: Run API Tests
         run: cargo run -p tremor-cli -- test api tremor-cli/tests ${{ matrix.exclude_tests }}
         env:
           TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib"
-          RUSTFLAGS: "-C target-feature=${{ matrix.target_feature }}"
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
       - name: Run Unit Tests
         run: cargo run -p tremor-cli -- test unit tremor-cli/tests ${{ matrix.exclude_tests }}
         env:
           TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib"
-          RUSTFLAGS: "-C target-feature=${{ matrix.target_feature }}"
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
       - name: Run Command Tests
         run: cargo run -p tremor-cli -- test command tremor-cli/tests ${{ matrix.exclude_tests }}
         env:
           TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib"
-          RUSTFLAGS: "-C target-feature=${{ matrix.target_feature }}"
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
       - name: Upload error logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Run tests and validate lockfile
         env:
           PROPTEST_CASES: 2500
+          RUSTFLAGS: -D warnings
         run: cargo test --all --locked
   code-coverage:
     runs-on: ubuntu-latest
@@ -37,7 +38,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         env:
           PROPTEST_CASES: 2500
-          RUSTFLAGS: -C target-feature=+avx,+avx2,+sse4.2
+          RUSTFLAGS: -D warnings -C target-feature=+avx,+avx2,+sse4.2
         with:
           version: "0.16.0"
           args: " --exclude-files target* tremor-cli tremor-api deprecated **/errors.rs --out Lcov --all"

--- a/tremor-common/src/lib.rs
+++ b/tremor-common/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Tremor common utility functions
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 #![deny(

--- a/tremor-influx/src/lib.rs
+++ b/tremor-influx/src/lib.rs
@@ -30,7 +30,6 @@
 //! }
 //! ```
 
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 #![deny(

--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -14,7 +14,6 @@
 
 //! Tremor script scripting language
 
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 #![deny(

--- a/tremor-value/src/lib.rs
+++ b/tremor-value/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![deny(
     clippy::all,


### PR DESCRIPTION
Ref:
https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html

Signed-off-by: Akshat Agarwal <humancalico@disroot.org>

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


