### PR TITLE
Update git linked crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "surf-sse"
 version = "1.0.0"
-source = "git+https://github.com/dak-x/surf-sse?branch=default#c7a7d5d989c3cbde1922f52cee4824f771caf9b0"
+source = "git+https://github.com/dak-x/surf-sse?tag=2.0#c7a7d5d989c3cbde1922f52cee4824f771caf9b0"
 dependencies = [
  "futures-core",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 tide = "0.16"
 
 # sse-onramp
-# sse onramp
-surf-sse = {git = "https://github.com/dak-x/surf-sse", branch = "default"}
+surf-sse = {git = "https://github.com/dak-x/surf-sse", tag = "2.0"}
 
 # nats
 async-nats = "0.9.18"


### PR DESCRIPTION
update the git linked crate surf-sse to a released branch.

Signed-off-by: Daksh Chauhan <dak-x@outlook.com>

# Pull request

## Description
Update surf-sse to point to a **tagged** git linked crate.
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: #1065 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [X] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [X] The code is tested
* [X] Use of unsafe code is reasoned about in a comment
* [X] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [X] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->
r? @mfelsche 

