### PR TITLE
removed unused imports

### DIFF
--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -135,7 +135,6 @@ impl<'consumer> StreamAndMsgs<'consumer> {
 }
 
 rental! {
-    #[allow(unused_imports)]
     pub mod rentals {
         use super::{StreamAndMsgs, LoggingConsumer};
 

--- a/tremor-script/src/errors.rs
+++ b/tremor-script/src/errors.rs
@@ -15,23 +15,21 @@
 // NOTE: We need this because of error_chain
 #![allow(clippy::large_enum_variant)]
 #![allow(deprecated)]
-#![allow(unused_imports)]
 #![allow(missing_docs)]
 
 pub use crate::prelude::ValueType;
 use crate::prelude::*;
 use crate::{
-    ast::{self, BaseExpr, Expr, Ident, NodeMetas},
+    ast::{self, BaseExpr, NodeMetas},
     errors, lexer,
-    path::ModulePath,
-    pos::{self, Location, Range, Spanned},
+    pos::{self, Range},
     Value,
 };
 use error_chain::error_chain;
 use lalrpop_util::ParseError as LalrpopError;
-use serde::{Deserialize, Serialize};
+
+use std::num;
 use std::ops::{Range as RangeExclusive, RangeInclusive};
-use std::{num, ops::Deref};
 
 /// A compile-time error capturing the preprocessors cus at the time of the error
 #[derive(Debug)]

--- a/tremor-script/src/registry.rs
+++ b/tremor-script/src/registry.rs
@@ -441,7 +441,6 @@ macro_rules! tremor_fn_ {
             use $crate::Value;
             use $crate::EventContext;
             use $crate::registry::{TremorFnWrapper, TremorFn};
-            #[allow(unused_imports)] // We might not use all of this imports
             use $crate::registry::{FResult, FunctionError, mfa, Mfa, to_runtime_error as to_runtime_error_ext};
             const ARGC: usize = {0_usize $(+ replace_expr!($arg 1_usize))*};
             // const MOD: &'static str = $module;
@@ -505,7 +504,6 @@ macro_rules! tremor_fn_ {
             use $crate::Value;
             use $crate::EventContext;
             use $crate::registry::{TremorFnWrapper, TremorFn};
-            #[allow(unused_imports)] // We might not use all of this imports
             use $crate::registry::{FResult, FunctionError, mfa, Mfa, to_runtime_error as to_runtime_error_ext};
             const ARGC: usize = {0_usize $(+ replace_expr!($arg 1_usize))*};
             // const MOD: &'static str = $module;
@@ -568,7 +566,6 @@ macro_rules! tremor_fn_ {
             use $crate::Value;
             use $crate::EventContext;
             use $crate::registry::{TremorFnWrapper, TremorFn};
-            #[allow(unused_imports)] // We might not use all of this imports
             use $crate::registry::{FResult, FunctionError, mfa, Mfa, to_runtime_error as to_runtime_error_ext};
             const ARGC: usize = 0;
             // const MOD: &'static str = $module;


### PR DESCRIPTION
Signed-off-by: therealansh <tyagiansh23@hotmail.com>

# Pull request

## Description
This PR removes unused imports.
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #996 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


