### PR TITLE
Add zstd pre-and-postprocessor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Experimental ARM support
 - Add `default => {...}` and `default "key" => "value` to patch
+- Add `zstd` pre- and post-processors [#1100](https://github.com/tremor-rs/tremor-runtime/issues/1100)
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -2898,6 +2901,15 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -6620,6 +6632,7 @@ dependencies = [
  "url 2.2.2",
  "value-trait",
  "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -7372,4 +7385,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7b6215e7933f19dd3c5fd17ecb8b0433318ea96862925a68a8c01ad920e3b9"
 dependencies = [
  "zip",
+]
+
+[[package]]
+name = "zstd"
+version = "0.9.0+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.1+zstd.1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ tremor-script = { path="tremor-script" }
 tremor-value = { path="tremor-value" }
 url = "2.2"
 value-trait = "0.2"
+zstd = "0.9"
+
 rustls = "0.19"
 async-tls = "0.11"
 

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -69,6 +69,7 @@ pub fn lookup(name: &str) -> Result<Box<dyn Preprocessor>> {
         "ingest-ns" => Ok(Box::new(ExtractIngresTs {})),
         "length-prefixed" => Ok(Box::new(LengthPrefix::default())),
         "textual-length-prefix" => Ok(Box::new(TextualLength::default())),
+        "zstd" => Ok(Box::new(Zstd::default())),
         _ => Err(format!("Preprocessor '{}' not found.", name).into()),
     }
 }
@@ -425,6 +426,20 @@ impl Preprocessor for TextualLength {
         Ok(res)
     }
 }
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Zstd {}
+impl Preprocessor for Zstd {
+    #[cfg(not(tarpaulin_include))]
+    fn name(&self) -> &str {
+        "ztd"
+    }
+    fn process(&mut self, _ingest_ns: &mut u64, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let decoded: Vec<u8> = zstd::decode_all(data)?;
+        Ok(vec![decoded])
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Signed-off-by: Daksh Chauhan <dak-x@outlook.com>

# Pull request
Add `zstd` pre-and-postprocessors

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->


* Related Issues: closes #1100 


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [X] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [X] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


