### PR TITLE
Log assigned partitions on startup and rebalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Fix false positives in cycle detection
 - Include `cncf::otel` stdlib sources in deb package
 - Add `/usr/local/share/tremor` to default `TREMOR_PATH` also for all packages as a well-known directory for custom tremor-script libraries and modules.
-- Fix to record the partition number assigned during rebalancing when running Kafka.
+- Record the partition number assigned during rebalancing when running Kafka.
 
 ## 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@
 - Run tests in tremor-cli bin
 - Switch operations of `tremor dbg lex` and `tremor dbg preprocess` as they did the job of the other.
 - Fix heredoc preprocessing, which was messing up error reporting
+<<<<<<< HEAD
 - Fix false positives in cycle detection
 - Include `cncf::otel` stdlib sources in deb package
 - Add `/usr/local/share/tremor` to default `TREMOR_PATH` also for all packages as a well-known directory for custom tremor-script libraries and modules.
+=======
+- Fix to record the partition number assigned during rebalancing when running Kafka.
+>>>>>>> 49c9121a (add an entry to changelog)
 
 ## 0.11.1
 
@@ -50,6 +54,7 @@
 - Fix windowed select queries not tracking the Events that constitute an outgoing aggregated event
 - Avoid several offramps to swallow fail insights.
 - Send correlation metadata for send error events in elastic sink
+- Record the partition number assigned during rebalancing when running Kafka.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,10 @@
 - Run tests in tremor-cli bin
 - Switch operations of `tremor dbg lex` and `tremor dbg preprocess` as they did the job of the other.
 - Fix heredoc preprocessing, which was messing up error reporting
-<<<<<<< HEAD
 - Fix false positives in cycle detection
 - Include `cncf::otel` stdlib sources in deb package
 - Add `/usr/local/share/tremor` to default `TREMOR_PATH` also for all packages as a well-known directory for custom tremor-script libraries and modules.
-=======
 - Fix to record the partition number assigned during rebalancing when running Kafka.
->>>>>>> 49c9121a (add an entry to changelog)
 
 ## 0.11.1
 
@@ -54,6 +51,7 @@
 - Fix windowed select queries not tracking the Events that constitute an outgoing aggregated event
 - Avoid several offramps to swallow fail insights.
 - Send correlation metadata for send error events in elastic sink
+- Record the partition number assigned during rebalancing when running Kafka.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@
 - Fix windowed select queries not tracking the Events that constitute an outgoing aggregated event
 - Avoid several offramps to swallow fail insights.
 - Send correlation metadata for send error events in elastic sink
