### PR TITLE
Allow backpressure with CB, fixes #1119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - replace macros with functions in gcp code
 - Add -q flag and clarify -v flag for unit tests
 - Add win::cardinality function
+- Backpressure now allows lossless (no discard) circuit breaker behaviour [#1119](https://github.com/tremor-rs/tremor-runtime/issues/1119)
 
 ### Fixes
 


### PR DESCRIPTION
# Pull request

## Description

Add the option to use CB instead of discarding for backpressure. This is done by specifying the method used by the backpressure operator as either `discard` or `pause`

## Related

* Related Issues: fixes #1119
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/179)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No logical changes in existing behavior
