### PR TITLE
Change KV response format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New features
 
 * Add `op` key to KV offramp responses in order to differentiate responses by the command that triggered them
-* Add `key` to KV offramp responses.
+* Change format of KV offramp responses to a more unified structure.
 * Add `KnownKey::map_*` functions to directly work on the `Value::Object`s inner `HashMap`, if available.
 ### Fixes
 

--- a/src/sink/kv.rs
+++ b/src/sink/kv.rs
@@ -52,8 +52,10 @@ fn decode(mut v: Option<IVec>, codec: &mut dyn Codec, ingest_ns: u64) -> Result<
 
 fn ok(k: Vec<u8>, v: Value<'static>) -> Value<'static> {
     literal!({
-        "key": Value::Bytes(k.into()),
-        "ok": v
+        "ok": {
+            "key": Value::Bytes(k.into()),
+            "value": v
+        }
     })
 }
 
@@ -77,7 +79,6 @@ impl Kv {
             Command::Delete { key } => {
                 decode(self.db.remove(&key)?, codec, ingest_ns).map(|v| ok(key, v))
             }
-
             Command::Cas { key, old, new } => {
                 if let Err(CompareAndSwapError { current, proposed }) = self.db.compare_and_swap(
                     &key,

--- a/tremor-cli/tests/integration/kv-linked/expected.json
+++ b/tremor-cli/tests/integration/kv-linked/expected.json
@@ -1,17 +1,17 @@
-{"event":{"key":"c25vdA==","ok":null},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"}}"}}
-{"event":{"key":"c25vdA==","ok":null},"meta":{"kv":{"op":"put"},"correlation":"{\"put\":{\"key\":\"snot\",\"value\":\"badger\"}}"}}
-{"event":{"key":"c25vdA==","ok":"badger"},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"},\"batch\":true}"}}
-{"event":{"key":"aGVpbno=","ok":null},"meta":{"kv":{"op":"put"},"correlation":"{\"put\":{\"key\":\"heinz\",\"value\":\"ketchup\"},\"batch\":true}"}}
-{"event":{"key":"aGVpbno=","ok":"ketchup"},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"heinz\"}}"}}
+{"event":{"ok":{"key":"c25vdA==","value":null}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"}}"}}
+{"event":{"ok":{"key":"c25vdA==","value":null}},"meta":{"kv":{"op":"put"},"correlation":"{\"put\":{\"key\":\"snot\",\"value\":\"badger\"}}"}}
+{"event":{"ok":{"key":"c25vdA==","value":"badger"}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"},\"batch\":true}"}}
+{"event":{"ok":{"key":"aGVpbno=","value":null}},"meta":{"kv":{"op":"put"},"correlation":"{\"put\":{\"key\":\"heinz\",\"value\":\"ketchup\"},\"batch\":true}"}}
+{"event":{"ok":{"key":"aGVpbno=","value":"ketchup"}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"heinz\"}}"}}
 {"event":{"ok":[{"key":"aGVpbno=","value":"ketchup"},{"key":"c25vdA==","value":"badger"}]},"meta":{"kv":{"op":"scan"},"correlation":"{\"scan\":{}}"}}
 {"event":{"ok":[{"key":"c25vdA==","value":"badger"}]},"meta":{"kv":{"op":"scan"},"correlation":"{\"scan\":{\"start\":\"snot\"}}"}}
 {"event":{"ok":[{"key":"aGVpbno=","value":"ketchup"},{"key":"c25vdA==","value":"badger"}]},"meta":{"kv":{"op":"scan"},"correlation":"{\"scan\":{\"start\":\"heinz\",\"stop\":\"meins\"}}"}}
 {"event":{"ok":[{"key":"aGVpbno=","value":"ketchup"},{"key":"c25vdA==","value":"badger"}]},"meta":{"kv":{"op":"scan"},"correlation":"{\"scan\":{\"stop\":\"heinz\"}}"}}
 {"event":{"key":"aGVpbno=","error":{"current":"ketchup","proposed":"ketchup"}},"meta":{"kv":{"op":"cas"},"correlation":"{\"cas\":{\"key\":\"heinz\",\"old\":\"gies\",\"new\":\"ketchup\"}}"}}
-{"event":{"key":"aGVpbno=","ok":null},"meta":{"kv":{"op":"cas"},"correlation":"{\"cas\":{\"key\":\"heinz\",\"old\":\"ketchup\",\"new\":\"gies\"}}"}}
-{"event":{"key":"bWF0dGhpYXM=","ok":null},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"matthias\",\"reason\":\"jokes way too bad\"}}"}}
-{"event":{"key":"bWF0dGhpYXM=","ok":null},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"matthias\"}}"}}
-{"event":{"key":"aGVpbno=","ok":"gies"},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"heinz\",\"reason\":\"ketchup\"}}"}}
-{"event":{"key":"aGVpbno=","ok":null},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"heinz\"}}"}}
-{"event":{"key":"c25vdA==","ok":"badger"},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"snot\"}}"}}
-{"event":{"key":"c25vdA==","ok":null},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"}}"}}
+{"event":{"ok":{"key":"aGVpbno=","value":null}},"meta":{"kv":{"op":"cas"},"correlation":"{\"cas\":{\"key\":\"heinz\",\"old\":\"ketchup\",\"new\":\"gies\"}}"}}
+{"event":{"ok":{"key":"bWF0dGhpYXM=","value":null}},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"matthias\",\"reason\":\"jokes way too bad\"}}"}}
+{"event":{"ok":{"key":"bWF0dGhpYXM=","value":null}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"matthias\"}}"}}
+{"event":{"ok":{"key":"aGVpbno=","value":"gies"}},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"heinz\",\"reason\":\"ketchup\"}}"}}
+{"event":{"ok":{"key":"aGVpbno=","value":null}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"heinz\"}}"}}
+{"event":{"ok":{"key":"c25vdA==","value":"badger"}},"meta":{"kv":{"op":"delete"},"correlation":"{\"delete\":{\"key\":\"snot\"}}"}}
+{"event":{"ok":{"key":"c25vdA==","value":null}},"meta":{"kv":{"op":"get"},"correlation":"{\"get\":{\"key\":\"snot\"}}"}}


### PR DESCRIPTION
# Pull request

## Description

As requested in https://github.com/tremor-rs/tremor-www-docs/pull/130

They will follow the form of:

```json
{
  "ok": {
    "key": "<binary>",
    "value": "<decoded>"
  }
}
```

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/130)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