-- Record the partition number assigned during rebalancing when running Kafka.
 
 ## 0.11.0
 

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -286,28 +286,31 @@ impl ConsumerContext for LoggingConsumerContext {
         match rebalance {
             Rebalance::Assign(tpl) => {
                 let offset_strings: Vec<String> = tpl
-                        .elements()
-                        .iter()
-                        .map(|elem| {
-                            format!(
-                                "[Topic: {}, Partition: {}, Offset: {:?}]",
-                                elem.topic(),
-                                elem.partition(),
-                                elem.offset()
-                            )
-                        })
-                        .collect();
-                    info!(
-                        "[Source::{}] Offsets: {}",
-                        self.onramp_id,
-                        offset_strings.join(" ")
-                    );
+                    .elements()
+                    .iter()
+                    .map(|elem| {
+                        format!(
+                            "[Topic: {}, Partition: {}, Offset: {:?}]",
+                            elem.topic(),
+                            elem.partition(),
+                            elem.offset()
+                        )
+                    })
+                    .collect();
+                info!(
+                    "[Source::{}] Offsets: {}",
+                    self.onramp_id,
+                    offset_strings.join(" ")
+                );
             }
             Rebalance::Revoke => {
                 info!("[Source::{}] ALL partitions are REVOKED", self.onramp_id)
             }
             Rebalance::Error(err_info) => {
-                warn!("[Source::{}] Post Rebalance error {}", self.onramp_id, err_info)
+                warn!(
+                    "[Source::{}] Post Rebalance error {}",
+                    self.onramp_id, err_info
+                )
             }
         }
     }

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -26,7 +26,7 @@ use rdkafka::{
     config::ClientConfig,
     consumer::{
         stream_consumer::{self, StreamConsumer},
-        CommitMode, Consumer, ConsumerContext,
+        CommitMode, Consumer, ConsumerContext, Rebalance,
     },
     error::{KafkaError, KafkaResult},
     message::{BorrowedMessage, Headers},
@@ -282,6 +282,14 @@ pub struct LoggingConsumerContext {
 impl ClientContext for LoggingConsumerContext {}
 
 impl ConsumerContext for LoggingConsumerContext {
+    fn pre_rebalance(&self, rebalance: &Rebalance) {
+        println!("Pre rebalance {:?}", rebalance);
+    }
+
+    fn post_rebalance(&self, rebalance: &Rebalance) {
+        println!("Post rebalance {:?}", rebalance);
+    }
+        
     fn commit_callback(&self, result: KafkaResult<()>, offsets: &rdkafka::TopicPartitionList) {
         match result {
             Ok(_) => {

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -283,33 +283,31 @@ impl ClientContext for LoggingConsumerContext {}
 
 impl ConsumerContext for LoggingConsumerContext {
     fn post_rebalance(&self, rebalance: &Rebalance) {
-        if log_enabled!(Debug) {
-            match rebalance {
-                Rebalance::Assign(tpl) => {
-                    let offset_strings: Vec<String> = tpl
-                            .elements()
-                            .iter()
-                            .map(|elem| {
-                                format!(
-                                    "[Topic: {}, Partition: {}, Offset: {:?}]",
-                                    elem.topic(),
-                                    elem.partition(),
-                                    elem.offset()
-                                )
-                            })
-                            .collect();
-                        debug!(
-                            "[Source::{}] Offsets: {}",
-                            self.onramp_id,
-                            offset_strings.join(" ")
-                        );
-                }
-                Rebalance::Revoke => {
-                    println!("ALL partitions are REVOKED")
-                }
-                Rebalance::Error(err_info) => {
-                    println!("Post Rebalance error {}", err_info)
-                }
+        match rebalance {
+            Rebalance::Assign(tpl) => {
+                let offset_strings: Vec<String> = tpl
+                        .elements()
+                        .iter()
+                        .map(|elem| {
+                            format!(
+                                "[Topic: {}, Partition: {}, Offset: {:?}]",
+                                elem.topic(),
+                                elem.partition(),
+                                elem.offset()
+                            )
+                        })
+                        .collect();
+                    info!(
+                        "[Source::{}] Offsets: {}",
+                        self.onramp_id,
+                        offset_strings.join(" ")
+                    );
+            }
+            Rebalance::Revoke => {
+                info!("ALL partitions are REVOKED")
+            }
+            Rebalance::Error(err_info) => {
+                warn!("Post Rebalance error {}", err_info)
             }
         }
     }

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -304,10 +304,10 @@ impl ConsumerContext for LoggingConsumerContext {
                     );
             }
             Rebalance::Revoke => {
-                info!("ALL partitions are REVOKED")
+                info!("[Source::{}] ALL partitions are REVOKED", self.onramp_id)
             }
             Rebalance::Error(err_info) => {
-                warn!("Post Rebalance error {}", err_info)
+                warn!("[Source::{}] Post Rebalance error {}", self.onramp_id, err_info)
             }
         }
     }


### PR DESCRIPTION
## Description
* Implement post_rebalance function
* Output partition log on info level

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->
* Issues: fixes #846
* post_rebalance
    *  [Document](https://docs.rs/rdkafka/0.9.1/rdkafka/consumer/trait.ConsumerContext.html)
    * [Implement ref](https://dzone.com/articles/getting-started-with-kafka-and-rust-part-2)
* [rdkafka](https://github.com/fede1024/rust-rdkafka/)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


