### PR TITLE
Unix socket source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add win::cardinality function
 - Backpressure now allows lossless (no discard) circuit breaker behaviour [#1119](https://github.com/tremor-rs/tremor-runtime/issues/1119)
 - Allow functions, constants and expressions as roots for path lookups
+- Add the `unix-socket` source
 
 ### Fixes
 

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -18,7 +18,7 @@ use crate::repository::ServantId;
 use crate::source::prelude::*;
 use crate::source::{
     amqp, blaster, cb, crononome, discord, env, file, gsub, kafka, metronome, nats, otel, postgres,
-    rest, sse, stdin, tcp, udp, ws,
+    rest, sse, stdin, tcp, udp, ws, unix_socket,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};
@@ -89,6 +89,7 @@ pub(crate) fn lookup(
         "otel" => otel::OpenTelemetry::from_config(id, config),
         "nats" => nats::Nats::from_config(id, config),
         "gsub" => gsub::GoogleCloudPubSub::from_config(id, config),
+        "unix-socket" => unix_socket::UnixSocket::from_config(id, config),
         _ => Err(format!("[onramp:{}] Onramp type {} not known", id, name).into()),
     }
 }

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -16,9 +16,11 @@ use crate::metrics::RampReporter;
 use crate::pipeline;
 use crate::repository::ServantId;
 use crate::source::prelude::*;
+#[cfg(unix)]
+use crate::source::unix_socket;
 use crate::source::{
     amqp, blaster, cb, crononome, discord, env, file, gsub, kafka, metronome, nats, otel, postgres,
-    rest, sse, stdin, tcp, udp, unix_socket, ws,
+    rest, sse, stdin, tcp, udp, ws,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};
@@ -89,6 +91,7 @@ pub(crate) fn lookup(
         "otel" => otel::OpenTelemetry::from_config(id, config),
         "nats" => nats::Nats::from_config(id, config),
         "gsub" => gsub::GoogleCloudPubSub::from_config(id, config),
+        #[cfg(unix)]
         "unix-socket" => unix_socket::UnixSocket::from_config(id, config),
         _ => Err(format!("[onramp:{}] Onramp type {} not known", id, name).into()),
     }

--- a/src/onramp.rs
+++ b/src/onramp.rs
@@ -18,7 +18,7 @@ use crate::repository::ServantId;
 use crate::source::prelude::*;
 use crate::source::{
     amqp, blaster, cb, crononome, discord, env, file, gsub, kafka, metronome, nats, otel, postgres,
-    rest, sse, stdin, tcp, udp, ws, unix_socket,
+    rest, sse, stdin, tcp, udp, unix_socket, ws,
 };
 use crate::url::TremorUrl;
 use async_std::task::{self, JoinHandle};

--- a/src/source.rs
+++ b/src/source.rs
@@ -56,6 +56,7 @@ pub(crate) mod sse;
 pub(crate) mod stdin;
 pub(crate) mod tcp;
 pub(crate) mod udp;
+#[cfg(unix)]
 pub mod unix_socket;
 pub(crate) mod ws;
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -56,8 +56,8 @@ pub(crate) mod sse;
 pub(crate) mod stdin;
 pub(crate) mod tcp;
 pub(crate) mod udp;
-pub(crate) mod ws;
 pub mod unix_socket;
