### PR TITLE
Trying to further optimize the record pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `op` key to KV offramp responses in order to differentiate responses by the command that triggered them
 * Add `key` to KV offramp responses.
+* Add `KnownKey::map_*` functions to directly work on the `Value::Object`s inner `HashMap`, if available.
 ### Fixes
 
 * KV offramp sends error responses for each failed command

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -1148,7 +1148,7 @@ where
     'script: 'event,
     'event: 'run,
 {
-    let res = if target.is_object() {
+    let res = if let Some(record) = target.as_object() {
         let mut acc = Value::object_with_capacity(if opts.result_needed {
             rp.fields.len()
         } else {
@@ -1168,19 +1168,19 @@ where
 
             match pp {
                 PredicatePattern::FieldPresent { .. } => {
-                    if let Some(v) = known_key.lookup(target) {
+                    if let Some(v) = known_key.map_lookup(record) {
                         store!(v.clone());
                     } else {
                         return Ok(None);
                     }
                 }
                 PredicatePattern::FieldAbsent { .. } => {
-                    if known_key.lookup(target).is_some() {
+                    if known_key.map_lookup(record).is_some() {
                         return Ok(None);
                     }
                 }
                 PredicatePattern::TildeEq { test, .. } => {
-                    let testee = if let Some(v) = known_key.lookup(target) {
+                    let testee = if let Some(v) = known_key.map_lookup(record) {
                         v
                     } else {
                         return Ok(None);
@@ -1196,7 +1196,7 @@ where
                     }
                 }
                 PredicatePattern::Bin { rhs, kind, .. } => {
-                    let testee = if let Some(v) = known_key.lookup(target) {
+                    let testee = if let Some(v) = known_key.map_lookup(record) {
                         v
                     } else {
                         return Ok(None);
@@ -1211,7 +1211,7 @@ where
                     }
                 }
                 PredicatePattern::RecordPatternEq { pattern, .. } => {
-                    let testee = if let Some(v) = known_key.lookup(target) {
+                    let testee = if let Some(v) = known_key.map_lookup(record) {
                         v
                     } else {
                         return Ok(None);
@@ -1230,7 +1230,7 @@ where
                     }
                 }
                 PredicatePattern::ArrayPatternEq { pattern, .. } => {
-                    let testee = if let Some(v) = known_key.lookup(target) {
+                    let testee = if let Some(v) = known_key.map_lookup(record) {
                         v
                     } else {
                         return Ok(None);

--- a/tremor-value/src/known_key.rs
+++ b/tremor-value/src/known_key.rs
@@ -72,7 +72,7 @@ impl<'key> KnownKey<'key> {
     /// key wasn't present or `target` isn't an object
     ///
     /// ```rust
-    /// use tremor_value::*;
+    /// use tremor_value::prelude::*;
     /// let object = literal!({
     ///   "answer": 42,
     ///   "key": 7
@@ -90,9 +90,35 @@ impl<'key> KnownKey<'key> {
         'key: 'value,
         'value: 'target,
     {
-        target
-            .as_object()
-            .and_then(|m| m.raw_entry().from_key_hashed_nocheck(self.hash, &self.key))
+        target.as_object().and_then(|m| self.map_lookup(m))
+    }
+    /// Looks up this key in a `HashMap<<Cow<'value, str>, Value<'value>>` the inner representation of an object `Value`, returns None if the
+    /// key wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let object = literal!({
+    ///   "answer": 42,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    /// if let Some(inner) = object.as_object() {
+    ///   assert_eq!(known_key.map_lookup(inner).unwrap(), &42);
+    /// }
+    /// ```
+
+    #[inline]
+    #[must_use]
+    pub fn map_lookup<'target, 'value>(
+        &self,
+        map: &'target halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+    ) -> Option<&'target Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        map.raw_entry()
+            .from_key_hashed_nocheck(self.hash, &self.key)
             .map(|kv| kv.1)
     }
 
@@ -100,7 +126,7 @@ impl<'key> KnownKey<'key> {
     /// key wasn't present or `target` isn't an object
     ///
     /// ```rust
-    /// use tremor_value::*;
+    /// use tremor_value::prelude::*;
     /// let mut object = literal!({
     ///   "answer": 23,
     ///   "key": 7
@@ -124,15 +150,46 @@ impl<'key> KnownKey<'key> {
         'key: 'value,
         'value: 'target,
     {
-        target.as_object_mut().and_then(|m| {
-            match m
-                .raw_entry_mut()
-                .from_key_hashed_nocheck(self.hash, &self.key)
-            {
-                RawEntryMut::Occupied(e) => Some(e.into_mut()),
-                RawEntryMut::Vacant(_e) => None,
-            }
-        })
+        target.as_object_mut().and_then(|m| self.map_lookup_mut(m))
+    }
+
+    /// Looks up this key in a `HashMap<Cow<'value, str>, Value<'value>>`, the inner representation of an object value.
+    /// returns None if the key wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// let known_key = KnownKey::from("answer");
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   if let Some(answer) = known_key.map_lookup_mut(inner) {
+    ///     *answer = Value::from(42);
+    ///   }
+    /// }
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// ```
+    #[inline]
+    pub fn map_lookup_mut<'target, 'value>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+    ) -> Option<&'target mut Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        match map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            RawEntryMut::Occupied(e) => Some(e.into_mut()),
+            RawEntryMut::Vacant(_e) => None,
+        }
     }
 
     /// Looks up this key in a `Value`, inserts `with` when the key
@@ -142,7 +199,7 @@ impl<'key> KnownKey<'key> {
     /// - if the value isn't an object
     ///
     /// ```rust
-    /// use tremor_value::*;
+    /// use tremor_value::prelude::*;
     /// let mut object = literal!({
     ///   "answer": 23,
     ///   "key": 7
@@ -177,18 +234,58 @@ impl<'key> KnownKey<'key> {
         'value: 'target,
         F: FnOnce() -> Value<'value>,
     {
-        if !target.is_object() {
-            return Err(Error::NotAnObject(target.value_type()));
+        // we make use of internals here, but this is the fastest way, only requiring one match
+        match target {
+            Value::Object(m) => Ok(self.map_lookup_or_insert_mut(m, with)),
+            other => Err(Error::NotAnObject(other.value_type())),
         }
-        target
-            .as_object_mut()
-            .map(|m| {
-                m.raw_entry_mut()
-                    .from_key_hashed_nocheck(self.hash, &self.key)
-                    .or_insert_with(|| (self.key.clone(), with()))
-                    .1
-            })
-            .ok_or(Error::NotAnObject(ValueType::Null))
+    }
+
+    /// Looks up this key in a `HashMap<Cow<'value, str>, Value<'value>>`, the inner representation of an object `Value`.
+    /// Inserts `with` when the key when wasn't present.
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   let answer = known_key.map_lookup_or_insert_mut(inner, || 17.into());
+    ///   assert_eq!(*answer, 23);
+    ///   *answer = Value::from(42);
+    /// }
+    ///
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// let known_key2 = KnownKey::from("also the answer");
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   let answer = known_key2.map_lookup_or_insert_mut(inner, || 8.into());
+    ///   assert_eq!(*answer, 8);
+    ///   *answer = Value::from(42);
+    /// }
+    ///
+    /// assert_eq!(object["also the answer"], 42);
+    /// ```
+    #[inline]
+    pub fn map_lookup_or_insert_mut<'target, 'value, F>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+        with: F,
+    ) -> &'target mut Value<'value>
+    where
+        'key: 'value,
+        'value: 'target,
+        F: FnOnce() -> Value<'value>,
+    {
+        map.raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+            .or_insert_with(|| (self.key.clone(), with()))
+            .1
     }
 
     /// Inserts a value key into  `Value`, returns None if the
@@ -198,7 +295,7 @@ impl<'key> KnownKey<'key> {
     /// - if `target` isn't an object
     ///
     /// ```rust
-    /// use tremor_value::*;
+    /// use tremor_value::prelude::*;
     /// let mut object = literal!({
     ///   "answer": 23,
     ///   "key": 7
@@ -227,22 +324,60 @@ impl<'key> KnownKey<'key> {
         'key: 'value,
         'value: 'target,
     {
-        if !target.is_object() {
-            return Err(Error::NotAnObject(target.value_type()));
-        }
+        target
+            .as_object_mut()
+            .map(|m| self.map_insert(m, value))
+            .ok_or_else(|| Error::NotAnObject(target.value_type()))
+    }
 
-        Ok(target.as_object_mut().and_then(|m| {
-            match m
-                .raw_entry_mut()
-                .from_key_hashed_nocheck(self.hash, &self.key)
-            {
-                RawEntryMut::Occupied(mut e) => Some(e.insert(value)),
-                RawEntryMut::Vacant(e) => {
-                    e.insert_hashed_nocheck(self.hash, self.key.clone(), value);
-                    None
-                }
+    /// Inserts a value key into `map`, returns None if the
+    /// key wasn't present otherwise Some(`old value`).
+    ///
+    /// ```rust
+    /// use tremor_value::prelude::*;
+    ///
+    /// let mut object = literal!({
+    ///   "answer": 23,
+    ///   "key": 7
+    /// });
+    /// let known_key = KnownKey::from("answer");
+    ///
+    /// assert_eq!(object["answer"], 23);
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   assert!(known_key.map_insert(inner, Value::from(42)).is_some());
+    /// }
+    ///
+    /// assert_eq!(object["answer"], 42);
+    ///
+    /// let known_key2 = KnownKey::from("also the answer");
+    ///
+    /// if let Some(inner) = object.as_object_mut() {
+    ///   assert!(known_key2.map_insert(inner, Value::from(42)).is_none());
+    /// }
+    ///
+    /// assert_eq!(object["also the answer"], 42);
+    /// ```
+    #[inline]
+    pub fn map_insert<'target, 'value>(
+        &self,
+        map: &'target mut halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
+        value: Value<'value>,
+    ) -> Option<Value<'value>>
+    where
+        'key: 'value,
+        'value: 'target,
+    {
+        match map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            RawEntryMut::Occupied(mut e) => Some(e.insert(value)),
+            RawEntryMut::Vacant(e) => {
+                e.insert_hashed_nocheck(self.hash, self.key.clone(), value);
+                None
             }
-        }))
+        }
     }
 }
 

--- a/tremor-value/src/prelude.rs
+++ b/tremor-value/src/prelude.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use super::Value;
+pub use super::{KnownKey, Value};
 pub use crate::literal;
 pub use crate::value_internal;
 pub use value_trait::{


### PR DESCRIPTION
# Pull request

## Description

As we have an hashmap available, i tweaked the `KnownKey` API to be able to work on those maps, so we can spare a match.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


