### PR TITLE
Add SSE source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### New features
 
 - Add tests for patch feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
+- Add onramp for SSE (Server Sent Events)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### New features
 
 - Add tests for patch feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
-- Add onramp for SSE (Server Sent Events)
+- Add onramp for SSE (Server Sent Events) [#885](https://github.com/tremor-rs/tremor-runtime/issues/885)
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "pin-project",
+ "pin-project 1.0.7",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "log",
- "pin-project",
+ "pin-project 1.0.7",
  "tokio 1.6.0",
  "tokio-rustls",
  "tungstenite 0.11.1",
@@ -2058,6 +2058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2082,18 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.15",
+ "memchr",
+ "pin-project 0.4.28",
 ]
 
 [[package]]
@@ -2623,7 +2641,7 @@ dependencies = [
  "httparse",
  "httpdate 0.3.2",
  "itoa",
- "pin-project",
+ "pin-project 1.0.7",
  "socket2 0.3.19",
  "tokio 0.2.25",
  "tower-service",
@@ -2647,7 +2665,7 @@ dependencies = [
  "httparse",
  "httpdate 1.0.0",
  "itoa",
- "pin-project",
+ "pin-project 1.0.7",
  "socket2 0.4.0",
  "tokio 1.6.0",
  "tower-service",
@@ -3839,11 +3857,31 @@ checksum = "7d7afeb98c5a10e0bffcc7fc16e105b04d06729fac5fd6384aebf7ff5cb5a67d"
 
 [[package]]
 name = "pin-project"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+dependencies = [
+ "pin-project-internal 0.4.28",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.7",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -5362,6 +5400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-codec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a59f811350c44b4a037aabeb72dc6a9591fc22aa95a036db9a96297c58085a"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-io",
+ "futures_codec",
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5518,6 +5568,18 @@ dependencies = [
  "serde",
  "serde_json",
  "web-sys",
+]
+
+[[package]]
+name = "surf-sse"
+version = "1.0.0"
+source = "git+https://github.com/dak-x/surf-sse?branch=default#c7a7d5d989c3cbde1922f52cee4824f771caf9b0"
+dependencies = [
+ "futures-core",
+ "futures-timer",
+ "log",
+ "sse-codec",
+ "surf",
 ]
 
 [[package]]
@@ -6222,7 +6284,7 @@ dependencies = [
  "http-body 0.4.2",
  "hyper 0.14.7",
  "percent-encoding 2.1.0",
- "pin-project",
+ "pin-project 1.0.7",
  "prost",
  "prost-derive",
  "tokio 1.6.0",
@@ -6258,7 +6320,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project",
+ "pin-project 1.0.7",
  "rand 0.8.4",
  "slab",
  "tokio 1.6.0",
@@ -6320,7 +6382,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
@@ -6534,6 +6596,7 @@ dependencies = [
  "smol",
  "snap",
  "surf",
+ "surf-sse",
  "syslog_loose",
  "tempfile",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,10 @@ openssl = { version = "0.10", features = ["vendored"] }
 # rest onramp
 tide = "0.16"
 
+# sse-onramp
+# sse onramp
+surf-sse = {git = "https://github.com/dak-x/surf-sse", branch = "default"}
+
 # nats
 async-nats = "0.9.18"
 

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -82,7 +82,7 @@ pub(crate) fn lookup(
         "udp" => udp::Udp::from_config(id, config),
         "tcp" => tcp::Tcp::from_config(id, config),
         "rest" => rest::Rest::from_config(id, config),
-        "sse" => sse::Sse::from_config(id,config),
+        "sse" => sse::Sse::from_config(id, config),
         "ws" => ws::Ws::from_config(id, config),
         "discord" => discord::Discord::from_config(id, config),
         "otel" => otel::OpenTelemetry::from_config(id, config),

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -18,7 +18,7 @@ use crate::repository::ServantId;
 use crate::source::prelude::*;
 use crate::source::{
     amqp, blaster, cb, crononome, discord, file, gsub, kafka, metronome, nats, otel, postgres,
-    rest, stdin, tcp, udp, ws,
+    rest, sse, stdin, tcp, udp, ws,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};
@@ -82,6 +82,7 @@ pub(crate) fn lookup(
         "udp" => udp::Udp::from_config(id, config),
         "tcp" => tcp::Tcp::from_config(id, config),
         "rest" => rest::Rest::from_config(id, config),
+        "sse" => sse::Sse::from_config(id,config),
         "ws" => ws::Ws::from_config(id, config),
         "discord" => discord::Discord::from_config(id, config),
         "otel" => otel::OpenTelemetry::from_config(id, config),

--- a/src/source.rs
+++ b/src/source.rs
@@ -51,6 +51,7 @@ pub(crate) mod otel;
 pub(crate) mod postgres;
 pub(crate) mod prelude;
 pub(crate) mod rest;
+pub(crate) mod sse;
 pub(crate) mod stdin;
 pub(crate) mod tcp;
 pub(crate) mod udp;

--- a/src/source/sse.rs
+++ b/src/source/sse.rs
@@ -167,7 +167,7 @@ impl Source for Int {
             uid: self.uid,
             scheme: "tremor-sse".to_string(),
             // What even is the host here?
-            host: "localhost".to_string(),
+            host: hostname(),
             port: None,
             path: vec![String::default()],
         };

--- a/src/source/sse.rs
+++ b/src/source/sse.rs
@@ -1,0 +1,159 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(not(tarpaulin_include))]
+use crate::source::prelude::*;
+use async_channel::{Sender, TryRecvError};
+use surf_sse;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Config {
+    // url
+    pub url: String,
+}
+impl ConfigImpl for Config {}
+
+pub struct Sse {
+    pub config: Config,
+    onramp_id: TremorUrl,
+}
+
+impl onramp::Impl for Sse {
+    fn from_config(id: &TremorUrl, config: &Option<YamlValue>) -> Result<Box<dyn Onramp>> {
+        if let Some(config) = config {
+            let config: Config = Config::new(config)?;
+            Ok(Box::new(Self {
+                config,
+                onramp_id: id.clone(),
+            }))
+        } else {
+            Err("Missing config for SSE onramp".into())
+        }
+    }
+}
+
+#[async_trait::async_trait()]
+impl Onramp for Sse {
+    async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
+        let source = Int::from_config(config.onramp_uid, self.onramp_id.clone(), &self.config)?;
+        SourceManager::start(source, config).await
+    }
+
+    fn default_codec(&self) -> &str {
+        // What is the default use case? maybe json?
+        "string"
+    }
+}
+
+pub struct Int {
+    uid: u64,
+    config: Config,
+    onramp_id: TremorUrl,
+    event_source: Option<Receiver<surf_sse::Event>>,
+}
+impl std::fmt::Debug for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SSE")
+    }
+}
+
+impl Int {
+    fn from_config(uid: u64, onramp_id: TremorUrl, config: &Config) -> Result<Self> {
+        Ok(Int {
+            uid,
+            config: config.clone(),
+            onramp_id,
+            event_source: None,
+        })
+    }
+}
+
+async fn handle_init(
+    url: surf_sse::Url,
+    tx: Sender<surf_sse::Event>,
+) -> Result<()>{
+    // Run the event source here.
+    let mut event_source = surf_sse::EventSource::new(url);
+
+    // Potential Problem on calling next. There is try_next available we need future_util crate for that.
+    while let Some(event) = event_source.next().await {
+        match event {
+            Ok(event) => {
+                tx.send(event).await?;
+            }
+            Err(e) => {
+                error!("SSE error while processing response :{}", e);
+            }
+        };
+    }
+    tx.close();
+    Ok(())
+}
+
+#[async_trait::async_trait()]
+impl Source for Int {
+    fn id(&self) -> &TremorUrl {
+        &self.onramp_id
+    }
+
+    async fn init(&mut self) -> Result<SourceState> {
+        info!(
+            "[Source::{}] subscribing to {}",
+            self.onramp_id.to_string(),
+            &self.config.url
+        );
+
+        let (tx, rx) = bounded(crate::QSIZE);
+        let url: surf_sse::Url = self.config.url.parse()?;
+        // The client runs with default configuration from crate
+        task::spawn(handle_init(url,tx));
+        self.event_source = Some(rx);
+
+        Ok(SourceState::Connected)
+    }
+
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
+        let origin_uri = EventOriginUri {
+            uid: self.uid,
+            scheme: "tremor-sse".to_string(),
+            // What even is the host here?
+            host: "localhost".to_string(),
+            port: None,
+            path: vec![String::default()],
+        };
+
+        self.event_source.as_ref().map_or_else(
+            // There is not recv.
+            || Ok(SourceReply::StateChange(SourceState::Disconnected)),
+            |event_source| {
+                match event_source.try_recv() {
+                    Ok(event) => {
+                        let src_rply = SourceReply::Data {
+                            origin_uri: origin_uri.clone(),
+                            data: event.data.into_bytes(),
+                            meta: None,
+                            codec_override: None,
+                            stream: 0,
+                        };
+                        Ok(src_rply)
+                    }
+                    Err(TryRecvError::Empty) => Ok(SourceReply::Empty(10)),
+                    Err(TryRecvError::Closed) => {
+                        Ok(SourceReply::StateChange(SourceState::Disconnected))
+                    }
+                }
+            },
+        )
+    }
+}


### PR DESCRIPTION
# Pull request

## Description
Adds an onramp for Server-Sent-Events.  
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: closes #885

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [X] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance
<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


