### PR TITLE
Lifetimes2.0

### DIFF
--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -28,7 +28,7 @@ use tremor_common::stry;
 
 use tremor_script::{
     self,
-    ast::{Aggregates, InvokeAggrFn, NodeMetas, Select, SelectStmt, WindowDecl},
+    ast::{AggregateScratch, Aggregates, InvokeAggrFn, NodeMetas, Select, SelectStmt, WindowDecl},
     interpreter::Env,
     interpreter::LocalStack,
     prelude::*,
@@ -628,16 +628,19 @@ impl Operator for TrickleSelect {
 
             // TODO: reason about soundness
             let SelectStmt {
-                stmt,
-                aggregates,
-                aggregate_scratches,
-                consts,
-                locals,
-                node_meta,
-            }: &mut SelectStmt = unsafe {
-                // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1024
-                mem::transmute(stmt)
-            };
+                ref stmt,
+                ref mut aggregates,
+                ref mut aggregate_scratches,
+                ref mut consts,
+                ref locals,
+                ref node_meta,
+            } = stmt;
+
+            // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1024
+            let aggregates: &mut Aggregates = unsafe { mem::transmute(aggregates)};
+            // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1024
+            let aggregate_scratches: &mut Option<(AggregateScratch, AggregateScratch)> = unsafe { mem::transmute(aggregate_scratches)};
+
             let local_stack = tremor_script::interpreter::LocalStack::with_size(*locals);
             consts.window = Value::null();
             consts.group = Value::null();

--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -26,7 +26,17 @@ use std::mem;
 use std::sync::Arc;
 use tremor_common::stry;
 
-use tremor_script::{self, QueryRental, Value, ast::{Aggregates, Consts, InvokeAggrFn, NodeMetas, Select, SelectStmt, WindowDecl}, interpreter::Env, interpreter::LocalStack, prelude::*, query::StmtRental, query::StmtRentalWrapper, utils::sorted_serialize};
+use tremor_script::{
+    self,
+    ast::{Aggregates, Consts, InvokeAggrFn, NodeMetas, Select, SelectStmt, WindowDecl},
+    interpreter::Env,
+    interpreter::LocalStack,
+    prelude::*,
+    query::StmtRental,
+    query::StmtRentalWrapper,
+    utils::sorted_serialize,
+    QueryRental, Value,
+};
 
 #[derive(Debug, Clone)]
 pub struct GroupData<'groups> {
@@ -629,12 +639,19 @@ impl Operator for TrickleSelect {
             // this is encoded in the program logic by the shutdown pattern of
             // sink -> pipeline -> source
             // There is no way to explain this to rust's borrow checker so we circumvent it here
-                      
+            // We need this for clippy
+            let select: &Select = select;
             // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1024
-            let select: & Box<Select> = unsafe{ mem::transmute(select)};
+            let select: &Select = unsafe{ mem::transmute(select)};
             // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1024
-            let consts: & mut Consts  = unsafe{ mem::transmute(consts)};
-            let Select {  target, maybe_where, maybe_having, maybe_group_by, .. } = select.as_ref(); 
+            let consts: &mut Consts  = unsafe{ mem::transmute(consts)};
+            let Select {
+                target,
+                maybe_where,
+                maybe_having,
+                maybe_group_by,
+                ..
+             } = select;
 
             let local_stack = tremor_script::interpreter::LocalStack::with_size(*locals);
             consts.window = Value::null();

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -1236,7 +1236,7 @@ impl<'script> Invocable<'script> {
     /// if the funciton fails to be invoked
     pub fn invoke<'event, 'run>(
         &'run self,
-        env: &'run Env<'run, 'event, 'script>,
+        env: &'run Env<'run, 'event>,
         args: &'run [&'run Value<'event>],
     ) -> FResult<Value<'event>>
     where

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -23,9 +23,11 @@ pub mod eq;
 pub mod query;
 pub(crate) mod raw;
 mod support;
+mod to_static;
 mod upable;
 /// collection of AST visitors
 pub mod visitors;
+
 use self::eq::AstEq;
 use crate::interpreter::{exec_binary, exec_unary, AggrType, Cont, Env, ExecOpts, LocalStack};
 pub use crate::lexer::CompilationUnit;

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -632,25 +632,23 @@ pub struct Script<'script> {
     pub docs: Docs<'script>,
 }
 
-impl<'input, 'run, 'script, 'event> Script<'script>
-where
-    'input: 'script,
-    'script: 'event,
-    'event: 'run,
-{
+impl<'script> Script<'script> {
     /// Runs the script and evaluates to a resulting event.
     /// This expects the script to be imutable!
     ///
     /// # Errors
     /// on runtime errors or if it isn't an imutable script
-    pub fn run_imut(
-        &'run self,
-        context: &'run crate::EventContext,
+    pub fn run_imut<'event>(
+        &self,
+        context: &crate::EventContext,
         aggr: AggrType,
-        event: &'run Value<'event>,
-        state: &'run Value<'static>,
-        meta: &'run Value<'event>,
-    ) -> Result<Return<'event>> {
+        event: &Value<'event>,
+        state: &Value<'static>,
+        meta: &Value<'event>,
+    ) -> Result<Return<'event>>
+    where
+        'script: 'event,
+    {
         let local = LocalStack::with_size(self.locals);
 
         let opts = ExecOpts {
@@ -688,14 +686,17 @@ where
     ///
     /// # Errors
     /// on runtime errors
-    pub fn run(
-        &'run self,
-        context: &'run crate::EventContext,
+    pub fn run<'event>(
+        &self,
+        context: &crate::EventContext,
         aggr: AggrType,
-        event: &'run mut Value<'event>,
-        state: &'run mut Value<'static>,
-        meta: &'run mut Value<'event>,
-    ) -> Result<Return<'event>> {
+        event: &mut Value<'event>,
+        state: &mut Value<'static>,
+        meta: &mut Value<'event>,
+    ) -> Result<Return<'event>>
+    where
+        'script: 'event,
+    {
         let mut local = LocalStack::with_size(self.locals);
 
         let mut exprs = self.exprs.iter().peekable();

--- a/tremor-script/src/ast/eq.rs
+++ b/tremor-script/src/ast/eq.rs
@@ -209,7 +209,7 @@ impl AstEq for TestExpr {
 
 impl<'script> AstEq for ClausePreCondition<'script> {
     fn ast_eq(&self, other: &Self) -> bool {
-        self.segments.ast_eq(&other.segments)
+        self.path.ast_eq(&other.path)
     }
 }
 

--- a/tremor-script/src/ast/query.rs
+++ b/tremor-script/src/ast/query.rs
@@ -65,17 +65,17 @@ pub type Aggregates<'a> = Vec<InvokeAggrFn<'a>>;
 /// Scratch data for efficiently merging window states in a tilt-frame without additional allocations at runtime.
 /// This is basically what needs to be dragged through
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub struct AggregateScratch<'script> {
+pub struct AggregateScratch {
     /// aggregate states
-    pub aggregates: Aggregates<'script>,
+    pub aggregates: Aggregates<'static>,
     /// transactional state for the outgoing event from a window
     pub transactional: bool,
 }
 
-impl<'script> AggregateScratch<'script> {
+impl AggregateScratch {
     /// constructor
     #[must_use]
-    pub fn new(aggregates: Aggregates<'script>) -> Self {
+    pub fn new(aggregates: Aggregates<'static>) -> Self {
         Self {
             aggregates,
             transactional: false,
@@ -89,10 +89,10 @@ pub struct SelectStmt<'script> {
     /// The select statement
     pub stmt: Box<Select<'script>>,
     /// Aggregates
-    pub aggregates: Aggregates<'script>,
+    pub aggregates: Aggregates<'static>,
     /// scratches needed when executing multiple windows
     /// only necessary if we have multiple windows, otherwise empty
-    pub aggregate_scratches: Option<(AggregateScratch<'script>, AggregateScratch<'script>)>,
+    pub aggregate_scratches: Option<(AggregateScratch, AggregateScratch)>,
     /// Constants
     pub consts: Consts<'script>,
     /// Number of locals

--- a/tremor-script/src/ast/query/raw.rs
+++ b/tremor-script/src/ast/query/raw.rs
@@ -27,11 +27,11 @@ use super::{
     Registry, Result, ScriptDecl, ScriptStmt, Select, SelectStmt, Serialize, Stmt, StreamStmt,
     Upable, Value, Warning, WindowDecl, WindowKind,
 };
-use crate::impl_expr;
 use crate::{
     ast::visitors::{GroupByExprExtractor, TargetEventRefVisitor},
     lexer::Range,
 };
+use crate::{ast::InvokeAggrFn, impl_expr};
 use beef::Cow;
 use value_trait::prelude::*;
 
@@ -151,6 +151,10 @@ impl<'script> Upable<'script> for StmtRaw<'script> {
                 helper.swap(&mut aggregates, &mut locals);
                 let stmt: Select<'script> = stmt.up(helper)?;
                 helper.swap(&mut aggregates, &mut locals);
+                let aggregates: Vec<_> = aggregates
+                    .into_iter()
+                    .map(InvokeAggrFn::into_static)
+                    .collect();
                 // only allocate scratches if they are really needed - when we have multiple windows
                 let aggregate_scratches = if stmt.windows.len() > 1 {
                     Some((

--- a/tremor-script/src/ast/to_static.rs
+++ b/tremor-script/src/ast/to_static.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This is just one big identify function with a few Cow::owned in it
+#![cfg(not(tarpaulin_include))]
+
 use beef::Cow;
 
 use crate::CustomFn;

--- a/tremor-script/src/ast/to_static.rs
+++ b/tremor-script/src/ast/to_static.rs
@@ -16,7 +16,14 @@ use beef::Cow;
 
 use crate::CustomFn;
 
-use super::*;
+use super::{
+    ArrayPattern, ArrayPredicatePattern, AssignPattern, BinExpr, Bytes, BytesPart, ClauseGroup,
+    ClausePreCondition, Comprehension, ComprehensionCase, DefaultCase, EmitExpr, EventPath, Expr,
+    Field, IfElse, ImutExpr, ImutExprInt, Invocable, Invoke, InvokeAggrFn, List, Literal,
+    LocalPath, Match, Merge, MetadataPath, Patch, PatchOperation, Path, Pattern, PredicateClause,
+    PredicatePattern, Record, RecordPattern, Recur, ReservedPath, Segment, StatePath,
+    StrLitElement, StringLit, TuplePattern, UnaryExpr,
+};
 
 impl<'script> ImutExpr<'script> {
     pub(crate) fn into_static(self) -> ImutExpr<'static> {

--- a/tremor-script/src/ast/to_static.rs
+++ b/tremor-script/src/ast/to_static.rs
@@ -144,7 +144,7 @@ impl<'script> CustomFn<'script> {
 }
 
 impl<'script> Expr<'script> {
-    fn into_static(self) -> Expr<'static> {
+    pub(crate) fn into_static(self) -> Expr<'static> {
         match self {
             Expr::Match(e) => Expr::Match(Box::new(e.into_static())),
             Expr::IfElse(e) => Expr::IfElse(Box::new(e.into_static())),
@@ -283,22 +283,23 @@ impl<'script> Match<'script, Expr<'script>> {
         }
     }
 }
-impl<'script> IfElse<'script, ImutExprInt<'script>> {
-    pub(crate) fn into_static(self) -> IfElse<'static, ImutExprInt<'static>> {
-        let IfElse {
-            mid,
-            target,
-            if_clause,
-            else_clause,
-        } = self;
-        IfElse {
-            mid,
-            target: target.into_static(),
-            if_clause: if_clause.into_static(),
-            else_clause: else_clause.into_static(),
-        }
-    }
-}
+
+// impl<'script> IfElse<'script, ImutExprInt<'script>> {
+//     pub(crate) fn into_static(self) -> IfElse<'static, ImutExprInt<'static>> {
+//         let IfElse {
+//             mid,
+//             target,
+//             if_clause,
+//             else_clause,
+//         } = self;
+//         IfElse {
+//             mid,
+//             target: target.into_static(),
+//             if_clause: if_clause.into_static(),
+//             else_clause: else_clause.into_static(),
+//         }
+//     }
+// }
 
 impl<'script> IfElse<'script, Expr<'script>> {
     pub(crate) fn into_static(self) -> IfElse<'static, Expr<'static>> {
@@ -465,7 +466,7 @@ impl<'script> PredicateClause<'script, Expr<'script>> {
 
         PredicateClause {
             mid,
-            pattern,
+            pattern: pattern.into_static(),
             guard: guard.map(ImutExprInt::into_static),
             exprs: exprs.into_iter().map(Expr::into_static).collect(),
             last_expr: last_expr.into_static(),
@@ -922,6 +923,25 @@ impl<'script> ArrayPredicatePattern<'script> {
             ArrayPredicatePattern::Tilde(e) => ArrayPredicatePattern::Tilde(e),
             ArrayPredicatePattern::Record(e) => ArrayPredicatePattern::Record(e.into_static()),
             ArrayPredicatePattern::Ignore => ArrayPredicatePattern::Ignore,
+        }
+    }
+}
+
+impl<'script> InvokeAggrFn<'script> {
+    pub(crate) fn into_static(self) -> InvokeAggrFn<'static> {
+        let InvokeAggrFn {
+            mid,
+            invocable,
+            module,
+            fun,
+            args,
+        } = self;
+        InvokeAggrFn {
+            mid,
+            invocable,
+            module,
+            fun,
+            args: args.into_iter().map(ImutExpr::into_static).collect(),
         }
     }
 }

--- a/tremor-script/src/ast/to_static.rs
+++ b/tremor-script/src/ast/to_static.rs
@@ -1,0 +1,927 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use beef::Cow;
+
+use crate::CustomFn;
+
+use super::*;
+
+impl<'script> ImutExpr<'script> {
+    pub(crate) fn into_static(self) -> ImutExpr<'static> {
+        ImutExpr(self.0.into_static())
+    }
+}
+impl<'script> ImutExprInt<'script> {
+    pub(crate) fn into_static(self) -> ImutExprInt<'static> {
+        match self {
+            ImutExprInt::Record(e) => ImutExprInt::Record(e.into_static()),
+            ImutExprInt::List(e) => ImutExprInt::List(e.into_static()),
+            ImutExprInt::Binary(e) => ImutExprInt::Binary(Box::new(e.into_static())),
+            ImutExprInt::Unary(e) => ImutExprInt::Unary(Box::new(e.into_static())),
+            ImutExprInt::Patch(e) => ImutExprInt::Patch(Box::new(e.into_static())),
+            ImutExprInt::Match(e) => ImutExprInt::Match(Box::new(e.into_static())),
+            ImutExprInt::Comprehension(e) => ImutExprInt::Comprehension(Box::new(e.into_static())),
+            ImutExprInt::Merge(e) => ImutExprInt::Merge(Box::new(e.into_static())),
+            ImutExprInt::Path(p) => ImutExprInt::Path(p.into_static()),
+            ImutExprInt::String(e) => ImutExprInt::String(e.into_static()),
+            ImutExprInt::Local { idx, mid, is_const } => ImutExprInt::Local { idx, mid, is_const },
+            ImutExprInt::Literal(l) => ImutExprInt::Literal(l.into_static()),
+            ImutExprInt::Present { path, mid } => ImutExprInt::Present {
+                path: path.into_static(),
+                mid,
+            },
+            ImutExprInt::Invoke1(i) => ImutExprInt::Invoke1(i.into_static()),
+            ImutExprInt::Invoke2(i) => ImutExprInt::Invoke2(i.into_static()),
+            ImutExprInt::Invoke3(i) => ImutExprInt::Invoke3(i.into_static()),
+            ImutExprInt::Invoke(i) => ImutExprInt::Invoke(i.into_static()),
+            ImutExprInt::InvokeAggr(e) => ImutExprInt::InvokeAggr(e),
+            ImutExprInt::Recur(r) => ImutExprInt::Recur(r.into_static()),
+            ImutExprInt::Bytes(e) => ImutExprInt::Bytes(e.into_static()),
+        }
+    }
+}
+impl<'script> Recur<'script> {
+    fn into_static(self) -> Recur<'static> {
+        let Recur {
+            mid,
+            argc,
+            open,
+            exprs,
+        } = self;
+        Recur {
+            mid,
+            argc,
+            open,
+            exprs: exprs.into_iter().map(ImutExpr::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> Literal<'script> {
+    fn into_static(self) -> Literal<'static> {
+        let Literal { mid, value } = self;
+        Literal {
+            mid,
+            value: value.into_static(),
+        }
+    }
+}
+
+impl<'script> Path<'script> {
+    fn into_static(self) -> Path<'static> {
+        match self {
+            Path::Const(p) => Path::Const(p.into_static()),
+            Path::Local(p) => Path::Local(p.into_static()),
+            Path::Event(p) => Path::Event(p.into_static()),
+            Path::State(p) => Path::State(p.into_static()),
+            Path::Meta(p) => Path::Meta(p.into_static()),
+            Path::Reserved(p) => Path::Reserved(p.into_static()),
+        }
+    }
+}
+
+impl<'script> Invoke<'script> {
+    fn into_static(self) -> Invoke<'static> {
+        let Invoke {
+            mid,
+            module,
+            fun,
+            invocable,
+            args,
+        } = self;
+        Invoke {
+            mid,
+            module,
+            fun,
+            invocable: invocable.into_static(),
+            args: args.into_iter().map(ImutExpr::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> Invocable<'script> {
+    fn into_static(self) -> Invocable<'static> {
+        match self {
+            Invocable::Intrinsic(i) => Invocable::Intrinsic(i),
+            Invocable::Tremor(f) => Invocable::Tremor(f.into_static()),
+        }
+    }
+}
+
+impl<'script> CustomFn<'script> {
+    fn into_static(self) -> CustomFn<'static> {
+        let CustomFn {
+            name,
+            body,
+            args,
+            open,
+            locals,
+            is_const,
+            inline,
+        } = self;
+        CustomFn {
+            name: Cow::owned(name.to_string()),
+            body: body.into_iter().map(Expr::into_static).collect(),
+            args,
+            open,
+            locals,
+            is_const,
+            inline,
+        }
+    }
+}
+
+impl<'script> Expr<'script> {
+    fn into_static(self) -> Expr<'static> {
+        match self {
+            Expr::Match(e) => Expr::Match(Box::new(e.into_static())),
+            Expr::IfElse(e) => Expr::IfElse(Box::new(e.into_static())),
+            Expr::PatchInPlace(e) => Expr::PatchInPlace(Box::new(e.into_static())),
+            Expr::MergeInPlace(e) => Expr::MergeInPlace(Box::new(e.into_static())),
+            Expr::Assign { mid, path, expr } => Expr::Assign {
+                mid,
+                path: path.into_static(),
+                expr: Box::new(expr.into_static()),
+            },
+            Expr::AssignMoveLocal { mid, path, idx } => Expr::AssignMoveLocal {
+                mid,
+                path: path.into_static(),
+                idx,
+            },
+            Expr::Comprehension(e) => Expr::Comprehension(Box::new(e.into_static())),
+            Expr::Drop { mid } => Expr::Drop { mid },
+            Expr::Emit(e) => Expr::Emit(Box::new(e.into_static())),
+            Expr::Imut(e) => Expr::Imut(e.into_static()),
+        }
+    }
+}
+
+impl<'script> Record<'script> {
+    pub(crate) fn into_static(self) -> Record<'static> {
+        let Record { mid, fields } = self;
+        Record {
+            mid,
+            fields: fields.into_iter().map(Field::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> List<'script> {
+    pub(crate) fn into_static(self) -> List<'static> {
+        let List { mid, exprs } = self;
+        List {
+            mid,
+            exprs: exprs.into_iter().map(ImutExpr::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> BinExpr<'script> {
+    pub(crate) fn into_static(self) -> BinExpr<'static> {
+        let BinExpr {
+            mid,
+            kind,
+            lhs,
+            rhs,
+        } = self;
+        BinExpr {
+            mid,
+            kind,
+            lhs: lhs.into_static(),
+            rhs: rhs.into_static(),
+        }
+    }
+}
+
+impl<'script> UnaryExpr<'script> {
+    pub(crate) fn into_static(self) -> UnaryExpr<'static> {
+        let UnaryExpr { mid, kind, expr } = self;
+        UnaryExpr {
+            mid,
+            kind,
+            expr: expr.into_static(),
+        }
+    }
+}
+
+impl<'script> Patch<'script> {
+    pub(crate) fn into_static(self) -> Patch<'static> {
+        let Patch {
+            mid,
+            target,
+            operations,
+        } = self;
+        Patch {
+            mid,
+            target: target.into_static(),
+            operations: operations
+                .into_iter()
+                .map(PatchOperation::into_static)
+                .collect(),
+        }
+    }
+}
+
+impl<'script> Merge<'script> {
+    pub(crate) fn into_static(self) -> Merge<'static> {
+        let Merge { mid, target, expr } = self;
+        Merge {
+            mid,
+            target: target.into_static(),
+            expr: expr.into_static(),
+        }
+    }
+}
+
+impl<'script> Match<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> Match<'static, ImutExprInt<'static>> {
+        let Match {
+            mid,
+            target,
+            patterns,
+            default,
+        } = self;
+        Match {
+            mid,
+            target: target.into_static(),
+            patterns: patterns
+                .into_iter()
+                .map(ClauseGroup::<ImutExprInt>::into_static)
+                .collect(),
+            default: default.into_static(),
+        }
+    }
+}
+impl<'script> Match<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> Match<'static, Expr<'static>> {
+        let Match {
+            mid,
+            target,
+            patterns,
+            default,
+        } = self;
+        Match {
+            mid,
+            target: target.into_static(),
+            patterns: patterns
+                .into_iter()
+                .map(ClauseGroup::<Expr>::into_static)
+                .collect(),
+            default: default.into_static(),
+        }
+    }
+}
+impl<'script> IfElse<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> IfElse<'static, ImutExprInt<'static>> {
+        let IfElse {
+            mid,
+            target,
+            if_clause,
+            else_clause,
+        } = self;
+        IfElse {
+            mid,
+            target: target.into_static(),
+            if_clause: if_clause.into_static(),
+            else_clause: else_clause.into_static(),
+        }
+    }
+}
+
+impl<'script> IfElse<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> IfElse<'static, Expr<'static>> {
+        let IfElse {
+            mid,
+            target,
+            if_clause,
+            else_clause,
+        } = self;
+        IfElse {
+            mid,
+            target: target.into_static(),
+            if_clause: if_clause.into_static(),
+            else_clause: else_clause.into_static(),
+        }
+    }
+}
+
+impl<'script> ClauseGroup<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> ClauseGroup<'static, ImutExprInt<'static>> {
+        match self {
+            ClauseGroup::Simple {
+                precondition,
+                patterns,
+            } => ClauseGroup::Simple {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                patterns: patterns
+                    .into_iter()
+                    .map(PredicateClause::<ImutExprInt>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::SearchTree {
+                precondition,
+                tree,
+                rest,
+            } => ClauseGroup::SearchTree {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                tree: tree
+                    .into_iter()
+                    .map(|(v, (es, e))| {
+                        (
+                            v.into_static(),
+                            (
+                                es.into_iter()
+                                    .map(ImutExprInt::into_static)
+                                    .collect::<Vec<_>>(),
+                                e.into_static(),
+                            ),
+                        )
+                    })
+                    .collect(),
+                rest: rest
+                    .into_iter()
+                    .map(PredicateClause::<ImutExprInt>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::Combined {
+                precondition,
+                groups,
+            } => ClauseGroup::Combined {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                groups: groups
+                    .into_iter()
+                    .map(ClauseGroup::<ImutExprInt>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::Single {
+                precondition,
+                pattern,
+            } => ClauseGroup::Single {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                pattern: pattern.into_static(),
+            },
+        }
+    }
+}
+
+impl<'script> ClauseGroup<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> ClauseGroup<'static, Expr<'static>> {
+        match self {
+            ClauseGroup::Simple {
+                precondition,
+                patterns,
+            } => ClauseGroup::Simple {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                patterns: patterns
+                    .into_iter()
+                    .map(PredicateClause::<Expr>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::SearchTree {
+                precondition,
+                tree,
+                rest,
+            } => ClauseGroup::SearchTree {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                tree: tree
+                    .into_iter()
+                    .map(|(v, (es, e))| {
+                        (
+                            v.into_static(),
+                            (
+                                es.into_iter().map(Expr::into_static).collect::<Vec<_>>(),
+                                e.into_static(),
+                            ),
+                        )
+                    })
+                    .collect(),
+                rest: rest
+                    .into_iter()
+                    .map(PredicateClause::<Expr>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::Combined {
+                precondition,
+                groups,
+            } => ClauseGroup::Combined {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                groups: groups
+                    .into_iter()
+                    .map(ClauseGroup::<Expr>::into_static)
+                    .collect(),
+            },
+            ClauseGroup::Single {
+                precondition,
+                pattern,
+            } => ClauseGroup::Single {
+                precondition: precondition.map(ClausePreCondition::into_static),
+                pattern: pattern.into_static(),
+            },
+        }
+    }
+}
+
+impl<'script> PredicateClause<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> PredicateClause<'static, ImutExprInt<'static>> {
+        let PredicateClause {
+            mid,
+            pattern,
+            guard,
+            exprs,
+            last_expr,
+        } = self;
+
+        PredicateClause {
+            mid,
+            pattern: pattern.into_static(),
+            guard: guard.map(ImutExprInt::into_static),
+            exprs: exprs.into_iter().map(ImutExprInt::into_static).collect(),
+            last_expr: last_expr.into_static(),
+        }
+    }
+}
+
+impl<'script> PredicateClause<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> PredicateClause<'static, Expr<'static>> {
+        let PredicateClause {
+            mid,
+            pattern,
+            guard,
+            exprs,
+            last_expr,
+        } = self;
+
+        PredicateClause {
+            mid,
+            pattern,
+            guard: guard.map(ImutExprInt::into_static),
+            exprs: exprs.into_iter().map(Expr::into_static).collect(),
+            last_expr: last_expr.into_static(),
+        }
+    }
+}
+
+impl<'script> DefaultCase<ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> DefaultCase<ImutExprInt<'static>> {
+        match self {
+            DefaultCase::None => DefaultCase::None,
+            DefaultCase::Null => DefaultCase::Null,
+            DefaultCase::Many { exprs, last_expr } => DefaultCase::Many {
+                exprs: exprs.into_iter().map(ImutExprInt::into_static).collect(),
+                last_expr: Box::new(last_expr.into_static()),
+            },
+            DefaultCase::One(e) => DefaultCase::One(e.into_static()),
+        }
+    }
+}
+
+impl<'script> DefaultCase<Expr<'script>> {
+    pub(crate) fn into_static(self) -> DefaultCase<Expr<'static>> {
+        match self {
+            DefaultCase::None => DefaultCase::None,
+            DefaultCase::Null => DefaultCase::Null,
+            DefaultCase::Many { exprs, last_expr } => DefaultCase::Many {
+                exprs: exprs.into_iter().map(Expr::into_static).collect(),
+                last_expr: Box::new(last_expr.into_static()),
+            },
+            DefaultCase::One(e) => DefaultCase::One(e.into_static()),
+        }
+    }
+}
+
+impl<'script> Comprehension<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> Comprehension<'static, ImutExprInt<'static>> {
+        let Comprehension {
+            mid,
+            key_id,
+            val_id,
+            target,
+            cases,
+        } = self;
+        Comprehension {
+            mid,
+            key_id,
+            val_id,
+            target: target.into_static(),
+            cases: cases
+                .into_iter()
+                .map(ComprehensionCase::<ImutExprInt>::into_static)
+                .collect(),
+        }
+    }
+}
+impl<'script> Comprehension<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> Comprehension<'static, Expr<'static>> {
+        let Comprehension {
+            mid,
+            key_id,
+            val_id,
+            target,
+            cases,
+        } = self;
+        Comprehension {
+            mid,
+            key_id,
+            val_id,
+            target: target.into_static(),
+            cases: cases
+                .into_iter()
+                .map(ComprehensionCase::<Expr>::into_static)
+                .collect(),
+        }
+    }
+}
+
+impl<'script> ComprehensionCase<'script, ImutExprInt<'script>> {
+    pub(crate) fn into_static(self) -> ComprehensionCase<'static, ImutExprInt<'static>> {
+        let ComprehensionCase {
+            mid,
+            key_name,
+            value_name,
+            guard,
+            exprs,
+            last_expr,
+        } = self;
+        ComprehensionCase {
+            mid,
+            key_name: Cow::owned(key_name.to_string()),
+            value_name: Cow::owned(value_name.to_string()),
+            guard: guard.map(ImutExprInt::into_static),
+            exprs: exprs.into_iter().map(ImutExprInt::into_static).collect(),
+            last_expr: last_expr.into_static(),
+        }
+    }
+}
+
+impl<'script> ComprehensionCase<'script, Expr<'script>> {
+    pub(crate) fn into_static(self) -> ComprehensionCase<'static, Expr<'static>> {
+        let ComprehensionCase {
+            mid,
+            key_name,
+            value_name,
+            guard,
+            exprs,
+            last_expr,
+        } = self;
+        ComprehensionCase {
+            mid,
+            key_name: Cow::owned(key_name.to_string()),
+            value_name: Cow::owned(value_name.to_string()),
+            guard: guard.map(ImutExprInt::into_static),
+            exprs: exprs.into_iter().map(Expr::into_static).collect(),
+            last_expr: last_expr.into_static(),
+        }
+    }
+}
+
+impl<'script> StringLit<'script> {
+    pub(crate) fn into_static(self) -> StringLit<'static> {
+        let StringLit { mid, elements } = self;
+        StringLit {
+            mid,
+            elements: elements
+                .into_iter()
+                .map(StrLitElement::into_static)
+                .collect(),
+        }
+    }
+}
+
+impl<'script> StrLitElement<'script> {
+    pub(crate) fn into_static(self) -> StrLitElement<'static> {
+        match self {
+            StrLitElement::Lit(e) => StrLitElement::Lit(Cow::owned(e.to_string())),
+            StrLitElement::Expr(e) => StrLitElement::Expr(e.into_static()),
+        }
+    }
+}
+
+impl<'script> Bytes<'script> {
+    pub(crate) fn into_static(self) -> Bytes<'static> {
+        let Bytes { mid, value } = self;
+        Bytes {
+            mid,
+            value: value.into_iter().map(BytesPart::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> BytesPart<'script> {
+    pub(crate) fn into_static(self) -> BytesPart<'static> {
+        let BytesPart {
+            mid,
+            data,
+            data_type,
+            endianess,
+            bits,
+        } = self;
+        BytesPart {
+            mid,
+            data: data.into_static(),
+            data_type,
+            endianess,
+            bits,
+        }
+    }
+}
+
+impl<'script> LocalPath<'script> {
+    pub(crate) fn into_static(self) -> LocalPath<'static> {
+        let LocalPath {
+            idx,
+            is_const,
+            mid,
+            segments,
+        } = self;
+        LocalPath {
+            idx,
+            is_const,
+            mid,
+            segments: segments.into_iter().map(Segment::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> EventPath<'script> {
+    pub(crate) fn into_static(self) -> EventPath<'static> {
+        let EventPath { mid, segments } = self;
+        EventPath {
+            mid,
+            segments: segments.into_iter().map(Segment::into_static).collect(),
+        }
+    }
+}
+impl<'script> StatePath<'script> {
+    pub(crate) fn into_static(self) -> StatePath<'static> {
+        let StatePath { mid, segments } = self;
+        StatePath {
+            mid,
+            segments: segments.into_iter().map(Segment::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> MetadataPath<'script> {
+    pub(crate) fn into_static(self) -> MetadataPath<'static> {
+        let MetadataPath { mid, segments } = self;
+        MetadataPath {
+            mid,
+            segments: segments.into_iter().map(Segment::into_static).collect(),
+        }
+    }
+}
+
+impl<'script> ReservedPath<'script> {
+    pub(crate) fn into_static(self) -> ReservedPath<'static> {
+        match self {
+            ReservedPath::Args { mid, segments } => ReservedPath::Args {
+                mid,
+                segments: segments.into_iter().map(Segment::into_static).collect(),
+            },
+            ReservedPath::Window { mid, segments } => ReservedPath::Window {
+                mid,
+                segments: segments.into_iter().map(Segment::into_static).collect(),
+            },
+            ReservedPath::Group { mid, segments } => ReservedPath::Group {
+                mid,
+                segments: segments.into_iter().map(Segment::into_static).collect(),
+            },
+        }
+    }
+}
+impl<'script> Segment<'script> {
+    pub(crate) fn into_static(self) -> Segment<'static> {
+        match self {
+            Segment::Id { key, mid } => Segment::Id {
+                key: key.into_static(),
+                mid,
+            },
+            Segment::Idx { idx, mid } => Segment::Idx { idx, mid },
+            Segment::Element { expr, mid } => Segment::Element {
+                expr: expr.into_static(),
+                mid,
+            },
+            Segment::Range {
+                lower_mid,
+                upper_mid,
+                mid,
+                range_start,
+                range_end,
+            } => Segment::Range {
+                lower_mid,
+                upper_mid,
+                mid,
+                range_start: Box::new(range_start.into_static()),
+                range_end: Box::new(range_end.into_static()),
+            },
+        }
+    }
+}
+
+impl<'script> EmitExpr<'script> {
+    pub(crate) fn into_static(self) -> EmitExpr<'static> {
+        let EmitExpr { mid, expr, port } = self;
+        EmitExpr {
+            mid,
+            expr: expr.into_static(),
+            port: port.map(ImutExprInt::into_static),
+        }
+    }
+}
+
+impl<'script> Field<'script> {
+    pub(crate) fn into_static(self) -> Field<'static> {
+        let Field { mid, name, value } = self;
+        Field {
+            mid,
+            name: name.into_static(),
+            value: value.into_static(),
+        }
+    }
+}
+
+impl<'script> PatchOperation<'script> {
+    pub(crate) fn into_static(self) -> PatchOperation<'static> {
+        match self {
+            PatchOperation::Insert { ident, expr } => PatchOperation::Insert {
+                ident: ident.into_static(),
+                expr: expr.into_static(),
+            },
+            PatchOperation::Upsert { ident, expr } => PatchOperation::Upsert {
+                ident: ident.into_static(),
+                expr: expr.into_static(),
+            },
+            PatchOperation::Update { ident, expr } => PatchOperation::Update {
+                ident: ident.into_static(),
+                expr: expr.into_static(),
+            },
+            PatchOperation::Erase { ident } => PatchOperation::Erase {
+                ident: ident.into_static(),
+            },
+            PatchOperation::Copy { from, to } => PatchOperation::Copy {
+                from: from.into_static(),
+                to: to.into_static(),
+            },
+            PatchOperation::Move { from, to } => PatchOperation::Move {
+                from: from.into_static(),
+                to: to.into_static(),
+            },
+            PatchOperation::Merge { ident, expr } => PatchOperation::Merge {
+                ident: ident.into_static(),
+                expr: expr.into_static(),
+            },
+            PatchOperation::TupleMerge { expr } => PatchOperation::TupleMerge {
+                expr: expr.into_static(),
+            },
+        }
+    }
+}
+
+impl<'script> ClausePreCondition<'script> {
+    pub(crate) fn into_static(self) -> ClausePreCondition<'static> {
+        let ClausePreCondition { path } = self;
+        ClausePreCondition {
+            path: path.into_static(),
+        }
+    }
+}
+
+impl<'script> Pattern<'script> {
+    pub(crate) fn into_static(self) -> Pattern<'static> {
+        match self {
+            Pattern::Record(e) => Pattern::Record(e.into_static()),
+            Pattern::Array(e) => Pattern::Array(e.into_static()),
+            Pattern::Expr(e) => Pattern::Expr(e.into_static()),
+            Pattern::Assign(e) => Pattern::Assign(e.into_static()),
+            Pattern::Tuple(e) => Pattern::Tuple(e.into_static()),
+            Pattern::Extract(e) => Pattern::Extract(e),
+            Pattern::DoNotCare => Pattern::DoNotCare,
+            Pattern::Default => Pattern::Default,
+        }
+    }
+}
+
+impl<'script> RecordPattern<'script> {
+    pub(crate) fn into_static(self) -> RecordPattern<'static> {
+        let RecordPattern { mid, fields } = self;
+        RecordPattern {
+            mid,
+            fields: fields
+                .into_iter()
+                .map(PredicatePattern::into_static)
+                .collect(),
+        }
+    }
+}
+
+impl<'script> ArrayPattern<'script> {
+    pub(crate) fn into_static(self) -> ArrayPattern<'static> {
+        let ArrayPattern { mid, exprs } = self;
+        ArrayPattern {
+            mid,
+            exprs: exprs
+                .into_iter()
+                .map(ArrayPredicatePattern::into_static)
+                .collect(),
+        }
+    }
+}
+
+impl<'script> AssignPattern<'script> {
+    pub(crate) fn into_static(self) -> AssignPattern<'static> {
+        let AssignPattern { id, idx, pattern } = self;
+        AssignPattern {
+            id: Cow::owned(id.to_string()),
+            idx,
+            pattern: Box::new(pattern.into_static()),
+        }
+    }
+}
+
+impl<'script> TuplePattern<'script> {
+    pub(crate) fn into_static(self) -> TuplePattern<'static> {
+        let TuplePattern { mid, exprs, open } = self;
+        TuplePattern {
+            mid,
+            exprs: exprs
+                .into_iter()
+                .map(ArrayPredicatePattern::into_static)
+                .collect(),
+            open,
+        }
+    }
+}
+
+impl<'script> PredicatePattern<'script> {
+    pub(crate) fn into_static(self) -> PredicatePattern<'static> {
+        match self {
+            PredicatePattern::TildeEq {
+                assign,
+                lhs,
+                key,
+                test,
+            } => PredicatePattern::TildeEq {
+                assign: Cow::owned(assign.to_string()),
+                lhs: Cow::owned(lhs.to_string()),
+                key: key.into_static(),
+                test,
+            },
+            PredicatePattern::Bin {
+                lhs,
+                key,
+                rhs,
+                kind,
+            } => PredicatePattern::Bin {
+                lhs: Cow::owned(lhs.to_string()),
+                key: key.into_static(),
+                rhs: rhs.into_static(),
+                kind,
+            },
+            PredicatePattern::RecordPatternEq { lhs, key, pattern } => {
+                PredicatePattern::RecordPatternEq {
+                    lhs: Cow::owned(lhs.to_string()),
+                    key: key.into_static(),
+                    pattern: pattern.into_static(),
+                }
+            }
+            PredicatePattern::ArrayPatternEq { lhs, key, pattern } => {
+                PredicatePattern::ArrayPatternEq {
+                    lhs: Cow::owned(lhs.to_string()),
+                    key: key.into_static(),
+                    pattern: pattern.into_static(),
+                }
+            }
+            PredicatePattern::FieldPresent { lhs, key } => PredicatePattern::FieldPresent {
+                lhs: Cow::owned(lhs.to_string()),
+                key: key.into_static(),
+            },
+            PredicatePattern::FieldAbsent { lhs, key } => PredicatePattern::FieldAbsent {
+                lhs: Cow::owned(lhs.to_string()),
+                key: key.into_static(),
+            },
+        }
+    }
+}
+
+impl<'script> ArrayPredicatePattern<'script> {
+    pub(crate) fn into_static(self) -> ArrayPredicatePattern<'static> {
+        match self {
+            ArrayPredicatePattern::Expr(e) => ArrayPredicatePattern::Expr(e.into_static()),
+            ArrayPredicatePattern::Tilde(e) => ArrayPredicatePattern::Tilde(e),
+            ArrayPredicatePattern::Record(e) => ArrayPredicatePattern::Record(e.into_static()),
+            ArrayPredicatePattern::Ignore => ArrayPredicatePattern::Ignore,
+        }
+    }
+}

