### PR TITLE
Resturcutre function args to avoid transmutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove `rental` from the entire runtime [#1037](https://github.com/tremor-rs/tremor-runtime/issues/1037)
 - Restructure operators and select to avoid transmutation [#1024](https://github.com/tremor-rs/tremor-runtime/issues/1024)
 - Fix tremor-cli to use it's own binary when possible [#1096](https://github.com/tremor-rs/tremor-runtime/issues/1096)
+- Restructure functions to avoid transmutation [#1028](https://github.com/tremor-rs/tremor-runtime/issues/1028)
 
 ### Fixes
 

--- a/tremor-cli/src/test/unit.rs
+++ b/tremor-cli/src/test/unit.rs
@@ -294,7 +294,7 @@ pub(crate) fn run_suite(
             let context = &EventContext::new(nanotime(), Some(EventOriginUri::default()));
             let env = Env {
                 context,
-                consts: &script.consts,
+                consts: script.consts.run(),
                 aggrs: &script.aggregates,
                 meta: &script.node_meta,
                 recursion_limit: tremor_script::recursion_limit(),

--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -642,7 +642,7 @@ impl Operator for TrickleSelect {
                 let (unwind_event, event_meta) = data.parts();
                 let env = Env {
                     context: &ctx,
-                    consts: &consts,
+                    consts: consts.run(),
                     aggrs: &NO_AGGRS,
                     meta: &node_meta,
                     recursion_limit: tremor_script::recursion_limit(),
@@ -682,7 +682,7 @@ impl Operator for TrickleSelect {
 
                     let env = Env {
                         context: &ctx,
-                        consts: &consts,
+                        consts: consts.run(),
                         aggrs: &NO_AGGRS,
                         meta: &node_meta,
                         recursion_limit: tremor_script::recursion_limit(),
@@ -753,7 +753,7 @@ impl Operator for TrickleSelect {
                         // evaluate select clause
                         let env = Env {
                             context: &ctx,
-                            consts: &consts,
+                            consts: consts.run(),
                             aggrs: &NO_AGGRS,
                             meta: &node_meta,
                             recursion_limit: tremor_script::recursion_limit(),
@@ -804,7 +804,7 @@ impl Operator for TrickleSelect {
                             // push
                             let env = Env {
                                 context: &ctx,
-                                consts: &consts,
+                                consts: consts.run(),
                                 aggrs: &this_group.aggrs,
                                 meta: &node_meta,
                                 recursion_limit: tremor_script::recursion_limit(),
@@ -837,7 +837,7 @@ impl Operator for TrickleSelect {
                         // accumulate the current event
                         let env = Env {
                             context: &ctx,
-                            consts: &consts,
+                            consts: consts.run(),
                             aggrs: &NO_AGGRS,
                             meta: &node_meta,
                             recursion_limit: tremor_script::recursion_limit(),
@@ -858,7 +858,7 @@ impl Operator for TrickleSelect {
                             // push
                             let env = Env {
                                 context: &ctx,
-                                consts: &consts,
+                                consts: consts.run(),
                                 aggrs: &this_group.aggrs,
                                 meta: &node_meta,
                                 recursion_limit: tremor_script::recursion_limit(),
@@ -999,7 +999,7 @@ impl Operator for TrickleSelect {
                                 // accumulate the current event
                                 let env = Env {
                                     context: &ctx,
-                                    consts: &consts,
+                                    consts: consts.run(),
                                     aggrs: &NO_AGGRS,
                                     meta: &node_meta,
                                     recursion_limit: tremor_script::recursion_limit(),
@@ -1057,7 +1057,7 @@ impl Operator for TrickleSelect {
                                     // push event
                                     let env = Env {
                                         context: &ctx,
-                                        consts: &consts,
+                                        consts: consts.run(),
                                         aggrs: &this_group.aggrs,
                                         meta: &node_meta,
                                         recursion_limit: tremor_script::recursion_limit(),
@@ -1096,7 +1096,7 @@ impl Operator for TrickleSelect {
                                     // push event
                                     let env = Env {
                                         context: &ctx,
-                                        consts: &consts,
+                                        consts: consts.run(),
                                         aggrs: &this_group.aggrs,
                                         meta: &node_meta,
                                         recursion_limit: tremor_script::recursion_limit(),
@@ -1187,7 +1187,7 @@ impl Operator for TrickleSelect {
                                     // accumulate the current event
                                     let env = Env {
                                         context: &ctx,
-                                        consts: &consts,
+                                        consts: consts.run(),
                                         aggrs: &NO_AGGRS,
                                         meta: &node_meta,
                                         recursion_limit: tremor_script::recursion_limit(),
@@ -1320,7 +1320,7 @@ impl Operator for TrickleSelect {
                                 // evaluate the event and push
                                 let env = Env {
                                     context: &ctx,
-                                    consts: &consts,
+                                    consts: consts.run(),
                                     aggrs: &group_data.aggrs,
                                     meta: &node_meta,
                                     recursion_limit: tremor_script::recursion_limit(),
@@ -1452,7 +1452,7 @@ impl Operator for TrickleSelect {
                                     // push event
                                     let env = Env {
                                         context: &ctx,
-                                        consts: &consts,
+                                        consts: consts.run(),
                                         aggrs: &this_group.aggrs,
                                         meta: &node_meta,
                                         recursion_limit: tremor_script::recursion_limit(),
@@ -1489,7 +1489,7 @@ impl Operator for TrickleSelect {
                                     // push event
                                     let env = Env {
                                         context: &ctx,
-                                        consts: &consts,
+                                        consts: consts.run(),
                                         aggrs: &this_group.aggrs,
                                         meta: &node_meta,
                                         recursion_limit: tremor_script::recursion_limit(),

--- a/tremor-pipeline/src/op/trickle/simple_select.rs
+++ b/tremor-pipeline/src/op/trickle/simple_select.rs
@@ -81,7 +81,7 @@ impl Operator for SimpleSelect {
                     let (unwind_event, event_meta) = event.data.parts();
                     let env = Env {
                         context: &ctx,
-                        consts: &consts,
+                        consts: consts.run(),
                         aggrs: &NO_AGGRS,
                         meta: &node_meta,
                         recursion_limit: tremor_script::recursion_limit(),
@@ -104,7 +104,7 @@ impl Operator for SimpleSelect {
                     let (unwind_event, event_meta) = event.data.parts();
                     let env = Env {
                         context: &ctx,
-                        consts: &consts,
+                        consts: consts.run(),
                         aggrs: &NO_AGGRS,
                         meta: &node_meta,
                         recursion_limit: tremor_script::recursion_limit(),

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -35,9 +35,9 @@ mod imut_expr;
 
 pub use self::expr::Cont;
 use crate::ast::{
-    ArrayPattern, ArrayPredicatePattern, BaseExpr, BinOpKind, Consts, GroupBy, GroupByInt,
-    ImutExprInt, InvokeAggrFn, NodeMetas, Patch, PatchOperation, Path, Pattern, PredicatePattern,
-    RecordPattern, ReservedPath, Segment, StringLit, TuplePattern, UnaryOpKind,
+    ArrayPattern, ArrayPredicatePattern, BaseExpr, BinOpKind, GroupBy, GroupByInt, ImutExprInt,
+    InvokeAggrFn, NodeMetas, Patch, PatchOperation, Path, Pattern, PredicatePattern, RecordPattern,
+    ReservedPath, RunConsts, Segment, StringLit, TuplePattern, UnaryOpKind,
 };
 use crate::errors::{
     error_array_out_of_bound, error_bad_array_index, error_bad_key, error_bad_key_err,
@@ -82,7 +82,7 @@ where
     /// Context of the event
     pub context: &'run EventContext,
     /// Constants
-    pub consts: &'run Consts<'event>,
+    pub consts: RunConsts<'run, 'event>,
     /// Aggregates
     pub aggrs: &'run [InvokeAggrFn<'event>],
     /// Node metadata
@@ -1534,7 +1534,7 @@ impl<'script> GroupByInt<'script> {
         };
         let local_stack = LocalStack::with_size(0);
         let env = Env {
-            consts: &NO_CONSTS,
+            consts: NO_CONSTS.run(),
             context: ctx,
             aggrs: &NO_AGGRS,
             meta: node_meta,


### PR DESCRIPTION
# Pull request

## Description

Remove the need for transmuting from the handling of function arguments by re-structuring the 'costs' to be referenced rather than owned values.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #1028
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

Within run to run variance of the current code.