### PR TITLE
Adding code for pubsub connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,18 @@
 ## 0.11.1
 
 ### New features
-* Add `tremor_value::structurize` convenience fn
-* Change `qos::wal` operator to only require one of `max_elements` or `max_bytes` (using both is still possible).
-* Add DNS sink
-* Add syslog codec.
-* Add `$udp.host` and `$udp.port` to allow controling udp packet destinations on a per event basis.
-* Deprecate `udp.dst_*` config, introduce `udp.bind.*` config instead.
-* Allow insights/contraflow events to traverse through multiple connected pipelines
-* Add branch/hash version output to versions of tremor not built on `main` branch
+
+- Add `tremor_value::structurize` convenience fn
+- Change `qos::wal` operator to only require one of `max_elements` or `max_bytes` (using both is still possible).
+- Add DNS sink
+- Add syslog codec.
+- Add `$udp.host` and `$udp.port` to allow controling udp packet destinations on a per event basis.
+- Deprecate `udp.dst_*` config, introduce `udp.bind.*` config instead.
+- Allow insights/contraflow events to traverse through multiple connected pipelines
+
+- Add GCP Cloud Storage linked sink connector.
+- Add textual-length-prefix pre and postprocessor.
+- Add GCP Pubsub sink and source connector.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "googapis"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9512782490ab8a5c752851ba49214f9e4d46c78f14a708098d8352cece35b235"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "gouth"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4023,16 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.9",
  "syn 1.0.64",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.0.1",
+ "prost",
 ]
 
 [[package]]