+pub(crate) mod ws;
 
 struct StaticValue(Value<'static>);
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -57,6 +57,7 @@ pub(crate) mod stdin;
 pub(crate) mod tcp;
 pub(crate) mod udp;
 pub(crate) mod ws;
+pub mod unix_socket;
 
 struct StaticValue(Value<'static>);
 

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -1,0 +1,169 @@
+use std::path::PathBuf;
+use async_std::channel::TryRecvError;
+use async_std::os::unix::net::{UnixListener};
+use smol::stream::StreamExt;
+use crate::source::prelude::*;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Config {
+    pub path: String,
+}
+
+impl ConfigImpl for Config {}
+
+pub struct UnixSocket {
+    pub config: Config,
+    onramp_id: TremorUrl
+}
+
+pub struct Int {
+    uid: u64,
+    config: Config,
+    listener: Option<Receiver<SourceReply>>,
+    onramp_id: TremorUrl,
+}
+
+impl std::fmt::Debug for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UnixSocket:{}", self.config.path)
+    }
+}
+
+impl Int {
+    fn from_config(uid: u64, onramp_id: TremorUrl, config: &Config) -> Self {
+        let config = config.clone();
+
+        Self {
+            uid,
+            config,
+            listener: None,
+            onramp_id,
+        }
+    }
+}
+
+#[async_trait::async_trait()]
+impl Onramp for UnixSocket {
+    async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
+        let source = Int::from_config(config.onramp_uid, self.onramp_id.clone(), &self.config);
+        let r = SourceManager::start(source, config).await;
+        match r {
+            Err(ref e) => { eprintln!("{:?}", e); }
+            _ => {}
+        }
+
+        r
+    }
+
+    fn default_codec(&self) -> &str {
+        "json"
+    }
+}
+
+impl onramp::Impl for UnixSocket {
+    fn from_config(id: &TremorUrl, config: &Option<YamlValue>) -> Result<Box<dyn Onramp>> {
+        if let Some(config) = config {
+            let config: Config = Config::new(config)?;
+            Ok(Box::new(Self {
+                config,
+                onramp_id: id.clone(),
+            }))
+        } else {
+            Err("Missing config for unix_socket onramp".into())
+        }
+    }
+}
+
+#[async_trait::async_trait()]
+impl Source for Int {
+    async fn pull_event(&mut self, _id: u64) -> Result<SourceReply> {
+        self.listener.as_ref().map_or_else(
+            || Ok(SourceReply::StateChange(SourceState::Disconnected)),
+            |listener| match listener.try_recv() {
+                Ok(r) => Ok(r),
+                Err(TryRecvError::Empty) => Ok(SourceReply::Empty(10)),
+                Err(TryRecvError::Closed) => {
+                    Ok(SourceReply::StateChange(SourceState::Disconnected))
+                }
+            },
+        )
+    }
+
+    async fn init(&mut self) -> Result<SourceState> {
+        let path = PathBuf::from(&self.config.path);
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        let stream = UnixListener::bind(path).await?;
+        let mut stream_id = 0;
+        let (tx, rx) = bounded(crate::QSIZE);
+
+        let path = vec![self.config.path.clone()];
+        let uid = self.uid;
+        task::spawn(async move {
+            if let Err(e) = tx.send(SourceReply::StartStream(0)).await {
+                error!("Unix Socket Error: {}", e);
+                return;
+            }
+
+            let origin_uri = EventOriginUri {
+                uid,
+                scheme: "tremor-unix-socket".to_string(),
+                host: String::new(),
+                port: None,
+                path: path.clone(), // captures server port
+            };
+
+            let mut buffer = [0; 8192];
+
+            let mut incoming = stream.incoming();
+            loop {
+                let mut connection = match incoming.try_next().await {
+                    Ok(Some(connection)) => connection,
+                    Ok(None) => break,
+                    Err(e) => {
+                        error!("Unix socket error: {}", e);
+                        return;
+                    }
+                };
+
+                let tx = tx.clone();
+                let origin_uri = origin_uri.clone();
+
+                task::spawn(async move {
+                    while let Ok(n) = connection.read(&mut buffer).await {
+                        if n == 0 {
+                            if let Err(e) = tx.send(SourceReply::EndStream(stream_id)).await {
+                                error!("Unix Socket Error: {}", e);
+                            };
+                            break;
+                        };
+                        if let Err(e) = tx
+                            .send(SourceReply::Data {
+                                origin_uri: origin_uri.clone(),
+                                // ALLOW: we define n as part of the read
+                                data: buffer[0..n].to_vec(),
+                                meta: None,
+                                codec_override: None,
+                                stream: stream_id,
+                            })
+                            .await
+                        {
+                            error!("Unix Socket Error: {}", e);
+                            break;
+                        };
+                    }
+                });
+                stream_id+=1;
+            }
+        });
+
+        self.listener = Some(rx);
+
+        Ok(SourceState::Connected)
+    }
+
+    fn id(&self) -> &TremorUrl {
+        &self.onramp_id
+    }
+}

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
-use async_std::channel::TryRecvError;
-use async_std::os::unix::net::{UnixListener};
-use smol::stream::StreamExt;
 use crate::source::prelude::*;
