### PR TITLE
Add fn for path resolution with defaults on no match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New featues
 
+- Add `std::path::try_default` fn
 - Experimental ARM support
 - Add `default => {...}` and `default "key" => "value` to patch
 - Add `zstd` pre- and post-processors [#1100](https://github.com/tremor-rs/tremor-runtime/issues/1100)

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -201,4 +201,5 @@ test_cases!(
     heredoc_interpolation,
     heredoc_usefn_interpolation,
     heredoc_regression,
+    path_defaulting,
 );

--- a/tests/scripts/path_defaulting/in
+++ b/tests/scripts/path_defaulting/in
@@ -1,0 +1,4 @@
+{ "base": {"snot": "badger", "arr": [{"beep": "boop"}, 1234]}, "segments": ["snot"], "default": "not-used"}
+{ "base": {"snot": "badger", "arr": [{"beep": "boop"}, 1234]}, "segments": [], "default": "not-used"}
+{ "base": {"snot": "badger", "arr": [{"beep": "boop"}, 1234]}, "segments": ["bad"], "default": "good"}
+{ "base": {"snot": "badger", "arr": [{"beep": "boop"}, 1234]}, "segments": ["arr", 0, "beep"], "default": "good"}

--- a/tests/scripts/path_defaulting/out
+++ b/tests/scripts/path_defaulting/out
@@ -1,0 +1,4 @@
+"badger"
+{ "snot": "badger", "arr": [{"beep": "boop"}, 1234]}
+"good"
+"boop"

--- a/tests/scripts/path_defaulting/script.tremor
+++ b/tests/scripts/path_defaulting/script.tremor
@@ -1,0 +1,3 @@
+use std::path;
+
+path::try_default(event.base, event.segments, event.`default`)

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -5,6 +5,7 @@ use std::float;
 use std::integer;
 use std::json;
 use std::math;
+use std::path;
 use std::random;
 use std::range;
 use std::re;
@@ -624,7 +625,7 @@ test::suite({
       "name": "Tests the len function",
       "test": test::assert("binary::len", binary::len(<< 115, 110, 111, 116 >>), 4),
     }),
-    test::test({
+    test::test({ 
       "name": "Tests the from_bytes function",
       "test": test::assert("binary::from_bytes", binary::from_bytes([115, 110, 111, 116]), << 115, 110, 111, 116 >>),
     }),
@@ -639,5 +640,35 @@ test::suite({
   ],
 });
 
+test::suite({
+  "name": "path utility functions",
+  "tags": [ "path" ],
+  "tests": [
+    test::test({
+      "name": "Path resolve or default 0",
+      "test": test::assert("path::try_default", path::try_default(null, ["snot"], "horse"), "horse")
+    }),
+    test::test({
+      "name": "Path resolve or default 0",
+      "test": test::assert("path::try_default", path::try_default(null, [], "horse"), "horse")
+    }),
+    test::test({
+      "name": "Path resolve or default 1",
+      "test": test::assert("path::try_default", path::try_default({"snort": "badger"}, ["snot"], "horse"), "horse")
+    }),
+    test::test({
+      "name": "Path resolve or default 1",
+      "test": test::assert("path::try_default", path::try_default({"snot": [ "badger" ]}, ["snot"], "horse"), [ "badger" ])
+    }),
+    test::test({
+      "name": "Path resolve or default 1",
+      "test": test::assert("path::try_default", path::try_default({"snot": [ "badger" ]}, ["snort"], "horse"), "horse")
+    }),
+    test::test({
+      "name": "Path resolve or default 1",
+      "test": test::assert("path::try_default", path::try_default({"snot": [ "badger" ]}, ["snot", 0], "horse"), "badger")
+    }),
+  ],
+});
 
 "snot badger";

--- a/tremor-script/lib/std.tremor
+++ b/tremor-script/lib/std.tremor
@@ -7,6 +7,7 @@
 ### * [integer](std/integer.md) - functions to deal with integer numbers
 ### * [json](std/json.md) - functions to deal with JSON
 ### * [math](std/math.md) - mathematical functions
+### * [path](std/path.md) - path utility functions
 ### * [random](std/random.md) - random related functions
 ### * [range](std/range.md) - range related functions
 ### * [re](std/re.md) - functions handeling regular expressions
@@ -23,6 +24,7 @@ use std::float;
 use std::integer;
 use std::json;
 use std::math;
+use std::path;
 use std::random;
 use std::range;
 use std::re;

--- a/tremor-script/lib/std/path.tremor
+++ b/tremor-script/lib/std/path.tremor
@@ -1,0 +1,43 @@
+### The path module contains utility functions for path handling
+
+use std::type;
+
+## Determine if a base value matches an segment index array.
+## Returns the value under the match on a hit.
+## Returns a default user provided value on no match.
+##
+## The `base` value can be a record, an array or the literal null.
+##
+## The `segments` value should be an array where each field is used
+## to traverse the `base` value, as follows:
+## * String yielding expression segments used for field traversal
+## * Integer yielding expression segments used for array traversal
+## * A empty segment list yields is considered a match yielding the base value
+##
+## Examples
+##
+## ```tremor
+## use std::path;
+##
+## {"snot": "badger"} == path::try_default({"snot": "badger"}, [], "test")
+##
+## "flook" == path::try_default([{"snot": "badger"}, ["fleek", "flook"]], [1, 1], "test")
+##
+## "badger" == path::try_default([{"snot": "badger"}, ["fleek", "flook"]], [0, "snot"], "test")
+##
+## "fleek" == path::try_default([{"snot": "badger"}, ["fleek", "flook"]], [1, 0], "test")
+##
+## "test" == path::try_default([{"snot": "badger"}, ["fleek", "flook"]], [1, 2], "test")
+##
+## # Statements of the general form
+##  match event of
+##    case %{ absent host } => let event.host = system::hostname()
+##    default => event.host
+##  end;
+##
+## Can now be written more tersely as:
+## # If host is absent, default to the system hostname
+## let host = try_default(event, ["host"], system::hostname())
+## ```
+## Returns a tremor value
+intrinsic fn try_default(base, segments, otherwise) as path::try_default;

--- a/tremor-script/src/std_lib.rs
+++ b/tremor-script/src/std_lib.rs
@@ -30,6 +30,7 @@ mod integer;
 mod json;
 mod math;
 mod origin;
+mod path;
 mod random;
 mod range;
 mod re;
@@ -66,6 +67,7 @@ pub fn load(registry: &mut Registry) {
     r#type::load(registry);
     url::load(registry);
     win::load(registry);
+    path::load(registry);
 }
 
 pub fn load_aggr(registry: &mut AggrRegistry) {

--- a/tremor-script/src/std_lib/path.rs
+++ b/tremor-script/src/std_lib/path.rs
@@ -1,0 +1,225 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::prelude::*;
+use crate::registry::Registry;
+use crate::tremor_const_fn;
+use tremor_value::StaticNode;
+
+pub fn load(registry: &mut Registry) {
+    registry
+        .insert(
+            tremor_const_fn! (path|try_default(_context, _base, _segments, _otherwise) {
+                let base = _base.clone_static();
+                let mut pivot = &base;
+
+                if let Value::Object(root) = _base {
+                    if let Value::Array(segments) = _segments {
+                        let segment_len = &segments.len();
+                        let mut i = 0;
+                        for segment in segments {
+                            if let Some(field) = segment.as_str() {
+                                if let Value::Object(test) = pivot {
+                                    if let Some(next) = test.get(field) {
+                                        pivot = next;
+                                        i += 1;
+                                        continue;
+                                    }
+
+                                    // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+
+                                    return Ok(_otherwise.clone_static());
+                                }
+                            }
+
+                            if let Value::Array(test) = pivot {
+                                if let Some(index) = segment.as_usize() {
+                                    if let Some(next) = test.get(index) {
+                                        pivot = next;
+                                        i += 1;
+                                        continue;
+                                    }
+                                }
+
+                                // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+
+                                return Ok(_otherwise.clone_static());
+                            }
+                        }
+                        if i > 0 && segments.len() > i {
+                            // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+                            return Ok(_otherwise.clone_static());
+                        }
+
+                        Ok(pivot.clone_static())
+                    } else {
+                        Err(FunctionError::RuntimeError{mfa: this_mfa(), error: "Expected path segment array as second argument".into()})
+                    }
+                } else if let Value::Array(root) = _base {
+                    let mut i = 0;
+                    if let Value::Array(segments) = _segments {
+                        for segment in segments {
+                            if let Some(field) = segment.as_str() {
+                                if let Value::Object(test) = pivot {
+                                    if let Some(next) = test.get(field) {
+                                        pivot = next;
+                                        i += 1;
+                                        continue;
+                                    }
+
+                                    // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+                                    return Ok(_otherwise.clone_static());
+                                }
+                            }
+
+                            if let Value::Array(test) = pivot {
+                                if let Some(index) = segment.as_usize() {
+                                    if let Some(next) = test.get(index) {
+                                        pivot = next;
+                                        i += 1;
+                                        continue;
+                                    }
+                                }
+
+                                // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+                                return Ok(_otherwise.clone_static());
+                            }
+                        }
+                        if i > 0 && segments.len() > i {
+                            // NOTE This is non-strict for dynamic / computed uses of the fn - we return the default rather than a runtime error
+                            return Ok(_otherwise.clone_static());
+                        }
+
+                        Ok(pivot.clone_static())
+                    } else {
+                        Err(FunctionError::RuntimeError{mfa: this_mfa(), error: "Expected path segment array as second argument".into()})
+                    }
+                } else if let Value::Static(StaticNode::Null) = _base {
+                    return Ok(_otherwise.clone_static());
+                } else {
+                     Err(FunctionError::RuntimeError{mfa: this_mfa(), error: "Expected record or array or literal `null` as first argument".into()})
+                }
+            }
+        ));
+}
+
+#[cfg(test)]
+mod test {
+    use crate::registry::fun;
+    use crate::registry::FunctionError;
+    use crate::registry::Mfa;
+    use crate::Value;
+    use tremor_value::literal;
+
+    fn try_default_mfa() -> Mfa {
+        Mfa::new("path", "try_default", 3)
+    }
+
+    #[test]
+    fn path_default_base_is_invalid() {
+        let f = fun("path", "try_default");
+
+        let base = literal!(1);
+        let segments = literal!([]);
+        let otherwise = literal!("error");
+
+        let e = f(&[&base, &segments, &otherwise]);
+
+        assert_eq!(
+            Err(FunctionError::RuntimeError {
+                mfa: try_default_mfa(),
+                error: "Expected record or array or literal `null` as first argument".to_string(),
+            }),
+            e
+        );
+    }
+
+    #[test]
+    fn path_default_segments_is_invalid() {
+        let f = fun("path", "try_default");
+
+        let base = literal!({});
+        let segments = literal!(1);
+        let otherwise = literal!("error");
+
+        let e = f(&[&base, &segments, &otherwise]);
+        assert!(e.is_err());
+        assert_eq!(
+            Some(FunctionError::RuntimeError {
+                mfa: try_default_mfa(),
+                error: "Expected path segment array as second argument".to_string(),
+            }),
+            e.err()
+        );
+
+        let base = literal!([]);
+        let segments = literal!(1);
+        let otherwise = literal!("error");
+
+        let e = f(&[&base, &segments, &otherwise]);
+        assert!(e.is_err());
+        assert_eq!(
+            Some(FunctionError::RuntimeError {
+                mfa: try_default_mfa(),
+                error: "Expected path segment array as second argument".to_string(),
+            }),
+            e.err()
+        );
+    }
+
+    #[test]
+    fn path_default_when_base_is_null_defaults() {
+        let f = fun("path", "try_default");
+
+        let base = literal!(null);
+        let segments = literal!([]);
+        let otherwise = literal!("pass");
+
+        assert_val!(f(&[&base, &segments, &otherwise]), "pass");
+    }
+
+    #[test]
+    fn path_default_depth_exceeds_base_defaults() {
+        let f = fun("path", "try_default");
+
+        let base = literal!({"snot": "badger"});
+        let segments = literal!(["snot", "badger"]);
+        let otherwise = literal!("pass");
+
+        assert_val!(f(&[&base, &segments, &otherwise]), "pass");
+
+        let base = literal!(["snot", "badger"]);
+        let segments = literal!(["snot", "badger"]);
+        let otherwise = literal!("pass");
+
+        assert_val!(f(&[&base, &segments, &otherwise]), "pass");
+    }
+
+    #[test]
+    fn path_default_ok() {
+        let f = fun("path", "try_default");
+
+        let base = literal!({"snot": { "snot": "badger" }});
+        let segments = literal!(["snot", "snot"]);
+        let otherwise = literal!("not_used_for_this_call");
+
+        assert_val!(f(&[&base, &segments, &otherwise]), "badger");
+
+        let base = literal!(["snot", ["snot", "badger"]]);
+        let segments = literal!([1, 1]);
+        let otherwise = literal!("not_used_for_this_call");
+
+        assert_val!(f(&[&base, &segments, &otherwise]), "badger");
+    }
+}


### PR DESCRIPTION
Signed-off-by: Darach Ennis <darach@gmail.com>

# Pull request

Fixes #1090 without changes to grammar or language via introducing `path::try_default` intrinsic fn.

## Description

The function `path::try_default` can traverse structured values based on a list of segments
returning a match, or a default when unsuccessful.

## Related

Grammar changes for default in expressions were explored but not preferred compred to a fn ( this PR ).
A try/catch/throw mechanism was explored but dropped in favour of this PR as it would need an RFC and
it would form the basis of a good mentorship project.

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #1090

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