@@ -6351,6 +6372,7 @@ dependencies = [
  "error-chain 0.12.4",
  "futures 0.3.15",
  "glob",
+ "googapis",
  "gouth",
  "grok",
  "halfbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,8 @@ tremor-otelapis = "0.1"
 gouth = {version = "0.2"}
 http = "0.2.4"
 reqwest = "0.11.3"
+googapis = { version = "0.4.2", default-features = false, features = ["google-pubsub-v1"] }
+
 
 [dependencies.tungstenite]
 default-features = false

--- a/src/connectors/gcp.rs
+++ b/src/connectors/gcp.rs
@@ -13,4 +13,6 @@
 // limitations under the License.
 
 pub(crate) mod auth;
+pub(crate) mod pubsub;
+pub(crate) mod pubsub_auth;
 pub(crate) mod storage;

--- a/src/connectors/gcp/pubsub.rs
+++ b/src/connectors/gcp/pubsub.rs
@@ -1,0 +1,85 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::Result;
+use googapis::google::pubsub::v1::{
+    publisher_client::PublisherClient, subscriber_client::SubscriberClient,
+};
+use googapis::google::pubsub::v1::{
+    AcknowledgeRequest, PublishRequest, PubsubMessage, PullRequest, PullResponse,
+};
+use std::collections::HashMap;
+use tonic::transport::Channel;
+
+pub(crate) async fn send_message(
+    client: &mut PublisherClient<Channel>,
+    project_id: &str,
+    topic_name: &str,
+    data_val: &[u8],
+) -> Result<String> {
+    let message = PubsubMessage {
+        data: data_val.to_vec(),
+        attributes: HashMap::new(),
+        message_id: "".into(),
+        publish_time: None,
+        ordering_key: "".to_string(),
+    };
+
+    let response = client
+        .publish(PublishRequest {
+            topic: format!("projects/{}/topics/{}", project_id, topic_name),
+            messages: vec![message],
+        })
+        .await?;
+    let res = &response.into_inner().message_ids[0];
+    Ok(res.to_string())
+}
+
+pub(crate) async fn receive_message(
+    client: &mut SubscriberClient<Channel>,
+    project_id: &str,
+    subscription_name: &str,
+) -> Result<PullResponse> {
+    // TODO: Use streaming pull
+    #[allow(warnings)]
+    let response = client
+        .pull(PullRequest {
+            subscription: format!(
+                "projects/{}/subscriptions/{}",
+                project_id, subscription_name
+            ),
+            max_messages: 50,
+            return_immediately: false,
+        })
+        .await?;
+    Ok(response.into_inner())
+}
+
+pub(crate) async fn acknowledge(
+    client: &mut SubscriberClient<Channel>,
+    project_id: &str,
+    subscription_name: &str,
+    ack_ids: Vec<String>,
+) -> Result<()> {
+    let _response = client
+        .acknowledge(AcknowledgeRequest {
+            subscription: format!(
+                "projects/{}/subscriptions/{}",
+                project_id, subscription_name
+            ),
+            ack_ids,
+        })
+        .await?;
+    Ok(())
+}

--- a/src/connectors/gcp/pubsub_auth.rs
+++ b/src/connectors/gcp/pubsub_auth.rs
@@ -1,0 +1,75 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::Result;
+/// Using `GOOGLE_APPLICATION_CREDENTIALS="<path to service token json file>"` this function
+/// will authenticate against the google cloud platform using the authentication flow defined
+/// in the file. The provided PEM file should be a current non-revoked and complete copy of the
+/// required certificate chain for the Google Cloud Platform.
+use googapis::google::pubsub::v1::{
+    publisher_client::PublisherClient, subscriber_client::SubscriberClient,
+};
+use googapis::CERTIFICATES;
+use gouth::Token;
+use tonic::{
+    metadata::MetadataValue,
+    transport::{Certificate, Channel, ClientTlsConfig},
+    Request,
+};
+
+pub(crate) async fn setup_publisher_client() -> Result<PublisherClient<Channel>> {
+    let token = Token::new()?;
+    let tls_config = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(CERTIFICATES))
+        .domain_name("pubsub.googleapis.com");
+
+    let channel = Channel::from_static(r#"https://pubsub.googleapis.com/pubsub/v1"#)
+        .tls_config(tls_config)?
+        .connect()
+        .await?;
+
+    let service = PublisherClient::with_interceptor(channel, move |mut req: Request<()>| {
+        let token = &*token
+            .header_value()
+            .expect("Error with token header value in `pubsub_auth`");
+        let meta = MetadataValue::from_str(token)
+            .expect("Error extracting metadata value from token in `pubsub_auth`");
+        req.metadata_mut().insert("authorization", meta);
+        Ok(req)
+    });
+    Ok(service)
+}
+
+pub(crate) async fn setup_subscriber_client() -> Result<SubscriberClient<Channel>> {
+    let token = Token::new()?;
+    let tls_config = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(CERTIFICATES))
+        .domain_name("pubsub.googleapis.com");
+
+    let channel = Channel::from_static(r#"https://pubsub.googleapis.com/pubsub/v1"#)
+        .tls_config(tls_config)?
+        .connect()
+        .await?;
+
+    let service = SubscriberClient::with_interceptor(channel, move |mut req: Request<()>| {
+        let token = &*token
+            .header_value()
+            .expect("Error with token header value in `pubsub_auth`");
+        let meta = MetadataValue::from_str(token)
+            .expect("Error extracting metadata value from token in `pubsub_auth`");
+        req.metadata_mut().insert("authorization", meta);
+        Ok(req)
+    });
+    Ok(service)
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -165,6 +165,7 @@ error_chain! {
         HttpHeaderError(http::header::InvalidHeaderValue);
         TonicTransportError(tonic::transport::Error);
         TonicStatusError(tonic::Status);
+
     }
 
     errors {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -163,6 +163,8 @@ error_chain! {
         GoogleAuthError(gouth::Error);
         ReqwestError(reqwest::Error);
         HttpHeaderError(http::header::InvalidHeaderValue);
+        TonicTransportError(tonic::transport::Error);
+        TonicStatusError(tonic::Status);
     }
 
     errors {

--- a/src/offramp.rs
+++ b/src/offramp.rs
@@ -19,8 +19,8 @@ use crate::permge::PriorityMerge;
 use crate::pipeline;
 use crate::registry::ServantId;
 use crate::sink::{
-    self, blackhole, cb, debug, dns, elastic, exit, file, gcs, handle_response, kafka, kv, nats,
-    newrelic, otel, postgres, rest, stderr, stdout, tcp, udp, ws,
+    self, blackhole, cb, debug, dns, elastic, exit, file, gcs, gpub, handle_response, kafka, kv,
+    nats, newrelic, otel, postgres, rest, stderr, stdout, tcp, udp, ws,
 };
 use crate::source::Processors;
 use crate::url::ports::{IN, METRICS};
@@ -128,6 +128,7 @@ pub fn lookup(name: &str, config: &Option<OpConfig>) -> Result<Box<dyn Offramp>>
         "udp" => udp::Udp::from_config(config),
         "ws" => ws::Ws::from_config(config),
         "gcs" => gcs::GoogleCloudStorage::from_config(config),
+        "gpub" => gpub::GoogleCloudPubSub::from_config(config),
         _ => Err(format!("Offramp {} not known", name).into()),
     }
 }

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -17,8 +17,8 @@ use crate::pipeline;
 use crate::repository::ServantId;
 use crate::source::prelude::*;
 use crate::source::{
-    blaster, cb, crononome, discord, file, kafka, metronome, nats, otel, postgres, rest, stdin,
-    tcp, udp, ws,
+    blaster, cb, crononome, discord, file, gsub, kafka, metronome, nats, otel, postgres, rest,
+    stdin, tcp, udp, ws,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};
@@ -85,6 +85,7 @@ pub(crate) fn lookup(
         "discord" => discord::Discord::from_config(id, config),
         "otel" => otel::OpenTelemetry::from_config(id, config),
         "nats" => nats::Nats::from_config(id, config),
+        "gsub" => gsub::GoogleCloudPubSub::from_config(id, config),
         _ => Err(format!("[onramp:{}] Onramp type {} not known", id, name).into()),
     }
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -27,6 +27,7 @@ pub(crate) mod elastic;
 pub(crate) mod exit;
 pub(crate) mod file;
 pub(crate) mod gcs;
+pub(crate) mod gpub;
 pub(crate) mod kafka;
 pub(crate) mod kv;
 pub(crate) mod nats;

--- a/src/sink/gpub.rs
+++ b/src/sink/gpub.rs
@@ -1,0 +1,264 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # File Offramp
+//!
+//! Writes events to a file, one event per line
+//!
+//! ## Configuration
+//!
+//! See [Config](struct.Config.html) for details.
+
+#![cfg(not(tarpaulin_include))]
+
+use crate::connectors::gcp::{pubsub, pubsub_auth};
+use crate::connectors::qos::{self, QoSFacilities, SinkQoS};
+use crate::sink::prelude::*;
+use futures::executor::block_on;
+use googapis::google::pubsub::v1::publisher_client::PublisherClient;
+use halfbrown::HashMap;
+use tonic::transport::Channel;
+use tremor_pipeline::{EventIdGenerator, OpMeta};
+use tremor_value::Value;
+
+pub struct GoogleCloudPubSub {
+    #[allow(dead_code)]
+    config: Config,
+    remote: Option<PublisherClient<Channel>>,
+    is_down: bool,
+    qos_facility: Box<dyn SinkQoS>,
+    reply_channel: Option<Sender<sink::Reply>>,
+    is_linked: bool,
+    postprocessors: Postprocessors,
+    codec: Box<dyn Codec>,
+    event_id_gen: EventIdGenerator,
+}
+
+#[derive(Deserialize)]
+pub struct Config {}
+
+enum PubSubCommand {
+    SendMessage(String, String, Value<'static>),
+    Unknown,
+}
+
+impl std::fmt::Display for PubSubCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                PubSubCommand::SendMessage(_, _, _) => "send_message",
+                PubSubCommand::Unknown => "Unknown",
+            }
+        )
+    }
+}
+
+impl ConfigImpl for Config {}
+
+impl offramp::Impl for GoogleCloudPubSub {
+    fn from_config(config: &Option<OpConfig>) -> Result<Box<dyn Offramp>> {
+        if let Some(config) = config {
+            let config: Config = Config::new(config)?;
+            let remote = Some(block_on(pubsub_auth::setup_publisher_client())?);
+            let hostport = "pubsub.googleapis.com:443";
+            Ok(SinkManager::new_box(Self {
+                config,
+                remote,
+                is_down: false,
+                qos_facility: Box::new(QoSFacilities::recoverable(hostport.to_string())),
+                reply_channel: None,
+                is_linked: false,
+                postprocessors: vec![],
+                codec: Box::new(crate::codec::null::Null {}),
+                event_id_gen: EventIdGenerator::new(0), // Fake ID overwritten in init
+            }))
+        } else {
+            Err("Offramp Google Cloud Pubsub (pub) requires a config".into())
+        }
+    }
+}
+
+macro_rules! parse_arg {
+    ($field_name: expr, $o: expr) => {
+        if let Some(Value::String(snot)) = $o.get($field_name) {
+            snot.to_string()
+        } else {
+            return Err(format!("Invalid Command, expected `{}` field", $field_name).into());
+        }
+    };
+}
+
+fn parse_command(value: &Value) -> Result<PubSubCommand> {
+    if let Value::Object(o) = value {
+        let cmd_name: &str = &parse_arg!("command", o);
+        let command = match cmd_name {
+            "send_message" => PubSubCommand::SendMessage(
+                parse_arg!("project", o),
+                parse_arg!("topic", o),
+                if let Some(data) = o.get("data") {
+                    data.clone().into_static()
+                } else {
+                    return Err("Invalid Command, expected `data` field".into());
+                },
+            ),
+            _ => PubSubCommand::Unknown,
+        };
+        return Ok(command);
+    }
+
+    Err("Invalid Command".into())
+}
+
+#[async_trait::async_trait]
+impl Sink for GoogleCloudPubSub {
+    async fn terminate(&mut self) {}
+
+    #[allow(clippy::too_many_lines)]
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        codec: &mut dyn Codec,
+        _codec_map: &HashMap<String, Box<dyn Codec>>,
+        mut event: Event,
+    ) -> ResultVec {
+        if self.remote.is_none() {
+            self.remote = Some(pubsub_auth::setup_publisher_client().await?);
+            // TODO - Qos checks
+        };
+        if let Some(remote) = &mut self.remote {
+            let maybe_correlation = event.correlation_meta();
+            let mut response = Vec::new();
+            for value in event.value_iter() {
+                let command = parse_command(value)?;
+                match command {
+                    PubSubCommand::SendMessage(project_id, topic_name, data) => {
+                        let mut msg: Vec<u8> = vec![];
+                        let encoded = codec.encode(&data)?;
+                        let mut processed =
+                            postprocess(&mut self.postprocessors, event.ingest_ns, encoded)?;
+                        for processed_elem in &mut processed {
+                            msg.append(processed_elem);
+                        }
+                        response.push(make_command_response(
+                            "send_message",
+                            &pubsub::send_message(remote, &project_id, &topic_name, &msg).await?,
+                        ));
+                    }
+
+                    PubSubCommand::Unknown => {
+                        warn!(
+                            "Unknown Google Cloud PubSub command: `{}` attempted",
+                            command.to_string()
+                        );
+                        return Err(format!(
+                            "Unknown Google Cloud PubSub command: `{}` attempted",
+                            command.to_string()
+                        )
+                        .into());
+                    }
+                };
+            }
+
+            if self.is_linked {
+                if let Some(reply_channel) = &self.reply_channel {
+                    let mut meta = Object::with_capacity(1);
+                    if let Some(correlation) = maybe_correlation {
+                        meta.insert_nocheck("correlation".into(), correlation);
+                    }
+
+                    reply_channel
+                        .send(sink::Reply::Response(
+                            OUT,
+                            Event {
+                                id: self.event_id_gen.next_id(),
+                                data: (response, meta).into(),
+                                ingest_ns: nanotime(),
+                                origin_uri: Some(EventOriginUri {
+                                    uid: 0,
+                                    scheme: "gRPC".into(),
+                                    host: "".into(),
+                                    port: None,
+                                    path: vec![],
+                                }),
+                                kind: None,
+                                is_batch: false,
+                                cb: CbAction::None,
+                                op_meta: OpMeta::default(),
+                                transactional: false,
+                            },
+                        ))
+                        .await?;
+                }
+            }
+        }
+
+        self.is_down = false;
+        return Ok(Some(vec![qos::ack(&mut event)]));
+    }
+
+    fn default_codec(&self) -> &str {
+        "json"
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn init(
+        &mut self,
+        sink_uid: u64,
+        _sink_url: &TremorUrl,
+        codec: &dyn Codec,
+        _codec_map: &HashMap<String, Box<dyn Codec>>,
+        processors: Processors<'_>,
+        is_linked: bool,
+        reply_channel: Sender<sink::Reply>,
+    ) -> Result<()> {
+        self.event_id_gen = EventIdGenerator::new(sink_uid);
+        self.postprocessors = make_postprocessors(processors.post)?;
+        self.reply_channel = Some(reply_channel);
+        self.codec = codec.boxed_clone();
+        self.is_linked = is_linked;
+        Ok(())
+    }
+
+    async fn on_signal(&mut self, signal: Event) -> ResultVec {
+        if self.is_down && self.qos_facility.probe(signal.ingest_ns) {
+            self.is_down = false;
+            // This means the port is connectable
+            info!("Google Cloud PubSub -  sink remote endpoint - recovered and contactable");
+            self.is_down = false;
+            // Clone needed to make it mutable, lint is wrong
+            #[allow(clippy::redundant_clone)]
+            let mut signal = signal.clone();
+            return Ok(Some(vec![qos::open(&mut signal)]));
+        }
+
+        Ok(None)
+    }
+
+    fn is_active(&self) -> bool {
+        true
+    }
+    fn auto_ack(&self) -> bool {
+        false
+    }
+}
+
+fn make_command_response(cmd: &str, message_id: &str) -> Value<'static> {
+    literal!({
+        "command": cmd,
+        "message-id": message_id
+    })
+    .into_static()
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -784,5 +784,21 @@ mod tests {
 
         assert_eq!(error_result.suffix().value(), &Value::from(expec_data));
         assert_eq!(error_result.suffix().meta(), &Value::from(expec_meta));
+
+        // testing with a second set of inputs
+        let source_id = "tremor-source-testing".to_string();
+        let e = Error::from("error oh no!!!");
+        let original_id = 7;
+        let error_result = super::make_error(source_id.clone(), &e, original_id);
+        let mut expec_meta = Object::with_capacity(1);
+        expec_meta.insert_nocheck("error".into(), e.to_string().into());
+
+        let mut expec_data = Object::with_capacity(3);
+        expec_data.insert_nocheck("error".into(), e.to_string().into());
+        expec_data.insert_nocheck("event_id".into(), original_id.into());
+        expec_data.insert_nocheck("source_id".into(), source_id.into());
+
+        assert_eq!(error_result.suffix().value(), &Value::from(expec_data));
+        assert_eq!(error_result.suffix().meta(), &Value::from(expec_meta));
     }
 }

