### PR TITLE
Add FLOAT4 and FLOAT8 support to postgres connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New featues
 
+- Add support for `FLOAT4` and `FLOAT8` serialization/deserialization to postgres connectors
 - Add `std::path::try_default` fn
 - Experimental ARM support
 - Add `default => {...}` and `default "key" => "value` to patch

--- a/src/ramp/postgres.rs
+++ b/src/ramp/postgres.rs
@@ -88,7 +88,7 @@ impl postgres::types::ToSql for Record<'_> {
             postgres::types::Type::INT4 => {
                 let val = match self.value.as_i32() {
                     Some(v) => v,
-                    None => return Err("Could not serialize".into()),
+                    None => return Err("Could not serialize as `INT4`".into()),
                 };
 
                 postgres_protocol::types::int4_to_sql(val, w);
@@ -96,10 +96,26 @@ impl postgres::types::ToSql for Record<'_> {
             postgres::types::Type::INT8 => {
                 let val = match self.value.as_i64() {
                     Some(v) => v,
-                    None => return Err("Could not serialize".into()),
+                    None => return Err("Could not serialize as `INT8`".into()),
                 };
 
                 postgres_protocol::types::int8_to_sql(val, w);
+            }
+            postgres::types::Type::FLOAT4 => {
+                let val = match self.value.as_f32() {
+                    Some(v) => v,
+                    None => return Err("Could not serialize as `FLOAT4`".into()),
+                };
+
+                postgres_protocol::types::float4_to_sql(val, w);
+            }
+            postgres::types::Type::FLOAT8 => {
+                let val = match self.value.as_f64() {
+                    Some(v) => v,
+                    None => return Err("Could not serialize  as `FLOAT8`".into()),
+                };
+
+                postgres_protocol::types::float8_to_sql(val, w);
             }
             postgres::types::Type::JSON => {
                 let val = self.value.as_str().unwrap_or_default();
@@ -153,6 +169,8 @@ impl postgres::types::ToSql for Record<'_> {
                 | postgres::types::Type::INT2
                 | postgres::types::Type::INT4
                 | postgres::types::Type::INT8
+                | postgres::types::Type::FLOAT4
+                | postgres::types::Type::FLOAT8
                 | postgres::types::Type::JSON
                 | postgres::types::Type::JSONB
                 | postgres::types::Type::TIMESTAMP
@@ -181,6 +199,8 @@ pub fn json_to_record<'a>(json: &'a Value<'a>) -> Result<Record> {
         "INT8" => postgres::types::Type::INT8,
         "INT2" => postgres::types::Type::INT2,
         "INT4" => postgres::types::Type::INT4,
+        "FLOAT4" => postgres::types::Type::FLOAT4,
+        "FLOAT8" => postgres::types::Type::FLOAT8,
         "JSON" => postgres::types::Type::JSON,
         "JSONB" => postgres::types::Type::JSONB,
         "TIMESTAMPTZ" => postgres::types::Type::TIMESTAMPTZ,
@@ -212,6 +232,8 @@ pub fn row_to_json(
             postgres::types::Type::INT8 => ("INT8", Value::from(row.get::<_, i64>(cid))),
             postgres::types::Type::INT2 => ("INT2", Value::from(row.get::<_, i64>(cid))),
             postgres::types::Type::INT4 => ("INT4", Value::from(row.get::<_, i64>(cid))),
+            postgres::types::Type::FLOAT4 => ("FLOAT4", Value::from(row.get::<_, f32>(cid))),
+            postgres::types::Type::FLOAT8 => ("FLOAT8", Value::from(row.get::<_, f64>(cid))),
             postgres::types::Type::JSON => ("JSON", Value::from(row.get::<_, String>(cid))),
             postgres::types::Type::JSONB => ("JSONB", Value::from(row.get::<_, String>(cid))),
             postgres::types::Type::NAME => ("NAME", Value::from(row.get::<_, String>(cid))),


### PR DESCRIPTION
Signed-off-by: Darach Ennis <darach@gmail.com>

# Pull request

## Description

Plugs limitation in postgres connectors for float compatibility from its basic supported types.

## Related

* Related Issues: fixes #1161

## Checklist

* [ x ] The RFC, if required, has been submitted and approved
* [ x ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ x ] The code is tested
* [ x ] Use of unsafe code is reasoned about in a comment
* [ x ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ x ] The performance impact of the change is measured (see below)
