### PR TITLE
Don't generate reports when not asked for it, closes #1072

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix some errors in otel pb <-> json translation
 - Fix windowed queries emitting events with `null` metadata on tick
 - Fix sorting for artefacts
+- Fix issde where the test framework would generate reports without being asked for it [#1072](https://github.com/tremor-rs/tremor-runtime/issues/1072)
 
 ## 0.11.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6467,7 +6467,6 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_derive",
- "serde_json",
  "serde_yaml",
  "shell-words",
  "simd-json",

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -21,8 +21,8 @@ pretty_assertions = "0.7.2"
 
 [dependencies]
 anyhow = "1"
-async-std = { version="1.9", features=["unstable"] }
-clap = { version="3.0.0-beta.2", features=["yaml", "color"] }
+async-std = { version = "1.9", features = ["unstable"] }
+clap = { version = "3.0.0-beta.2", features = ["yaml", "color"] }
 clap_generate = "3.0.0-beta.2"
 difference = "2"
 dirs-next = "2"
@@ -35,30 +35,29 @@ log4rs = "1.0.0"
 serde = "1"
 serde_derive = "1"
 serde_yaml = "0.8"
-simd-json = { version="0.4", features=["known-key"] }
+simd-json = { version = "0.4", features = ["known-key"] }
 # we need to stick with 0.2.26 as it includes its own libc
 # which allows us to build on older systems like centos 7
 # issues to track until we can loosen those restrictions:
 #   - https://github.com/microsoft/snmalloc/issues/328
 #   - https://github.com/SchrodingerZhu/snmalloc-rs/issues/145
-snmalloc-rs = { version="=0.2.26", optional=false }
-snmalloc-sys = { version="=0.2.26", optional=false }
+snmalloc-rs = { version = "=0.2.26", optional = false }
+snmalloc-sys = { version = "=0.2.26", optional = false }
 surf = "=2.2.0"
 tide = "0.16"
-tremor-api = { path="../tremor-api" }
-tremor-common = { path="../tremor-common" }
-tremor-pipeline = { path="../tremor-pipeline" }
-tremor-runtime = { path="../" }
-tremor-script = { path="../tremor-script" }
+tremor-api = { path = "../tremor-api" }
+tremor-common = { path = "../tremor-common" }
+tremor-pipeline = { path = "../tremor-pipeline" }
+tremor-runtime = { path = "../" }
+tremor-script = { path = "../tremor-script" }
 url = "2"
 # mimalloc-rs = { version = "0.1", default-features = true, optional = true }
 # allocator_api = "0.6.0"
 error-chain = "0.12"
 globwalk = "0.8"
 port_scanner = "0.1"
-serde_json = "1.0"
 shell-words = "1.0"
-tch = { version="*", optional=true }
+tch = { version = "*", optional = true }
 termcolor = "1.1"
 [[bin]]
 name = "tremor"

--- a/tremor-cli/src/cli.yaml
+++ b/tremor-cli/src/cli.yaml
@@ -105,7 +105,6 @@ subcommands:
             long: report
             required: false
             takes_value: true
-            default_value: "report.json"
         - INCLUDES:
             help: Optional tags to filter test executions by
             short: i

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -223,7 +223,7 @@ fn suite_unit(
 pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
     let kind: test::TestKind = matches.value_of("MODE").unwrap_or_default().try_into()?;
     let path = matches.value_of("PATH").unwrap_or_default();
-    let report = matches.value_of("REPORT").unwrap_or_default();
+    let report = matches.value_of("REPORT");
     let quiet = matches.is_present("QUIET");
     let mut includes: Vec<String> = if matches.is_present("INCLUDES") {
         if let Some(matches) = matches.values_of("INCLUDES") {
@@ -344,9 +344,9 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
         reports,
         stats: stats_map,
     };
-    let mut file = file::create(report)?;
-
-    if let Ok(result) = serde_json::to_string(&test_run) {
+    if let Some(report) = report {
+        let mut file = file::create(report)?;
+        let result = simd_json::to_string(&test_run)?;
         file.write_all(&result.as_bytes())
             .map_err(|e| Error::from(format!("Failed to write report to `{}`: {}", report, e)))?;
     }

--- a/tremor-cli/src/test/after.rs
+++ b/tremor-cli/src/test/after.rs
@@ -39,8 +39,8 @@ impl After {
 }
 
 pub(crate) fn load_after(path: &Path) -> Result<After> {
-    let tags_data = slurp_string(path)?;
-    match serde_json::from_str(&tags_data) {
+    let mut tags_data = slurp_string(path)?;
+    match simd_json::from_str(&mut tags_data) {
         Ok(s) => Ok(s),
         Err(_not_well_formed) => Err(Error::from(format!(
             "Unable to load `after.json` from path: {}",

--- a/tremor-cli/src/test/before.rs
+++ b/tremor-cli/src/test/before.rs
@@ -108,8 +108,8 @@ fn default_min_await_secs() -> u64 {
 }
 
 pub(crate) fn load_before(path: &Path) -> Result<Before> {
-    let tags_data = slurp_string(path)?;
-    match serde_json::from_str(&tags_data) {
+    let mut tags_data = slurp_string(path)?;
+    match simd_json::from_str(&mut tags_data) {
         Ok(s) => Ok(s),
         Err(e) => Err(Error::from(format!(
             "Invalid `before.json` in path `{}`: {}",

--- a/tremor-cli/src/test/tag.rs
+++ b/tremor-cli/src/test/tag.rs
@@ -27,7 +27,7 @@ pub(crate) type Tags = Vec<String>;
 pub(crate) fn maybe_slurp_tags(path: &Path) -> Tags {
     let tags_data = slurp_string(path);
     match tags_data {
-        Ok(tags_data) => serde_json::from_str(&tags_data).unwrap_or_default(),
+        Ok(mut tags_data) => simd_json::from_str(&mut tags_data).unwrap_or_default(),
         Err(_not_found) => vec![],
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Only generate the `report.json` if the user asks for it (as the CLI suggestions). As a bonus, the cli no longer depends on `serde_json` :D

## Related

* Related Issues: fixes #1072

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no hot path code changes