### PR TITLE
fix: don't allow duplicate stream names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixes
 
+- Don't allow duplicate stream names: #1212
 - Fix memory safety issue when using `merge` or `patch` with `state` as target and reassigning the resulting value to `state` [#1217](https://github.com/tremor-rs/tremor-runtime/pull/1217)
 - Fix delayed event re-execution in case of errors in a branched pipeline
 - Skip instead of fail EQC on out of repo PRs

--- a/tests/query_error.rs
+++ b/tests/query_error.rs
@@ -142,6 +142,7 @@ test_cases!(
     pp_embed_unrecognized_token4,
     pp_embed_unrecognized_token5,
     // INSERT
+    duplicate_stream_name,
     window_both_settings,
     window_group_by_event_in_target,
     window_event_in_target,

--- a/tests/query_errors/duplicate_stream_name/error.txt
+++ b/tests/query_errors/duplicate_stream_name/error.txt
@@ -1,0 +1,3 @@
+Error: 
+    2 | create stream snot; #  this should error
+      | ^^^^^^^^^^^^^^^^^^ duplicate stream name

--- a/tests/query_errors/duplicate_stream_name/query.trickle
+++ b/tests/query_errors/duplicate_stream_name/query.trickle
@@ -1,0 +1,5 @@
+create stream snot;
+create stream snot; # this should error
+
+select event from in into snot;
+select event from snot into out;


### PR DESCRIPTION
Signed-off-by: David McKay <david@rawkode.com>

# Pull request

## Description

Currently tremor-script allows multiple streams with the same name. Let's not allow that.

Closes #1212

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)
