### PR TITLE
Load config files from sub directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `KnownKey::map_*` functions to directly work on the `Value::Object`s inner `HashMap`, if available.
 - Add `HEALTHCHECK` to Dockerfiles
 - Improve printing for dot files
+- Scan sub directories of ${CFG_DIR} for config files.
 
 ### Fixes
 

--- a/packaging/distribution/usr/share/tremor/tremor.sh
+++ b/packaging/distribution/usr/share/tremor/tremor.sh
@@ -29,25 +29,17 @@ else
     ARTEFACTS=""
 
     # Load *.yaml files
-    YAMLS=$(find ${CFG_DIR} -name '*.yaml' -print 2>/dev/null | wc -l)
-    if [ "$YAMLS" != 0 ]
-    then
-        ARTEFACTS="$ARTEFACTS ${CFG_DIR}/*.yaml"
-    fi
+    YAMLS=$(find ${CFG_DIR} -name '*.yaml' -print 2>/dev/null)
+    [ ! -z "$YAMLS" ] && ARTEFACTS="$ARTEFACTS $YAMLS"
 
     # Load *.yml files
-    YMLS=$(find ${CFG_DIR} -name '*.yml' -print 2>/dev/null | wc -l)
-    if [ "$YMLS" != 0 ]
-    then
-        ARTEFACTS="$ARTEFACTS ${CFG_DIR}/*.yml"
-    fi
+    YMLS=$(find ${CFG_DIR} -name '*.yml' -print 2>/dev/null)
+    [ ! -z "$YMLS" ] && ARTEFACTS="$ARTEFACTS $YMLS"
 
     # Load *.trickle files
-    QUERIES=$(find ${CFG_DIR}/ -name '*.trickle' -print 2>/dev/null | wc -l)
-    if [ "$QUERIES" != 0 ]
-    then
-        ARTEFACTS="$ARTEFACTS ${CFG_DIR}/*.trickle"
-    fi
+    QUERIES=$(find ${CFG_DIR}/ -name '*.trickle' -print 2>/dev/null)
+    [ ! -z "$QUERIES" ] && ARTEFACTS="$ARTEFACTS $QUERIES"
+
     ARGS="server run --logger-config ${LOGGER_FILE}"
 
     if [ ! -z "${ARTEFACTS}" ]


### PR DESCRIPTION
# Pull request

## Description
Today, Tremor considers config files that are placed under ${CFG_DIR}.  This change Identifies yaml, yml and trickle files from subdirectories of ${CFG_DIR} as well. 

## Related

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
It is startup script change. Performance testing is not applicable.