--- a/src/source/gsub.rs
+++ b/src/source/gsub.rs
@@ -51,7 +51,6 @@ impl Int {
         let config: Config = config.clone();
         let remote = None;
         let project_id = "".to_string();
-        let _hostport = "pubsub.googleapis.com:443";
         let origin = EventOriginUri {
             uid: 0,
             scheme: "google-sub".to_string(),

--- a/src/source/gsub.rs
+++ b/src/source/gsub.rs
@@ -1,0 +1,194 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![cfg(not(tarpaulin_include))]
+
+use crate::source::prelude::*;
+use crate::{
+    codec::Codec,
+    connectors::gcp::{pubsub, pubsub_auth},
+};
+use googapis::google::pubsub::v1::subscriber_client::SubscriberClient;
+use std::env;
+use std::{fs::File, io::Read};
+use tonic::transport::Channel;
+pub struct GoogleCloudPubSub {
+    config: Config,
+    onramp_id: TremorUrl,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct Config {
+    pub subscription: String,
+}
+
+impl ConfigImpl for Config {}
+
+pub struct Int {
+    config: Config,
+    onramp_id: TremorUrl,
+    remote: Option<SubscriberClient<Channel>>,
+    origin: EventOriginUri,
+    project_id: String,
+}
+impl std::fmt::Debug for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GoogleCloudPubSub")
+    }
+}
+impl Int {
+    fn from_config(onramp_id: TremorUrl, config: &Config) -> Self {
+        let config: Config = config.clone();
+        let remote = None;
+        let project_id = "".to_string();
+        let _hostport = "pubsub.googleapis.com:443";
+        let origin = EventOriginUri {
+            uid: 0,
+            scheme: "google-sub".to_string(),
+            host: hostname(),
+            port: None,
+            path: vec![],
+        };
+        Self {
+            config,
+            origin,
+            onramp_id,
+            remote,
+            project_id,
+        }
+    }
+}
+
+impl onramp::Impl for GoogleCloudPubSub {
+    fn from_config(id: &TremorUrl, config: &Option<YamlValue>) -> Result<Box<dyn Onramp>> {
+        if let Some(config) = config {
+            let config: Config = Config::new(config)?;
+            Ok(Box::new(Self {
+                config,
+                onramp_id: id.clone(),
+            }))
+        } else {
+            Err("Onramp Google Cloud Pubsub (sub) requires a config".into())
+        }
+    }
+}
+
+#[async_trait::async_trait()]
+impl Source for Int {
+    fn id(&self) -> &TremorUrl {
+        &self.onramp_id
+    }
+
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
+        let subscription_name = &self.config.subscription;
+        let mut remote = match &mut self.remote {
+            Some(v) => v,
+            None => return Err("Error creating the client".into()),
+        };
+        let project_id = &self.project_id;
+
+        // TODO: Error Handling
+        let data = pubsub::receive_message(&mut remote, &project_id, &subscription_name).await?;
+        let mut res = Vec::new();
+        let mut ack_ids = Vec::new();
+        for msg in data.received_messages {
+            let ack_id = msg.ack_id.clone();
+            let data = msg
+                .message
+                .as_ref()
+                .ok_or("Error getting pubsub message")?
+                .data
+                .clone();
+            let message_id = msg
+                .message
+                .as_ref()
+                .ok_or("Error getting pubsub message")?
+                .message_id
+                .clone();
+            let mut meta = Value::object_with_capacity(2);
+            meta.insert("message_id", message_id)?;
+            meta.insert("acknowledgement_id", ack_id.clone())?;
+            ack_ids.push(ack_id);
+            res.push((data, Some(meta)));
+        }
+        // TODO: Construct tests to make sure that duplicate messages are not coming since acknowledgement is done after
+        pubsub::acknowledge(&mut remote, &project_id, &subscription_name, ack_ids).await?;
+        return Ok(SourceReply::BatchData {
+            origin_uri: self.origin.clone(),
+            batch_data: res,
+            codec_override: None,
+            stream: 0,
+        });
+    }
+
+    async fn init(&mut self) -> Result<SourceState> {
+        self.remote = Some(pubsub_auth::setup_subscriber_client().await?);
+        let file;
+        match env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+            Ok(val) => file = val,
+            Err(_e) => file = "service account file not found".to_string(),
+        }
+        let mut f = File::open(file)?;
+        let mut buffer = Vec::new();
+        f.read_to_end(&mut buffer)?;
+        let json = tremor_value::parse_to_value(&mut buffer)?;
+        self.project_id = match json.get_str("project_id") {
+            Some(v) => v.to_string(),
+            None => return Err("Error getting `project id` in gsub".into()),
+        };
+        Ok(SourceState::Connected)
+    }
+
+    async fn on_empty_event(&mut self, _id: u64, _stream: usize) -> Result<()> {
+        Ok(())
+    }
+
+    async fn reply_event(
+        &mut self,
+        _event: Event,
+        _codec: &dyn Codec,
+        _codec_map: &halfbrown::HashMap<String, Box<dyn Codec>>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn metrics(&mut self, _t: u64) -> Vec<Event> {
+        vec![]
+    }
+
+    async fn terminate(&mut self) {}
+
+    fn trigger_breaker(&mut self) {}
+
+    fn restore_breaker(&mut self) {}
+
+    fn ack(&mut self, _id: u64) {}
+
+    fn fail(&mut self, _id: u64) {}
+
+    fn is_transactional(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait::async_trait]
+impl Onramp for GoogleCloudPubSub {
+    async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
+        let source = Int::from_config(self.onramp_id.clone(), &self.config);
+        SourceManager::start(source, config).await
+    }
+
+    fn default_codec(&self) -> &str {
+        "json"
+    }
+}

--- a/src/source/gsub.rs
+++ b/src/source/gsub.rs
@@ -60,9 +60,9 @@ impl Int {
         };
         Self {
             config,
-            origin,
             onramp_id,
             remote,
+            origin,
             project_id,
         }
     }


### PR DESCRIPTION
Signed-off-by: Jigyasa <jigyasakhaneja05@gmail.com>

# Pull request

## Description

Added code for Google Cloud Pubsub connectors

## Related

https://github.com/tremor-rs/tremor-runtime/issues/724

## Checklist


* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


