### PR TITLE
Fix contraflow cycle via system::metrics pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Record the partition number assigned during rebalancing when running Kafka.
 - Fix bug in HDR histogram implementation when using emit without reset.
 - Fix bug in mean that invalid values would be counted as part of the total number of values.
+- Avoid possible contraflow cycles via `system::metrics` pipeline, if a pipeline is connected to an output port of `system::metrics` pipeline.
 
 ## 0.11.1
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -305,7 +305,7 @@ where
                 onramp::Msg::Connect(port, ps) => {
                     if port.eq_ignore_ascii_case(METRICS.as_ref()) {
                         if ps.len() > 1 {
-                            warn!("Connecting more than 1 metrics pipelines will only connect the latest.");
+                            warn!("[Source::{}] Connecting more than 1 metrics pipelines will only connect the latest.", self.source_id);
                         }
                         for p in ps {
                             info!(

--- a/tremor-cli/src/test/process.rs
+++ b/tremor-cli/src/test/process.rs
@@ -69,8 +69,11 @@ pub(crate) fn run_process(
 
     let bench_rootx = bench_root.to_path_buf();
 
-    let mut process =
-        job::TargetProcess::new_with_stderr(&job::which("tremor")?, &args, &HashMap::default())?;
+    // enable info level logging
+    let mut env = HashMap::with_capacity(1);
+    env.insert(String::from("RUST_LOG"), String::from("info"));
+
+    let mut process = job::TargetProcess::new_with_stderr(&job::which("tremor")?, &args, &env)?;
     let process_status = process.wait_with_output()?;
 
     let fg_out_file = bench_rootx.join("fg.out.log");

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/assert.yaml
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/assert.yaml
@@ -1,0 +1,10 @@
+status: 0
+name: avoid CB cycle via tremor's system::metrics pipeline
+asserts:
+  - source: fg.err.log
+    contains:
+      - |
+        All required CB events received.
+    doesnt_contain:
+      - |
+        [Pipeline::tremor://localhost/pipeline/cb_pipe/01] failed to send insight to input: SendError(..) tremor://localhost/onramp/file_in/01/out

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/cb_pipe.trickle
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/cb_pipe.trickle
@@ -1,0 +1,2 @@
+#! metrics_interval_s = 1
+select event from in into out;

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/config.yaml
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/config.yaml
@@ -1,0 +1,33 @@
+onramp:
+  - id: cb_in
+    type: cb
+    config:
+      source: input.json
+      #source: tremor-cli/tests/integration/avoid_cycle_via_system_metrics/input.json
+  - id: file_in
+    type: file
+    config:
+      source: input.json
+      #source: tremor-cli/tests/integration/avoid_cycle_via_system_metrics/input.json
+offramp:
+  - id: cb_out
+    type: cb
+
+binding:
+  - id: metrics
+    links:
+      # loose input at this pipeline
+      "/pipeline/system::metrics/system/out":
+        - "/pipeline/metrics/{instance}/in"
+      "/pipeline/metrics/{instance}/out":
+        - "/offramp/system::stderr/system/in"
+      "/onramp/cb_in/{instance}/out":
+        - "/pipeline/cb_pipe/{instance}/in"
+      "/onramp/file_in/{instance}/out":
+        - "/pipeline/cb_pipe/{instance}/in"
+      "/pipeline/cb_pipe/{instance}/out":
+        - "/offramp/cb_out/{instance}/in"
+
+mapping:
+  /binding/metrics/01:
+    instance: "01"

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/input.json
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/input.json
@@ -1,0 +1,10 @@
+{"cb": "ack"}
+{"cb": "fail"}
+{"cb": "ack"}
+{"cb": "fail"}
+{"cb": "ack"}
+{"cb": "fail"}
+{"cb": "ack"}
+{"cb": "fail"}
+{"cb": "ack"}
+{"cb": "fail"}

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/metrics.trickle
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/metrics.trickle
@@ -1,0 +1,1 @@
+select event from in into out;

--- a/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/tags.json
+++ b/tremor-cli/tests/integration/avoid_cycle_via_system_metrics/tags.json
@@ -1,0 +1,1 @@
+["cycle", "system_metrics"]


### PR DESCRIPTION
# Pull request

## Description

Before this PR is was possible to trigger a contraflow event cycle when connecting any pipeline to the `system::metrics` pipeline. In that case contraflow messages might be sent via the `system::metrics` pipeline which used to account for all its input pipelines (all pipelines are input to the `system::metrics` pipeline). So the cycle went from offramp to pipeline `X` to `system::metrics` pipeline to all of its inputs (among them pipeline `X`) and to `system::metrics` pipeline and so forth.

This is avoided by having `system::metrics` not account for its input pipelines, so it is a dead end for contraflow messages.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


