### PR TITLE
Redesign system_metrics test to be less dependent on timings.

### DIFF
--- a/tremor-cli/tests/integration/system_metrics/assert.yaml
+++ b/tremor-cli/tests/integration/system_metrics/assert.yaml
@@ -8,4 +8,16 @@ asserts:
   - source: metrics_offramp.log
     equals_file: "expected_metrics_offramp.json"
   - source: events.log
-    equals_file: "expected_events.json"
+    contains:
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":0}
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":1}
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":2}
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":3}
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":4}
+      - |
+        {"onramp":"metronome","ingest_ns":null,"id":5}

--- a/tremor-cli/tests/integration/system_metrics/config.yaml
+++ b/tremor-cli/tests/integration/system_metrics/config.yaml
@@ -45,7 +45,8 @@ binding:
       "/pipeline/metrics/{instance}/out": ["/offramp/system::stdout/system/in"]
       "/pipeline/metrics/{instance}/err": ["/offramp/system::stderr/system/in"]
 
-      "/pipeline/main/{instance}/done": ["/offramp/exit/{instance}/in"]
+      # exit when we have all events
+      "/pipeline/metrics/{instance}/done": ["/offramp/exit/{instance}/in"]
 
 mapping:
   /binding/test/1:

--- a/tremor-cli/tests/integration/system_metrics/expected_events.json
+++ b/tremor-cli/tests/integration/system_metrics/expected_events.json
@@ -1,6 +1,0 @@
-{"onramp":"metronome","ingest_ns":null,"id":0}
-{"onramp":"metronome","ingest_ns":null,"id":1}
-{"onramp":"metronome","ingest_ns":null,"id":2}
-{"onramp":"metronome","ingest_ns":null,"id":3}
-{"onramp":"metronome","ingest_ns":null,"id":4}
-{"onramp":"metronome","ingest_ns":null,"id":5}

--- a/tremor-cli/tests/integration/system_metrics/main.trickle
+++ b/tremor-cli/tests/integration/system_metrics/main.trickle
@@ -1,19 +1,12 @@
 #!config metrics_interval_s = 3
-
 define script process
 script
-  let event.ingest_ns = null; # for testing
-  match event.id of
-    # 7th event from metronome
-    case 6 => emit {"exit": 0, "delay": 100} => "done"
-    default => event
-  end
+  let event.ingest_ns = null;
+  event
 end;
 
 create script process;
 
 select event from in into process;
-select event from process into out;
+select event from process/out into out;
 select event from process/err into err;
-
-select event from process/done into out/done;

--- a/tremor-cli/tests/integration/system_metrics/metrics.trickle
+++ b/tremor-cli/tests/integration/system_metrics/metrics.trickle
@@ -2,6 +2,20 @@ define script process
 script
   let event.timestamp = null; # for testing
 
+  let state = match state of
+    # exit when we have all metrics events
+    case %{ present onramp, present pipeline, present offramp } when state.onramp >= 9 and state.pipeline >= 4 and state.offramp >= 6 => emit {"exit": 0, "delay": 100} => "done"
+    # state is valid
+    case %{} => state
+    # initialize state
+    default => {
+      "out": 0,
+      "onramp": 0,
+      "pipeline": 0,
+      "offramp": 0
+    }
+  end;
+
   let port = match event.measurement of
     case "events" => "pipeline"
     case "ramp_events" =>
@@ -12,6 +26,8 @@ script
       end
     default => "out"
   end;
+  # count events per port
+  let state[port] = state[port] + 1;
 
   emit event => "#{port}";
 end;
@@ -23,5 +39,6 @@ select event from in into process;
 select event from process/pipeline into out/pipeline;
 select event from process/onramp into out/onramp;
 select event from process/offramp into out/offramp;
+select event from process/done into out/done;
 
 select event from process/err into err;


### PR DESCRIPTION
# Pull request

## Description

The system_metrics integration test failed pretty often due to timing issues. Those should be fixed with this PR.

The test has been redesigned to depend less on timings.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


