### PR TITLE
Add target for generating aggregate docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ perf.data*
 logger-*
 tremor.log
 docs
+aggr-docs
 /packaging/out/
 report.txt
 report.json

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ stdlib-doc:
 	-mkdir docs
 	-TREMOR_PATH=./tremor-script/lib cargo run -p tremor-cli -- doc tremor-script/lib docs
 
+aggr-doc:
+	-rm -rf aggr-docs
+	-mkdir aggr-docs
+	-TREMOR_PATH=./tremor-script/docs cargo run -p tremor-cli -- doc tremor-script/docs aggr-docs
+
 chk_copyright:
 	@./.github/checks/copyright.sh
 


### PR DESCRIPTION
# Pull request

## Description

Add a make target to generate aggregate function documentation from the dummy `aggr` function definitions. This is similar to the `make docs`  target just for aggregate documentation.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
no code changes