### PR TITLE
TCP/TLS offramp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Add tests for merge feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
 - Add support for receiving TLS encrypted data via TCP onramp.
+- Add support for sending TLS encrypted data via TCP offramp.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6585,7 +6585,6 @@ dependencies = [
  "tungstenite 0.13.0",
  "url 2.2.2",
  "value-trait",
- "webpki-roots 0.21.1",
  "xz2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,9 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elastic"
@@ -6518,6 +6521,7 @@ dependencies = [
  "bytes 1.0.1",
  "chrono",
  "cron",
+ "either",
  "elastic",
  "env_logger 0.8.3",
  "error-chain 0.12.4",
@@ -6581,6 +6585,7 @@ dependencies = [
  "tungstenite 0.13.0",
  "url 2.2.2",
  "value-trait",
+ "webpki-roots 0.21.1",
  "xz2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ beef = {version = "0.5", features = ["impl_serde"]}
 byteorder = "1"
 bytes = "1.0"
 chrono = "0.4"
+either = { version = "1.6", features = ["serde"]}
 elastic = "0.21.0-pre.5"
 error-chain = "0.12"
 futures = "0.3.15"
@@ -78,7 +79,9 @@ tremor-value = {path = "tremor-value"}
 url = "2.2"
 value-trait = "0.2"
 rustls = "0.19"
-async-tls = "0.11.0"
+# needs to be compatible with what rusttls is using
+webpki-roots = "0.21"
+async-tls = { version = "0.11", features = ["client", "server"]}
 
 mapr = "0.8"
 tempfile = {version = "3.2"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,7 @@ tremor-value = {path = "tremor-value"}
 url = "2.2"
 value-trait = "0.2"
 rustls = "0.19"
-# needs to be compatible with what rusttls is using
-webpki-roots = "0.21"
-async-tls = { version = "0.11", features = ["client", "server"]}
+async-tls = "0.11"
 
 mapr = "0.8"
 tempfile = {version = "3.2"}


### PR DESCRIPTION
# Pull request

## Description

Add support for sending TLS encrypted data via TCP offramp.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #12 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


