### PR TITLE
Remove two transmutes, fixes #1025

### DIFF
--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -74,7 +74,7 @@ extern crate rental;
 pub use crate::ast::query::SelectType;
 pub use crate::ctx::{EventContext, EventOriginUri};
 use crate::prelude::*;
-pub use crate::query::Query;
+pub use crate::query::{Query, QueryRental};
 pub use crate::registry::{
     aggr as aggr_registry, registry, Aggr as AggrRegistry, CustomFn, Registry, TremorAggrFn,
     TremorAggrFnWrapper, TremorFn, TremorFnWrapper,


### PR DESCRIPTION
# Pull request

## Description

This restructures the way we create the instantiated, we use an ARC for the source to reference from the borrowed entity. We transmuted this instead of re-looking the at node up when creating the self-referential struct. This is safe but depends on reasoning rather than automated checks which carry the risk that refactoring that the constraints get violated or overlooked.

This PR moves the borrowing inside of the rental to avoid transmutation.

## Related

* Related Issues: fixes #1025

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

This does not touch any hot path code.