+use async_std::channel::TryRecvError;
+use async_std::os::unix::net::UnixListener;
+use smol::stream::StreamExt;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
@@ -13,7 +13,7 @@ impl ConfigImpl for Config {}
 
 pub struct UnixSocket {
     pub config: Config,
-    onramp_id: TremorUrl
+    onramp_id: TremorUrl,
 }
 
 pub struct Int {
@@ -48,7 +48,9 @@ impl Onramp for UnixSocket {
         let source = Int::from_config(config.onramp_uid, self.onramp_id.clone(), &self.config);
         let r = SourceManager::start(source, config).await;
         match r {
-            Err(ref e) => { eprintln!("{:?}", e); }
+            Err(ref e) => {
+                eprintln!("{:?}", e);
+            }
             _ => {}
         }
 
@@ -154,7 +156,7 @@ impl Source for Int {
                         };
                     }
                 });
-                stream_id+=1;
+                stream_id += 1;
             }
         });
 

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     pub fn default_codec_is_json() {
-        let onramp_config = json!({l
+        let onramp_config = json!({
             "path": "/tmp/test.sock"
         });
         let onramp = UnixSocket::from_config(

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -1,3 +1,16 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use crate::source::prelude::*;
 use async_std::channel::TryRecvError;
 use async_std::os::unix::net::UnixListener;

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -175,24 +175,37 @@ impl Source for Int {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::onramp::Impl;
     use crate::source::unix_socket::{Config, Int, UnixSocket};
     use crate::url::TremorUrl;
+    use simd_json::json;
 
     #[test]
     pub fn default_codec_is_json() {
-        let onramp = UnixSocket::from_config(&TremorUrl::from_onramp_id("test").unwrap(), &None).unwrap();
+        let onramp_config = json!({l
+            "path": "/tmp/test.sock"
+        });
+        let onramp = UnixSocket::from_config(
+            &TremorUrl::from_onramp_id("test").unwrap(),
+            &serde_yaml::from_value(serde_yaml::to_value(onramp_config).expect("")).expect(""),
+        )
+        .unwrap();
 
         assert_eq!("json", onramp.default_codec());
     }
 
     #[test]
     pub fn can_be_formatted_for_debug() {
-        let int = Int::from_config(1, TremorUrl::from_onramp_id("test").unwrap(), &Config { path: "/tmp/test.sock".to_string() });
+        let int = Int::from_config(
+            1,
+            TremorUrl::from_onramp_id("test").unwrap(),
+            &Config {
+                path: "/tmp/test.sock".to_string(),
+            },
+        );
 
-        assert_eq!("unix-socket:/tmp/test.sock", format!("{:?}", int));
+        assert_eq!("UnixSocket:/tmp/test.sock", format!("{:?}", int));
     }
 }

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -174,3 +174,25 @@ impl Source for Int {
         &self.onramp_id
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use crate::onramp::Impl;
+    use crate::source::unix_socket::{Config, Int, UnixSocket};
+    use crate::url::TremorUrl;
+
+    #[test]
+    pub fn default_codec_is_json() {
+        let onramp = UnixSocket::from_config(&TremorUrl::from_onramp_id("test").unwrap(), &None).unwrap();
+
+        assert_eq!("json", onramp.default_codec());
+    }
+
+    #[test]
+    pub fn can_be_formatted_for_debug() {
+        let int = Int::from_config(1, TremorUrl::from_onramp_id("test").unwrap(), &Config { path: "/tmp/test.sock".to_string() });
+
+        assert_eq!("unix-socket:/tmp/test.sock", format!("{:?}", int));
+    }
+}

--- a/src/source/unix_socket.rs
+++ b/src/source/unix_socket.rs
@@ -46,15 +46,7 @@ impl Int {
 impl Onramp for UnixSocket {
     async fn start(&mut self, config: OnrampConfig<'_>) -> Result<onramp::Addr> {
         let source = Int::from_config(config.onramp_uid, self.onramp_id.clone(), &self.config);
-        let r = SourceManager::start(source, config).await;
-        match r {
-            Err(ref e) => {
-                eprintln!("{:?}", e);
-            }
-            _ => {}
-        }
-
-        r
+        SourceManager::start(source, config).await
     }
 
     fn default_codec(&self) -> &str {

--- a/tests/unix_socket.rs
+++ b/tests/unix_socket.rs
@@ -1,3 +1,16 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use tremor_runtime::config::Binding;
 use tremor_runtime::system;
 use tremor_runtime::url::TremorUrl;

--- a/tests/unix_socket.rs
+++ b/tests/unix_socket.rs
@@ -1,12 +1,12 @@
-use tremor_runtime::config::{Binding};
-use tremor_runtime::url::TremorUrl;
+use tremor_runtime::config::Binding;
 use tremor_runtime::system;
+use tremor_runtime::url::TremorUrl;
 
+use hashbrown::HashMap;
 use pretty_assertions::assert_eq;
 use std::io::prelude::*;
-use std::os::unix::net::{UnixStream};
+use std::os::unix::net::UnixStream;
 use std::path::Path;
-use hashbrown::HashMap;
 
 use tremor_runtime::errors::*;
 
@@ -28,9 +28,13 @@ pub async fn unix_socket() -> Result<()> {
             "path": socket_path
         }
     });
-    let onramp:tremor_runtime::config::OnRamp = serde_yaml::from_value(serde_yaml::to_value(onramp_config).expect("")).expect("");
+    let onramp: tremor_runtime::config::OnRamp =
+        serde_yaml::from_value(serde_yaml::to_value(onramp_config).expect("")).expect("");
 
-    world.repo.publish_onramp(&onramp_url, false, onramp).await?;
+    world
+        .repo
+        .publish_onramp(&onramp_url, false, onramp)
+        .await?;
 
     let offramp_url = TremorUrl::from_offramp_id("test").expect("");
     let output_file = "/tmp/unix-socket-out.log";
@@ -47,9 +51,13 @@ pub async fn unix_socket() -> Result<()> {
             "file": output_file
         }
     });
-    let offramp:tremor_runtime::config::OffRamp = serde_yaml::from_value(serde_yaml::to_value(offramp_config).expect("")).expect("");
+    let offramp: tremor_runtime::config::OffRamp =
+        serde_yaml::from_value(serde_yaml::to_value(offramp_config).expect("")).expect("");
 
-    world.repo.publish_offramp(&offramp_url, false, offramp).await?;
+    world
+        .repo
+        .publish_offramp(&offramp_url, false, offramp)
+        .await?;
 
     let id = TremorUrl::parse(&format!("/pipeline/{}", "test"))?;
     let module_path = &tremor_script::path::ModulePath { mounts: Vec::new() };
@@ -106,16 +114,18 @@ links:
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
-
     world.stop().await?;
 
     let actual_output = std::fs::read_to_string(output_file).unwrap();
-    assert_eq!(r#"{"a":0}
+    assert_eq!(
+        r#"{"a":0}
 {"b":1}
 {"c":2}
 {"d":3}
 {"e":4}
-"#, actual_output);
+"#,
+        actual_output
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Pull request

## Description

Adds a source/sink for Unix sockets

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwords impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment (**there's no unsafe code**)
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

The changes don't affect anything in the runtime itself, just add a sink so there's no performance impact.
<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


