### PR TITLE
Allow for gcp headers to be included on `uses_gcp_auth` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Update blackhole to print events / s [#1129](https://github.com/tremor-rs/tremor-runtime/issues/1129)
 - Improve soundness and documentation of SRS code.
 - Add support for concatenating arrays [#1113](https://github.com/tremor-rs/tremor-runtime/issues/1113)
-
+- Allow gcp headers to be included in `rest` offramp with `auth: gcp`
 ### Fixes
 
 - Skip instead of fail EQC on out of repo PRs

--- a/src/connectors/gcp/auth.rs
+++ b/src/connectors/gcp/auth.rs
@@ -18,46 +18,43 @@ use crate::errors::Result;
 /// in the file. The provided PEM file should be a current non-revoked and complete copy of the
 /// required certificate chain for the Google Cloud Platform.
 use gouth::Token;
+use halfbrown::HashMap;
 use reqwest::header::HeaderMap;
 use reqwest::Client;
-use halfbrown::HashMap;
 
 pub(crate) async fn authenticate_bearer() -> Result<String> {
     Ok(Token::new()?.header_value()?.to_string())
 }
 
 pub(crate) async fn json_api_client(extra_headers: &HeaderMap) -> Result<Client> {
-  let bearer = authenticate_bearer().await?;
-  let mut headers = reqwest::header::HeaderMap::new();
-  headers.insert(
-      "authorization",
-      reqwest::header::HeaderValue::from_maybe_shared(bearer)?,
-  );
-  headers.insert(
-      "content-type",
-      reqwest::header::HeaderValue::from_static("application/json"),
-  );
-  for header in extra_headers {
-      headers.append(header.0, header.1.clone());
-  }  
-  Ok(reqwest::Client::builder()
+    let bearer = authenticate_bearer().await?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "authorization",
+        reqwest::header::HeaderValue::from_maybe_shared(bearer)?,
+    );
+    headers.insert(
+        "content-type",
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+    for header in extra_headers {
+        headers.append(header.0, header.1.clone());
+    }
+    Ok(reqwest::Client::builder()
         .default_headers(headers)
         .build()?)
 }
 
-pub(crate) async fn merge_gcp_headers(extra_headers: &HashMap<String,String>) -> Result<HashMap<String, String>> {
-  let bearer = authenticate_bearer().await?;
-  let mut headers: HashMap<String,String> = halfbrown::HashMap::new();
-  headers.insert(
-      "authorization".to_string(),
-      bearer,
-  );
-  headers.insert(
-      "content-type".to_string(),
-      "application/json".to_string(),
-  );
-  for header in extra_headers { // should be a small list so clone em all, I say.
-      headers.insert(header.0.clone().to_string(), header.1.clone().to_string());
-  }
-  Ok(headers)
+pub(crate) async fn merge_gcp_headers(
+    extra_headers: &HashMap<String, String>,
+) -> Result<HashMap<String, String>> {
+    let bearer = authenticate_bearer().await?;
+    let mut headers: HashMap<String, String> = halfbrown::HashMap::new();
+    headers.insert("authorization".to_string(), bearer);
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    for header in extra_headers {
+        // should be a small list so clone em all, I say.
+        headers.insert(header.0.clone().to_string(), header.1.clone().to_string());
+    }
+    Ok(headers)
 }

--- a/src/connectors/gcp/auth.rs
+++ b/src/connectors/gcp/auth.rs
@@ -20,30 +20,44 @@ use crate::errors::Result;
 use gouth::Token;
 use reqwest::header::HeaderMap;
 use reqwest::Client;
+use halfbrown::HashMap;
 
 pub(crate) async fn authenticate_bearer() -> Result<String> {
     Ok(Token::new()?.header_value()?.to_string())
 }
 
 pub(crate) async fn json_api_client(extra_headers: &HeaderMap) -> Result<Client> {
-    Ok(reqwest::Client::builder()
-        .default_headers(make_headers(extra_headers).await?)
+  let bearer = authenticate_bearer().await?;
+  let mut headers = reqwest::header::HeaderMap::new();
+  headers.insert(
+      "authorization",
+      reqwest::header::HeaderValue::from_maybe_shared(bearer)?,
+  );
+  headers.insert(
+      "content-type",
+      reqwest::header::HeaderValue::from_static("application/json"),
+  );
+  for header in extra_headers {
+      headers.append(header.0, header.1.clone());
+  }  
+  Ok(reqwest::Client::builder()
+        .default_headers(headers)
         .build()?)
 }
 
-pub(crate) async fn make_headers(extra_headers: &HeaderMap) -> Result<HeaderMap> {
+pub(crate) async fn merge_gcp_headers(extra_headers: &HashMap<String,String>) -> Result<HashMap<String, String>> {
   let bearer = authenticate_bearer().await?;
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(
-        "authorization",
-        reqwest::header::HeaderValue::from_maybe_shared(bearer)?,
-    );
-    headers.insert(
-        "content-type",
-        reqwest::header::HeaderValue::from_static("application/json"),
-    );
-    for header in extra_headers {
-        headers.append(header.0, header.1.clone());
-    }
-    Ok(headers)
+  let mut headers: HashMap<String,String> = halfbrown::HashMap::new();
+  headers.insert(
+      "authorization".to_string(),
+      bearer,
+  );
+  headers.insert(
+      "content-type".to_string(),
+      "application/json".to_string(),
+  );
+  for header in extra_headers { // should be a small list so clone em all, I say.
+      headers.insert(header.0.clone().to_string(), header.1.clone().to_string());
+  }
+  Ok(headers)
 }

--- a/src/connectors/gcp/auth.rs
+++ b/src/connectors/gcp/auth.rs
@@ -26,7 +26,13 @@ pub(crate) async fn authenticate_bearer() -> Result<String> {
 }
 
 pub(crate) async fn json_api_client(extra_headers: &HeaderMap) -> Result<Client> {
-    let bearer = authenticate_bearer().await?;
+    Ok(reqwest::Client::builder()
+        .default_headers(make_headers(extra_headers).await?)
+        .build()?)
+}
+
+pub(crate) async fn make_headers(extra_headers: &HeaderMap) -> Result<HeaderMap> {
+  let bearer = authenticate_bearer().await?;
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         "authorization",
@@ -39,8 +45,5 @@ pub(crate) async fn json_api_client(extra_headers: &HeaderMap) -> Result<Client>
     for header in extra_headers {
         headers.append(header.0, header.1.clone());
     }
-
-    Ok(reqwest::Client::builder()
-        .default_headers(headers)
-        .build()?)
+    Ok(headers)
 }

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -535,7 +535,7 @@ async fn codec_task(
     // create token in this lifetime (ambiguous to compiler), instead of bound to the sink.
     let token = match auth {
         Some(Auth::GCP) => {
-            let (t, _) = auth::authenticate_bearer().await?;
+            let t = Token::new()?;
             Some(t)
         }
         None => None,

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -457,11 +457,9 @@ impl Sink for Rest {
         let default_method = self.config.method.0;
         let endpoint = self.config.endpoint.clone();
         let mut config_headers = self.config.headers.clone();
-        // if there is additional auth specified for sink...
-        match self.config.auth.as_str() {
-          "gcp" => config_headers = block_on(auth::merge_gcp_headers(&config_headers))?,
-          _ => (),
-        }
+        // this could be a match case if other sink auth types are introduced
+        // for now clippy doesn't like equality checks disguised as match cases.
+        if self.config.auth.as_str() == "gcp" { config_headers = block_on(auth::merge_gcp_headers(&config_headers))? }
         let cloned_sink_url = sink_url.clone();
         self.sink_url = sink_url.clone();
 

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -16,6 +16,8 @@
 
 use crate::codec::Codec;
 use crate::errors::ErrorKind;
+#[allow(unused_imports)]
+use crate::connectors::gcp::{auth};
 use crate::sink::prelude::*;
 use async_channel::{bounded, Receiver, Sender};
 use halfbrown::HashMap;
@@ -449,6 +451,9 @@ impl Sink for Rest {
             .collect::<HashMap<String, Box<dyn Codec>>>();
         let default_method = self.config.method.0;
         let endpoint = self.config.endpoint.clone();
+        #[cfg(uses_gcp_auth)]
+        let config_headers = auth::make_headers(self.config.headers.clone());
+        #[cfg(not(uses_gcp_auth))]
         let config_headers = self.config.headers.clone();
         let cloned_sink_url = sink_url.clone();
         self.sink_url = sink_url.clone();

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -15,8 +15,8 @@
 #![cfg(not(tarpaulin_include))]
 
 use crate::codec::Codec;
+use crate::connectors::gcp::auth;
 use crate::errors::ErrorKind;
-use crate::connectors::gcp::{auth};
 use crate::sink::prelude::*;
 use async_channel::{bounded, Receiver, Sender};
 use futures::executor::block_on;
@@ -459,7 +459,9 @@ impl Sink for Rest {
         let mut config_headers = self.config.headers.clone();
         // this could be a match case if other sink auth types are introduced
         // for now clippy doesn't like equality checks disguised as match cases.
-        if self.config.auth.as_str() == "gcp" { config_headers = block_on(auth::merge_gcp_headers(&config_headers))? }
+        if self.config.auth.as_str() == "gcp" {
+            config_headers = block_on(auth::merge_gcp_headers(&config_headers))?
+        }
         let cloned_sink_url = sink_url.clone();
         self.sink_url = sink_url.clone();
 

--- a/src/sink/rest.rs
+++ b/src/sink/rest.rs
@@ -15,10 +15,10 @@
 #![cfg(not(tarpaulin_include))]
 
 use crate::codec::Codec;
-use crate::connectors::gcp::auth;
 use crate::errors::ErrorKind;
 use crate::sink::prelude::*;
 use async_channel::{bounded, Receiver, Sender};
+use gouth::Token;
 use halfbrown::HashMap;
 use http_types::mime::Mime;
 use http_types::{headers::HeaderValue, Method};


### PR DESCRIPTION
# Pull request

## Description

Addresses #1081 
Will enhance usage of `rest` sinks by allowing for GCS credentials to be specified when specifying `uses_gcp_auth` feature, and specifying a credentials file with `GOOGLE_APPLICATION_CREDENTIALS` env var

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
should not have significant impact to performance.
This will only authenticate against GCP API by specific request by a user specifying the `uses_gcp_auth` option. No other performance impact should be noticeable.
