### PR TITLE
Add support for tls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### New features
 
 - Add tests for merge feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
+- Add support for receiving TLS encrypted data via TCP onramp.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
+name = "async-tls"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls 0.19.1",
+ "webpki",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6496,6 +6509,7 @@ dependencies = [
  "async-nats",
  "async-std",
  "async-std-resolver",
+ "async-tls",
  "async-trait",
  "async-tungstenite 0.13.1",
  "base64 0.13.0",
@@ -6541,6 +6555,7 @@ dependencies = [
  "rental",
  "reqwest 0.11.3",
  "rmp-serde",
+ "rustls 0.19.1",
  "serde",
  "serde_derive",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ tremor-script = {path = "tremor-script"}
 tremor-value = {path = "tremor-value"}
 url = "2.2"
 value-trait = "0.2"
+rustls = "0.19"
+async-tls = "0.11.0"
 
 mapr = "0.8"
 tempfile = {version = "3.2"}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -165,7 +165,7 @@ error_chain! {
         HttpHeaderError(http::header::InvalidHeaderValue);
         TonicTransportError(tonic::transport::Error);
         TonicStatusError(tonic::Status);
-
+        RustlsError(rustls::TLSError);
     }
 
     errors {
@@ -291,7 +291,10 @@ error_chain! {
         KvError(s: String) {
             description("KV error")
                 display("{}", s)
-
+        }
+        TLSError(s: String) {
+            description("TLS error")
+                display("{}", s)
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: murex971 <nupur202000@gmail.com>

# Pull request

## Description

add support for receiving TLS encrypted data via TCP onramp

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #12 (Phase 3)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [X] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


