### PR TITLE
Add option "raw" to "tremor-cli dbg" subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Add tests for patch feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
 - Add onramp for SSE (Server Sent Events) [#885](https://github.com/tremor-rs/tremor-runtime/issues/885)
-
+- Add raw flag in tremor-cli dbg [#854](https://github.com/tremor-rs/tremor-runtime/issues/854)
 ### Fixes
 
 - Fix the Release archive and package build process

--- a/tremor-cli/src/cli.yaml
+++ b/tremor-cli/src/cli.yaml
@@ -137,6 +137,10 @@ subcommands:
             help: do not highlight output
             short: n
             long: no-highlight
+        - raw:
+            help: do not output any formatting. Disables highlight, banner, line numbers.
+            short: r
+            long: raw
       subcommands:
         - dot:
             about: prints the .dot representation for a trickle file (you can use `| dot -Tpng -oout.png` to generate a picture)

--- a/tremor-cli/src/debug.rs
+++ b/tremor-cli/src/debug.rs
@@ -30,6 +30,7 @@ use tremor_script::script::Script;
 
 struct Opts<'src> {
     banner: bool,
+    raw_output: bool,
     kind: SourceKind,
     src: &'src str,
     raw: String,
@@ -59,8 +60,8 @@ where
 {
     banner(h, opts, "Source", "Source code listing")?;
     match &opts.kind {
-        SourceKind::Tremor | SourceKind::Json => Script::highlight_script_with(&opts.raw, h)?,
-        SourceKind::Trickle => Query::highlight_script_with(&opts.raw, h)?,
+        SourceKind::Tremor | SourceKind::Json => Script::highlight_script_with(&opts.raw, h, !&opts.raw_output)?,
+        SourceKind::Trickle => Query::highlight_script_with(&opts.raw, h,!opts.raw_output)?,
         SourceKind::Yaml => error!("Unsupported: yaml"),
         SourceKind::Unsupported(Some(t)) => error!("Unsupported: {}", t),
         SourceKind::Unsupported(None) => error!("Unsupported: no file type"),
@@ -217,7 +218,7 @@ where
                         simd_json::to_string_pretty(&runnable.script.suffix())?
                     };
                     println!();
-                    Script::highlight_script_with(&ast, h)?;
+                    Script::highlight_script_with(&ast, h,!opts.raw_output)?;
                 }
                 Err(e) => {
                     if let Err(e) = Script::format_error_from_script(&opts.raw, h, &e) {
@@ -238,7 +239,7 @@ where
                 Ok(runnable) => {
                     let ast = simd_json::to_string_pretty(&runnable.query.suffix())?;
                     println!();
-                    Script::highlight_script_with(&ast, h)?;
+                    Script::highlight_script_with(&ast, h, !opts.raw_output)?;
                 }
                 Err(e) => {
                     if let Err(e) = Script::format_error_from_script(&opts.raw, h, &e) {
@@ -257,7 +258,7 @@ where
     Ok(())
 }
 
-fn script_opts(matches: &ArgMatches, no_banner: bool) -> Result<Opts> {
+fn script_opts(matches: &ArgMatches, no_banner: bool,raw_output: bool) -> Result<Opts> {
     let src = matches.value_of("SCRIPT");
     let mut raw = String::new();
 
@@ -279,6 +280,7 @@ fn script_opts(matches: &ArgMatches, no_banner: bool) -> Result<Opts> {
     raw.push('\n'); // Ensure last token is whitespace
     let opts = Opts {
         banner: !no_banner,
+        raw_output,
         src,
         kind,
         raw,
@@ -319,26 +321,29 @@ where
 }
 
 pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
-    let no_highlight = matches.is_present("no-highlight");
-    let no_banner = matches.is_present("no-banner");
+    let raw = matches.is_present("raw");
+    // Do not highlist or put banner when raw provided raw flag.
+    let no_highlight = matches.is_present("no-highlight") || raw;
+    let no_banner = matches.is_present("no-banner") || raw;
 
+    
     if no_highlight {
         let mut h = TermNoHighlighter::new();
         let r = if let Some(args) = matches.subcommand_matches("ast") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             let exprs_only = args.is_present("exprs-only");
             dbg_ast(&mut h, &opts, exprs_only)
         } else if let Some(args) = matches.subcommand_matches("preprocess") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_pp(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("lex") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_lex(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("src") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_src(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("dot") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_dot(&mut h, &opts)
         } else {
             Err("Missing subcommand".into())
@@ -350,20 +355,20 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
     } else {
         let mut h = TermHighlighter::default();
         let r = if let Some(args) = matches.subcommand_matches("ast") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             let exprs_only = args.is_present("exprs-only");
             dbg_ast(&mut h, &opts, exprs_only)
         } else if let Some(args) = matches.subcommand_matches("preprocess") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_pp(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("lex") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_lex(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("src") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_src(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("dot") {
-            let opts = script_opts(args, no_banner)?;
+            let opts = script_opts(args, no_banner,raw)?;
             dbg_dot(&mut h, &opts)
         } else {
             Err("Missing subcommand".into())

--- a/tremor-cli/src/debug.rs
+++ b/tremor-cli/src/debug.rs
@@ -60,8 +60,10 @@ where
 {
     banner(h, opts, "Source", "Source code listing")?;
     match &opts.kind {
-        SourceKind::Tremor | SourceKind::Json => Script::highlight_script_with(&opts.raw, h, !&opts.raw_output)?,
-        SourceKind::Trickle => Query::highlight_script_with(&opts.raw, h,!opts.raw_output)?,
+        SourceKind::Tremor | SourceKind::Json => {
+            Script::highlight_script_with(&opts.raw, h, !&opts.raw_output)?
+        }
+        SourceKind::Trickle => Query::highlight_script_with(&opts.raw, h, !opts.raw_output)?,
         SourceKind::Yaml => error!("Unsupported: yaml"),
         SourceKind::Unsupported(Some(t)) => error!("Unsupported: {}", t),
         SourceKind::Unsupported(None) => error!("Unsupported: no file type"),
@@ -218,7 +220,7 @@ where
                         simd_json::to_string_pretty(&runnable.script.suffix())?
                     };
                     println!();
-                    Script::highlight_script_with(&ast, h,!opts.raw_output)?;
+                    Script::highlight_script_with(&ast, h, !opts.raw_output)?;
                 }
                 Err(e) => {
                     if let Err(e) = Script::format_error_from_script(&opts.raw, h, &e) {
@@ -258,7 +260,7 @@ where
     Ok(())
 }
 
-fn script_opts(matches: &ArgMatches, no_banner: bool,raw_output: bool) -> Result<Opts> {
+fn script_opts(matches: &ArgMatches, no_banner: bool, raw_output: bool) -> Result<Opts> {
     let src = matches.value_of("SCRIPT");
     let mut raw = String::new();
 
@@ -326,24 +328,23 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
     let no_highlight = matches.is_present("no-highlight") || raw;
     let no_banner = matches.is_present("no-banner") || raw;
 
-    
     if no_highlight {
         let mut h = TermNoHighlighter::new();
         let r = if let Some(args) = matches.subcommand_matches("ast") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             let exprs_only = args.is_present("exprs-only");
             dbg_ast(&mut h, &opts, exprs_only)
         } else if let Some(args) = matches.subcommand_matches("preprocess") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_pp(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("lex") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_lex(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("src") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_src(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("dot") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_dot(&mut h, &opts)
         } else {
             Err("Missing subcommand".into())
@@ -355,20 +356,20 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
     } else {
         let mut h = TermHighlighter::default();
         let r = if let Some(args) = matches.subcommand_matches("ast") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             let exprs_only = args.is_present("exprs-only");
             dbg_ast(&mut h, &opts, exprs_only)
         } else if let Some(args) = matches.subcommand_matches("preprocess") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_pp(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("lex") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_lex(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("src") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_src(&mut h, &opts)
         } else if let Some(args) = matches.subcommand_matches("dot") {
-            let opts = script_opts(args, no_banner,raw)?;
+            let opts = script_opts(args, no_banner, raw)?;
             dbg_dot(&mut h, &opts)
         } else {
             Err("Missing subcommand".into())

--- a/tremor-script/src/query.rs
+++ b/tremor-script/src/query.rs
@@ -162,7 +162,11 @@ where
     /// # Errors
     /// on io errors
     #[cfg(not(tarpaulin_include))]
-    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H, emit_lines:bool) -> std::io::Result<()> {
+    pub fn highlight_script_with<H: Highlighter>(
+        script: &str,
+        h: &mut H,
+        emit_lines: bool,
+    ) -> std::io::Result<()> {
         let mut script = script.to_string();
         script.push('\n');
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)

--- a/tremor-script/src/query.rs
+++ b/tremor-script/src/query.rs
@@ -162,13 +162,13 @@ where
     /// # Errors
     /// on io errors
     #[cfg(not(tarpaulin_include))]
-    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H) -> std::io::Result<()> {
+    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H, emit_lines:bool) -> std::io::Result<()> {
         let mut script = script.to_string();
         script.push('\n');
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
             .tokenize_until_err()
             .collect();
-        h.highlight(None, &tokens, "", true, None)
+        h.highlight(None, &tokens, "", emit_lines, None)
     }
 
     /// Format an error given a script source.

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -151,11 +151,11 @@ where
     /// # Errors
     /// on io errors
     #[cfg(not(tarpaulin_include))]
-    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H) -> io::Result<()> {
+    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H, emit_lines: bool) -> io::Result<()> {
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
             .tokenize_until_err()
             .collect();
-        h.highlight(None, &tokens, "", true, None)?;
+        h.highlight(None, &tokens, "", emit_lines, None)?;
         io::Result::Ok(())
     }
 

--- a/tremor-script/src/script.rs
+++ b/tremor-script/src/script.rs
@@ -151,7 +151,11 @@ where
     /// # Errors
     /// on io errors
     #[cfg(not(tarpaulin_include))]
-    pub fn highlight_script_with<H: Highlighter>(script: &str, h: &mut H, emit_lines: bool) -> io::Result<()> {
+    pub fn highlight_script_with<H: Highlighter>(
+        script: &str,
+        h: &mut H,
+        emit_lines: bool,
+    ) -> io::Result<()> {
         let tokens: Vec<_> = lexer::Tokenizer::new(&script)
             .tokenize_until_err()
             .collect();


### PR DESCRIPTION
This flag when set overrites the "no-banner", "no-highlight" flags.

Signed-off-by: Daksh Chauhan <dak-x@outlook.com>

# Pull request

## Description
I have added an extra option to `tremor-cli dbg`. It will not output any additions (banner, highlight, line_no) to the output of any of the sub-command used. (Currently line spans are output for lexeme).
  
<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #854


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [X] The code is tested
* [X] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [X] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


