### PR TITLE
Make EventPayload lifetime laundering more robust

### DIFF
--- a/tremor-script/src/srs.rs
+++ b/tremor-script/src/srs.rs
@@ -609,17 +609,19 @@ impl EventPayload {
         // READ: ORDER MATTERS!
         self.raw.append(&mut other.raw);
 
-        // ALLOW: we are turning a longer lifetime into a shorter one for a
-        // covariant type ValueAndMeta. &mut is invariant over it's lifetime,
-        // but we are choosing a shorter one and passing it down not up. So a
-        // user should not be able to choose an inappropriate lifetime for it,
-        // plus they don't control the owner here.
+        //  we are turning a longer lifetime into a shorter one for a covariant
+        // type ValueAndMeta. &mut is invariant over it's lifetime, but we are
+        // choosing a shorter one and passing it down not up. So a user should
+        // not be able to choose an inappropriate lifetime for it, plus they
+        // don't control the owner here.
         join_f(
             unsafe {
+                // ALLOW: See above for explenation            
                 mem::transmute::<&'iref mut ValueAndMeta<'static>, &'iref mut ValueAndMeta<'iref>>(
                     &mut self.data,
                 )
             },
+            // ALLOW: See above for explenation
             unsafe { mem::transmute::<ValueAndMeta<'static>, ValueAndMeta<'iref>>(other.data) },
         )
     }

--- a/tremor-script/src/srs.rs
+++ b/tremor-script/src/srs.rs
@@ -507,12 +507,13 @@ impl EventPayload {
     where
         F: for<'head> FnOnce(&'head ValueAndMeta<'head>) -> R,
     {
-        // ALLOW: we are turning a longer lifetime into a shorter one for a
-        // covariant type ValueAndMeta. &mut is invariant over it's lifetime,
-        // but we are choosing a shorter one and passing it down not up. So a
-        // user should not be able to choose an inappropriate lifetime for it,
-        // plus they don't control the owner here.
+        // we are turning a longer lifetime into a shorter one for a covariant
+        // type ValueAndMeta. &mut is invariant over it's lifetime, but we are
+        // choosing a shorter one and passing it down not up. So a user
+        // should not be able to choose an inappropriate lifetime for it, plus
+        // they don't control the owner here.
         f(unsafe {
+            // ALLOW: See above explenation
             mem::transmute::<&'iref ValueAndMeta<'static>, &'iref ValueAndMeta<'iref>>(&self.data)
         })
     }

--- a/tremor-script/src/srs.rs
+++ b/tremor-script/src/srs.rs
@@ -535,12 +535,13 @@ impl EventPayload {
     where
         F: for<'head> FnOnce(&'head mut ValueAndMeta<'head>) -> R,
     {
-        // ALLOW: we are turning a longer lifetime into a shorter one for a
-        // covariant type ValueAndMeta. &mut is invariant over it's lifetime,
-        // but we are choosing a shorter one and passing it down not up. So a
-        // user should not be able to choose an inappropriate lifetime for it,
-        // plus they don't control the owner here.
+        // we are turning a longer lifetime into a shorter one for a covariant
+        // type ValueAndMeta. &mut is invariant over it's lifetime, but we are
+        // choosing a shorter one and passing it down not up. So a user should
+        // not be able to choose an inappropriate lifetime for it, plus they
+        // don't control the owner here.
         f(unsafe {
+            // ALLOW: See above explenation
             mem::transmute::<&'iref mut ValueAndMeta<'static>, &'iref mut ValueAndMeta<'iref>>(
                 &mut self.data,
             )


### PR DESCRIPTION
This tries to address 2 issues:

- No correlation between 'iref and 'head
- 'head is 'static

The first one is problematic because we know 'head and 'iref are very much
correlated lifetimes. If one could take a reference 'head that outlives 'iref,
that would be unsound.

The second issue is related and maybe even more problematic. While there might
not be any code patterns allowing the abuse of this wrongly marked 'static
lifetime today. Upcoming features like Fn Traits and specialization could easily break
the assumptions here. More pressing even seem potential compiler optimization,
around 'will be alive for whole program duration' lifetimes.

To make the lie about 'static lifetimes more robust, we .. lie even more. By
transmuting the dependent lifetime from 'static to a lifetime bound to the
function call, we ensure that nothing can outlive the scope of the function we
know must be smaller than the lifetime of the object itself. In essence it's the
reverse lie found in the constructor, where we take a function local reference
lifetime and turn it into a 'static lifetime. Technically this approach is still
UB, but the assumption is that it has less potential of breaking in the future,
should for example the constrains of HRTBs be relaxed.

# Pull request

Followup suggestion to https://github.com/tremor-rs/tremor-runtime/pull/1132. It's not complete, there are further consume like functions left. This is aimed to be an POC.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

Not tested. But can't see how it would change.


