### PR TITLE
Remove preprocess from cli dbg, Add option --preprocess instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@
 - Add tests for patch feature in tremor-script [#721](https://github.com/tremor-rs/tremor-runtime/issues/721)
 - Add onramp for SSE (Server Sent Events) [#885](https://github.com/tremor-rs/tremor-runtime/issues/885)
 - Add raw flag in tremor-cli dbg [#854](https://github.com/tremor-rs/tremor-runtime/issues/854)
+
 ### Fixes
 
 - Fix the Release archive and package build process
+- Replace preprocess from tremor-cli dbg with --preprocess option [#1085](https://github.com/tremor-rs/tremor-runtime/issues/1085)
 
 ## 0.11.3
 

--- a/tremor-cli/src/cli.yaml
+++ b/tremor-cli/src/cli.yaml
@@ -141,10 +141,6 @@ subcommands:
             help: do not output any formatting. Disables highlight, banner, line numbers.
             short: r
             long: raw
-        - preprocess:
-            help: output the pre-processed source. 
-            short: pp
-            long: preprocess
       subcommands:
         - dot:
             about: prints the .dot representation for a trickle file (you can use `| dot -Tpng -oout.png` to generate a picture)
@@ -165,12 +161,18 @@ subcommands:
         - lex:
             about: prints lexemes
             args:
+              - preprocess:
+                  help: output the pre-processed source.
+                  long: preprocess
               - SCRIPT:
                   help: tremor/json/trickle script filename
                   required: true
         - src:
             about: prints source
             args:
+              - preprocess:
+                  help: output the pre-processed source.
+                  long: preprocess
               - SCRIPT:
                   help: tremor/json/trickle script filename
                   required: true

--- a/tremor-cli/src/cli.yaml
+++ b/tremor-cli/src/cli.yaml
@@ -141,6 +141,10 @@ subcommands:
             help: do not output any formatting. Disables highlight, banner, line numbers.
             short: r
             long: raw
+        - preprocess:
+            help: output the pre-processed source. 
+            short: pp
+            long: preprocess
       subcommands:
         - dot:
             about: prints the .dot representation for a trickle file (you can use `| dot -Tpng -oout.png` to generate a picture)
@@ -155,12 +159,6 @@ subcommands:
                   help: only prints the expressions
                   short: x
                   long: exprs-only
-              - SCRIPT:
-                  help: tremor/json/trickle script filename
-                  required: true
-        - preprocess:
-            about: prints the preprocessed source
-            args:
               - SCRIPT:
                   help: tremor/json/trickle script filename
                   required: true


### PR DESCRIPTION
Signed-off-by: Daksh Chauhan <dak-x@outlook.com>

# Pull request

## Description
The `--preprocess` flag is added to `tremor-cli dbg` (and **not** to the two sub-cmds).

Cmd like: `tremor-cli dbg --no-banner src --preprocess <SCRIPT>` looks too clumsy (to me).

So `tremor-cli dbg --preprocess --no-banner src <SCRIPT>` is chosen.

`preprocess` cmd is removed as stated.
<!-- please add a description of what the goal of this pull request is -->

## Related
<!-- please include links to related issues are RFCs, remove if not required  -->
* Related Issues: fixes #1085 


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [X] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [X] The code is tested
* [X] Use of unsafe code is reasoned about in a comment
* [X] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [X] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