--- a/tremor-script/src/ast/visitors.rs
+++ b/tremor-script/src/ast/visitors.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod impl
 use super::{base_expr::BaseExpr, ClauseGroup, Comprehension};
 use super::{eq::AstEq, PredicateClause};
 use super::{
@@ -812,7 +811,8 @@ mod tests {
             })
             .cloned()
             .last()
-            .unwrap().into_static();
+            .unwrap()
+            .into_static();
         let mut visitor = Find42Visitor::default();
         visitor.walk_expr(&mut imut_expr)?;
         assert_eq!(

--- a/tremor-script/src/ast/visitors.rs
+++ b/tremor-script/src/ast/visitors.rs
@@ -157,7 +157,7 @@ pub trait ImutExprIntVisitor<'script> {
         &mut self,
         precondition: &mut super::ClausePreCondition<'script>,
     ) -> Result<()> {
-        for segment in &mut precondition.segments {
+        for segment in precondition.path.segments_mut() {
             self.walk_segment(segment)?;
         }
         Ok(())

--- a/tremor-script/src/ast/visitors.rs
+++ b/tremor-script/src/ast/visitors.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod impl
 use super::{base_expr::BaseExpr, ClauseGroup, Comprehension};
 use super::{eq::AstEq, PredicateClause};
 use super::{
@@ -811,7 +812,7 @@ mod tests {
             })
             .cloned()
             .last()
-            .unwrap();
+            .unwrap().into_static();
         let mut visitor = Find42Visitor::default();
         visitor.walk_expr(&mut imut_expr)?;
         assert_eq!(

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -585,16 +585,17 @@ where
                 subrange = None;
 
                 current = key.lookup(current).ok_or_else(|| {
-                    if let Some(o) = current.as_object() {
-                        let key = env.meta.name_dflt(*mid).to_string();
-                        let options = o.keys().map(ToString::to_string).collect();
-                        error_bad_key_err(
-                            outer, segment, //&Expr::dummy(*start, *end),
-                            &path, key, options, &env.meta,
-                        )
-                    } else {
-                        error_need_obj_err(outer, segment, current.value_type(), &env.meta)
-                    }
+                    current.as_object().map_or_else(
+                        || error_need_obj_err(outer, segment, current.value_type(), &env.meta),
+                        |o| {
+                            let key = env.meta.name_dflt(*mid).to_string();
+                            let options = o.keys().map(ToString::to_string).collect();
+                            error_bad_key_err(
+                                outer, segment, //&Expr::dummy(*start, *end),
+                                &path, key, options, &env.meta,
+                            )
+                        },
+                    )
                 })?;
                 continue;
             }
@@ -1124,6 +1125,7 @@ where
 /// A record pattern matches a target if the target is a record that contains **at least all
 /// declared keys** and the tests for **each of the declared key** match.
 #[inline]
+#[allow(clippy::clippy::too_many_lines)]
 fn match_rp_expr<'event, 'script, Expr>(
     outer: &Expr,
     opts: ExecOpts,

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -1120,7 +1120,7 @@ where
 /// A record pattern matches a target if the target is a record that contains **at least all
 /// declared keys** and the tests for **each of the declared key** match.
 #[inline]
-#[allow(clippy::clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 fn match_rp_expr<'event, Expr>(
     outer: &Expr,
     opts: ExecOpts,

--- a/tremor-script/src/interpreter/expr.rs
+++ b/tremor-script/src/interpreter/expr.rs
@@ -85,7 +85,7 @@ impl<'script> Expr<'script> {
 
     #[inline]
     #[allow(clippy::too_many_lines)]
-    fn match_expr(
+    fn match_expr<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event>,

--- a/tremor-script/src/interpreter/expr.rs
+++ b/tremor-script/src/interpreter/expr.rs
@@ -63,13 +63,9 @@ macro_rules! demit {
     };
 }
 
-impl<'script, 'event, 'run> Expr<'script>
-where
-    'script: 'event,
-    'event: 'run,
-{
+impl<'script> Expr<'script> {
     #[inline]
-    pub(crate) fn execute_effectors(
+    pub(crate) fn execute_effectors<'run, 'event>(
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
         event: &'run mut Value<'event>,
@@ -191,7 +187,7 @@ where
     }
 
     #[inline]
-    fn if_expr(
+    fn if_expr<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -223,8 +219,7 @@ where
         }
     }
 
-    fn patch_in_place(
-        &'run self,
+    fn patch_in_place<'run, 'event>(
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
         event: &'run Value<'event>,
@@ -283,7 +278,7 @@ where
         Ok(value)
     }
 
-    fn merge_in_place(
+    fn merge_in_place<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -323,7 +318,7 @@ where
     }
 
     // TODO: Quite some overlap with `ImutExprInt::comprehension`
-    fn comprehension(
+    fn comprehension<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -387,7 +382,7 @@ where
     }
 
     #[inline]
-    fn assign(
+    fn assign<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -407,7 +402,7 @@ where
 
     // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1033
     #[allow(mutable_transmutes, clippy::transmute_ptr_to_ptr)]
-    fn assign_nested(
+    fn assign_nested<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -519,7 +514,7 @@ where
         }
     }
 
-    fn assign_direct(
+    fn assign_direct<'run, 'event>(
         &'run self,
         _opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -575,7 +570,7 @@ where
     ///
     /// # Errors
     /// if evaluation fails
-    pub fn run(
+    pub fn run<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -655,9 +650,9 @@ where
             Expr::MergeInPlace(ref expr) => self
                 .merge_in_place(opts, env, event, state, meta, local, expr)
                 .map(Cont::Cont),
-            Expr::PatchInPlace(ref expr) => self
-                .patch_in_place(opts, env, event, state, meta, local, expr)
-                .map(Cont::Cont),
+            Expr::PatchInPlace(ref expr) => {
+                Self::patch_in_place(opts, env, event, state, meta, local, expr).map(Cont::Cont)
+            }
             Expr::Comprehension(ref expr) => {
                 self.comprehension(opts, env, event, state, meta, local, expr)
             }

--- a/tremor-script/src/interpreter/expr.rs
+++ b/tremor-script/src/interpreter/expr.rs
@@ -660,7 +660,7 @@ impl<'script> Expr<'script> {
                 // If we don't need the result of a immutable value then we
                 // don't need to evaluate it.
                 let r = if opts.result_needed {
-                    expr.run(opts, env, event, state, meta, local)?
+                    stry!(expr.run(opts, env, event, state, meta, local))
                 } else {
                     Cow::Borrowed(&NULL)
                 };

--- a/tremor-script/src/interpreter/imut_expr.rs
+++ b/tremor-script/src/interpreter/imut_expr.rs
@@ -250,7 +250,7 @@ impl<'script> ImutExprInt<'script> {
                 self.invoke(opts, env, event, state, meta, local, call)
             }
             ImutExprInt::InvokeAggr(ref call) => self.emit_aggr(opts, env, call),
-            ImutExprInt::Patch(ref expr) => self.patch(opts, env, event, state, meta, local, expr),
+            ImutExprInt::Patch(ref expr) => Self::patch(opts, env, event, state, meta, local, expr),
             ImutExprInt::Merge(ref expr) => self.merge(opts, env, event, state, meta, local, expr),
             ImutExprInt::Local {
                 idx,
@@ -766,7 +766,6 @@ impl<'script> ImutExprInt<'script> {
     }
 
     fn patch<'run, 'event>(
-        &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
         event: &'run Value<'event>,
@@ -785,7 +784,7 @@ impl<'script> ImutExprInt<'script> {
     }
 
     fn merge<'run, 'event>(
-        &'run self,
+        &self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
         event: &'run Value<'event>,

--- a/tremor-script/src/interpreter/imut_expr.rs
+++ b/tremor-script/src/interpreter/imut_expr.rs
@@ -43,17 +43,13 @@ use std::borrow::Cow;
 use std::mem;
 use std::{borrow::Borrow, iter};
 
-impl<'run, 'event, 'script> ImutExpr<'script>
-where
-    'script: 'event,
-    'event: 'run,
-{
+impl<'script> ImutExpr<'script> {
     /// Evaluates the expression
     ///
     /// # Errors
     /// if evaluation fails
     #[inline]
-    pub fn run(
+    pub fn run<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -65,11 +61,8 @@ where
         self.0.run(opts, env, event, state, meta, local)
     }
 }
-impl<'run, 'event, 'script> ImutExprInt<'script>
-where
-    'script: 'event,
-    'event: 'run,
-{
+
+impl<'script> ImutExprInt<'script> {
     /// Checks if the expression is a literal expression
     #[inline]
     #[must_use]
@@ -82,14 +75,14 @@ where
     /// if the resulting value can not be represented as a str or the evaluation fails
 
     #[inline]
-    pub fn eval_to_string(
-        &'run self,
+    pub fn eval_to_string<'event>(
+        &self,
         opts: ExecOpts,
-        env: &'run Env<'run, 'event, 'script>,
-        event: &'run Value<'event>,
-        state: &'run Value<'static>,
-        meta: &'run Value<'event>,
-        local: &'run LocalStack<'event>,
+        env: &Env<'_, 'event, '_>,
+        event: &Value<'event>,
+        state: &Value<'static>,
+        meta: &Value<'event>,
+        local: &LocalStack<'event>,
     ) -> Result<beef::Cow<'event, str>> {
         let value = stry!(self.run(opts, env, event, state, meta, local));
         value.as_str().map_or_else(
@@ -107,16 +100,16 @@ where
     /// # Errors
     /// if the resulting value can not be represented as a usize or the evaluation fails
     #[inline]
-    pub fn eval_to_index<Expr>(
-        &'run self,
-        outer: &'run Expr,
+    pub fn eval_to_index<'event, Expr>(
+        &self,
+        outer: &Expr,
         opts: ExecOpts,
-        env: &'run Env<'run, 'event, 'script>,
-        event: &'run Value<'event>,
-        state: &'run Value<'static>,
-        meta: &'run Value<'event>,
-        local: &'run LocalStack<'event>,
-        path: &'run Path<'script>,
+        env: &Env<'_, 'event, '_>,
+        event: &Value<'event>,
+        state: &Value<'static>,
+        meta: &Value<'event>,
+        local: &LocalStack<'event>,
+        path: &Path<'script>,
         array: &[Value],
     ) -> Result<usize>
     where
@@ -132,7 +125,7 @@ where
     ///
     /// # Errors
     /// on any runtime error
-    pub fn run(
+    pub fn run<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -296,7 +289,7 @@ where
         }
     }
 
-    fn comprehension(
+    fn comprehension<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -364,7 +357,7 @@ where
     }
 
     #[inline]
-    fn execute_effectors(
+    fn execute_effectors<'run, 'event>(
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
         event: &'run Value<'event>,
@@ -377,7 +370,7 @@ where
     }
 
     #[allow(clippy::too_many_lines)]
-    fn match_expr(
+    fn match_expr<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -482,7 +475,7 @@ where
         }
     }
 
-    fn binary(
+    fn binary<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -497,7 +490,7 @@ where
         exec_binary(self, expr, &env.meta, expr.kind, &lhs, &rhs)
     }
 
-    fn unary(
+    fn unary<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -516,7 +509,7 @@ where
     }
 
     // TODO: Quite some overlap with `interpreter::resolve` (and some with `expr::assign`)
-    fn present(
+    fn present<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -634,7 +627,7 @@ where
     }
 
     // TODO: Can we convince Rust to generate the 3 or 4 versions of this method from one template?
-    fn invoke1(
+    fn invoke1<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -656,7 +649,7 @@ where
             })
     }
 
-    fn invoke2(
+    fn invoke2<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -679,7 +672,7 @@ where
             })
     }
 
-    fn invoke3(
+    fn invoke3<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -710,7 +703,7 @@ where
             })
     }
 
-    fn invoke(
+    fn invoke<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -739,7 +732,7 @@ where
             })
     }
 
-    fn emit_aggr(
+    fn emit_aggr<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -772,7 +765,7 @@ where
         Ok(r)
     }
 
-    fn patch(
+    fn patch<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,
@@ -791,7 +784,7 @@ where
         Ok(Cow::Owned(value))
     }
 
-    fn merge(
+    fn merge<'run, 'event>(
         &'run self,
         opts: ExecOpts,
         env: &'run Env<'run, 'event, 'script>,

--- a/tremor-script/src/registry/custom_fn.rs
+++ b/tremor-script/src/registry/custom_fn.rs
@@ -133,7 +133,7 @@ impl<'script> CustomFn<'script> {
     #[allow(mutable_transmutes, clippy::transmute_ptr_to_ptr)]
     pub(crate) fn invoke<'event>(
         &self,
-        env: &Env<'_, 'event, '_>,
+        env: &Env<'_, 'event>,
         args: &[&Value<'event>],
     ) -> FResult<Value<'event>>
     where

--- a/tremor-script/src/registry/custom_fn.rs
+++ b/tremor-script/src/registry/custom_fn.rs
@@ -131,14 +131,13 @@ impl<'script> CustomFn<'script> {
 
     // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1028
     #[allow(mutable_transmutes, clippy::transmute_ptr_to_ptr)]
-    pub(crate) fn invoke<'event, 'run>(
-        &'script self,
-        env: &'run Env<'run, 'event, 'script>,
-        args: &'run [&'run Value<'event>],
+    pub(crate) fn invoke<'event>(
+        &self,
+        env: &Env<'_, 'event, '_>,
+        args: &[&Value<'event>],
     ) -> FResult<Value<'event>>
     where
         'script: 'event,
-        'event: 'run,
     {
         use std::mem;
         const NO_AGGRS: [InvokeAggrFn<'static>; 0] = [];
@@ -152,7 +151,7 @@ impl<'script> CustomFn<'script> {
 
         // We are swapping out the var args for constants
         // ALLOW: https://github.com/tremor-rs/tremor-runtime/issues/1028
-        let consts: &'run mut Consts<'event> = unsafe { mem::transmute(env.consts) };
+        let consts: &mut Consts<'event> = unsafe { mem::transmute(env.consts) };
 
         mem::swap(&mut consts.args, &mut args_const);
 

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -85,11 +85,7 @@ rental! {
     }
 }
 
-impl<'run, 'event, 'script> Script
-where
-    'script: 'event,
-    'event: 'run,
-{
+impl Script {
     /// Parses a string and turns it into a script
     ///
     /// # Errors
@@ -289,14 +285,17 @@ where
     ///
     /// # Errors
     /// if the script fails to run for the given context, event state and metadata
-    pub fn run(
-        &'script self,
+    pub fn run<'run, 'event>(
+        &'event self,
         context: &'run EventContext,
         aggr: AggrType,
         event: &'run mut Value<'event>,
         state: &'run mut Value<'static>,
         meta: &'run mut Value<'event>,
-    ) -> Result<Return<'event>> {
+    ) -> Result<Return<'event>>
+    where
+        'event: 'run,
+    {
         self.script.suffix().run(context, aggr, event, state, meta)
     }
 }

--- a/tremor-value/src/known_key.rs
+++ b/tremor-value/src/known_key.rs
@@ -280,8 +280,9 @@ impl<'key> KnownKey<'key> {
         'value: 'target,
         F: FnOnce() -> Value<'value>,
     {
+        let key: &str = &self.key;
         map.raw_entry_mut()
-            .from_key_hashed_nocheck(self.hash, &self.key)
+            .from_key_hashed_nocheck(self.hash, key)
             .or_insert_with(|| (self.key.clone(), with()))
             .1
     }
@@ -368,7 +369,7 @@ impl<'key> KnownKey<'key> {
     {
         match map
             .raw_entry_mut()
-            .from_key_hashed_nocheck(self.hash, &self.key)
+            .from_key_hashed_nocheck(self.hash, self.key())
         {
             RawEntryMut::Occupied(mut e) => Some(e.insert(value)),
             RawEntryMut::Vacant(e) => {

--- a/tremor-value/src/known_key.rs
+++ b/tremor-value/src/known_key.rs
@@ -382,6 +382,7 @@ impl<'key> KnownKey<'key> {
 
 impl<'script> KnownKey<'script> {
     /// turns the key into one with static lifetime
+    #[must_use]
     pub fn into_static(self) -> KnownKey<'static> {
         let KnownKey { key, hash } = self;
         KnownKey {

--- a/tremor-value/src/known_key.rs
+++ b/tremor-value/src/known_key.rs
@@ -64,7 +64,7 @@ impl<'key> KnownKey<'key> {
     /// The known key
     #[inline]
     #[must_use]
-    pub fn key(&self) -> &Cow<'key, str> {
+    pub fn key(&self) -> &str {
         &self.key
     }
 
@@ -87,7 +87,6 @@ impl<'key> KnownKey<'key> {
         target: &'target Value<'value>,
     ) -> Option<&'target Value<'value>>
     where
-        'key: 'value,
         'value: 'target,
     {
         target.as_object().and_then(|m| self.map_lookup(m))
@@ -114,11 +113,10 @@ impl<'key> KnownKey<'key> {
         map: &'target halfbrown::HashMap<Cow<'value, str>, Value<'value>>,
     ) -> Option<&'target Value<'value>>
     where
-        'key: 'value,
         'value: 'target,
     {
         map.raw_entry()
-            .from_key_hashed_nocheck(self.hash, &self.key)
+            .from_key_hashed_nocheck(self.hash, self.key())
             .map(|kv| kv.1)
     }
 

--- a/tremor-value/src/known_key.rs
+++ b/tremor-value/src/known_key.rs
@@ -380,6 +380,17 @@ impl<'key> KnownKey<'key> {
     }
 }
 
+impl<'script> KnownKey<'script> {
+    /// turns the key into one with static lifetime
+    pub fn into_static(self) -> KnownKey<'static> {
+        let KnownKey { key, hash } = self;
+        KnownKey {
+            key: Cow::owned(key.to_string()),
+            hash,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unnecessary_operation, clippy::non_ascii_literal)]
@@ -470,8 +481,7 @@ mod tests {
 
     #[test]
     fn known_key_get_key() {
-        let key1 = KnownKey::from("snot");
-
+        let key1 = KnownKey::from("snot").into_static();
         assert_eq!(key1.key(), "snot");
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR reduces the use of the `'script` lifetime in the interpreter, this simplifies the logic a bit and allows some cleanup along the path.

There should not be any functional changes here.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no difference outside of run to run varriance