### PR TITLE
nicer skipping for EQC tests

### DIFF
--- a/.github/workflows/eqc-tremor-script.yaml
+++ b/.github/workflows/eqc-tremor-script.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   eqc-tests:
+    if: ${{ secrets.EQC_LICENSE != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0

--- a/.github/workflows/eqc.yaml
+++ b/.github/workflows/eqc.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   eqc-tests:
+    if: ${{ secrets.EQC_LICENSE != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## Unreleased
+
+## Fixes
+
+- Skip instead of fail EQC on out of repo PRs
+
 ## 0.11.4
 
 ### Fixes
 
 - Fix the Release archive and package build process
+
 ## 0.11.3
 
 ### New features

--- a/tremor-script/src/ast/eq.rs
+++ b/tremor-script/src/ast/eq.rs
@@ -819,8 +819,10 @@ mod tests {
             case event.foo => "event.foo"
             case %( _, 12, ... ) => "has 12 at index 1"
             case %[] => "empty_array"
-            case %[ %{ present x } ] => "complex"
+            case %[ %{ present x }, ~ json|| ] => "complex"
+            case %{ absent y, snot == "badger", superhero ~= %{absent name}} => "snot"
             case object = %{ absent y, snot == "badger", superhero ~= %{absent name}} when object.superhero.is_snotty => "snotty_badger"
+            case ~ json|| => "json"
             default => null
         end);
         (match x of
@@ -828,8 +830,10 @@ mod tests {
             case event.foo => "event.foo"
             case %( _, 12, ... ) => "has 12 at index 1"
             case %[] => "empty_array"
-            case %[ %{ present x } ] => "complex"
+            case %[ %{ present x }, ~ json|| ] => "complex"
+            case %{ absent y, snot == "badger", superhero ~= %{absent name}} => "snot"
             case object = %{ absent y, snot == "badger", superhero ~= %{absent name}} when object.superhero.is_snotty => "snotty_badger"
+            case ~ json|| => "json"
             default => null
         end)
         "#
@@ -916,11 +920,11 @@ mod tests {
     eq_test!(
         test_comprehension_eq,
         r#"
-        (for event[1] of
+        (for event[1][1:3] of
             case (i, e) =>
                 {" #{i}": e}
         end);
-        (for event[1] of
+        (for event[1][1:3] of
             case (i, e) =>
                 {" #{i}": e}
         end)


### PR DESCRIPTION
# Pull request

## Description

This skips EQC tests in out of repo PRs instead of failing them, not giving the nasty red-looking errors, and instead grayed out results. Just cosmetics but it will make people feeling happier not having any reds.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no code changes