### PR TITLE
Add support for concatenating arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Restructure functions to avoid transmutation [#1028](https://github.com/tremor-rs/tremor-runtime/issues/1028)
 - Update blackhole to print events / s [#1129](https://github.com/tremor-rs/tremor-runtime/issues/1129)
 - Improve soundness and documentation of SRS code.
+- Add support for concatenating arrays [#1113](https://github.com/tremor-rs/tremor-runtime/issues/1113)
 
 ### Fixes
 

--- a/tremor-script/lib/std/array.tremor
+++ b/tremor-script/lib/std/array.tremor
@@ -73,3 +73,13 @@ intrinsic fn coalesce(array) as array::coalesce;
 ##
 ## Returns a `string`.
 intrinsic fn join(array, string) as array::join;
+
+## Concatenates two arrays returning a new array. The new array is not a set,
+## i.e. it can contain duplicates depending on the input arrays.
+##
+## ```tremor
+## array::concatenate([1, 2, 3], [3, 4]) == [1, 2, 3, 3, 4]
+## ```
+##
+## Returns an `array`
+intrinsic fn concatenate(left, right) as array::concatenate

--- a/tremor-script/src/std_lib/array.rs
+++ b/tremor-script/src/std_lib/array.rs
@@ -85,6 +85,10 @@ pub fn load(registry: &mut Registry) {
             }else {
                 Some(v.clone())
             }).collect::<Vec<_>>()))
+        }))
+        .insert(tremor_const_fn!(array|concatenate(_context, _left: Array, _right: Array) {
+            let output: Vec<Value> = [_left.as_slice(), _right.as_slice()].concat();
+            Ok(Value::from(output))
         }));
 }
 
@@ -222,5 +226,27 @@ mod test {
                 "this", "cake", "is", "really", "a", "good", "test", "cake", "!",
             ])
         );
+    }
+
+    #[test]
+    fn concatenate() {
+        let f = fun("array", "concatenate");
+        let v1 = Value::from(vec!["this", "is"]);
+        let v2 = Value::from(vec!["the", "way"]);
+
+        // Concat two non empty vectors.
+        assert_val!(
+            f(&[&v1, &v2]),
+            Value::from(vec!["this", "is", "the", "way"])
+        );
+
+        let empty_vector: Vec<Value> = vec![];
+        let empty = Value::from(empty_vector);
+
+        // Concat one empty vector with one non empty vector.
+        assert_val!(f(&[&v1, &empty]), Value::from(vec!["this", "is"]));
+
+        // Concat two empty vectors.
+        assert_val!(f(&[&empty, &empty]), Value::from(empty));
     }
 }


### PR DESCRIPTION
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>

# Pull request

## Description
This PR adds a new function in the `std::array` module named `concatenate` which takes two arrays and returns a single concatenated array.

```
define script concat
script
    use std::array;
    let event.tags = array::concatenate(event.tags, event.marks);
    event;
end;
```

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #1113 
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


