### PR TITLE
Factor out ID + Module into a `NodeId` for different Node types

### DIFF
--- a/tremor-pipeline/src/op/trickle/operator.rs
+++ b/tremor-pipeline/src/op/trickle/operator.rs
@@ -55,7 +55,7 @@ impl TrickleOperator {
             ast::Stmt::OperatorDecl(ref op) => {
                 let op = op.clone().into_static();
                 let config = mk_node_config(
-                    op.id,
+                    op.node_id.id().to_string(),
                     format!("{}::{}", op.kind.module, op.kind.operation),
                     op.params,
                 );

--- a/tremor-pipeline/src/query.rs
+++ b/tremor-pipeline/src/query.rs
@@ -426,24 +426,21 @@ impl Query {
                     subqueries.insert(s.id.clone(), s.clone());
                 }
                 Stmt::Operator(o) => {
-                    if nodes.contains_key(&common_cow(&o.id)) {
-                        let error_func = if has_builtin_node_name(&common_cow(&o.id)) {
+                    if nodes.contains_key(&common_cow(o.node_id.id())) {
+                        let error_func = if has_builtin_node_name(&common_cow(o.node_id.id())) {
                             query_node_reserved_name_err
                         } else {
                             query_node_duplicate_name_err
                         };
-                        return Err(error_func(o, o.id.clone(), &query.node_meta).into());
+                        return Err(
+                            error_func(o, o.node_id.id().to_string(), &query.node_meta).into()
+                        );
                     }
 
-                    let target = o.target.clone().to_string();
-                    let fqon = if o.module.is_empty() {
-                        target
-                    } else {
-                        format!("{}::{}", o.module.join("::"), target)
-                    };
+                    let fqon = o.node_id.target_fqn(&o.target);
 
                     let node = NodeConfig {
-                        id: o.id.clone(),
+                        id: o.node_id.id().to_string(),
                         kind: NodeKind::Operator,
                         op_type: "trickle::operator".to_string(),
                         ..NodeConfig::default()
@@ -482,25 +479,22 @@ impl Query {
                         None,
                     )?;
                     pipe_ops.insert(id, op);
-                    nodes.insert(common_cow(&o.id), id);
+                    nodes.insert(common_cow(o.node_id.id()), id);
                     outputs.push(id);
                 }
                 Stmt::Script(o) => {
-                    if nodes.contains_key(&common_cow(&o.id)) {
-                        let error_func = if has_builtin_node_name(&common_cow(&o.id)) {
+                    if nodes.contains_key(&common_cow(o.node_id.id())) {
+                        let error_func = if has_builtin_node_name(&common_cow(o.node_id.id())) {
                             query_node_reserved_name_err
                         } else {
                             query_node_duplicate_name_err
                         };
-                        return Err(error_func(o, o.id.clone(), &query.node_meta).into());
+                        return Err(
+                            error_func(o, o.node_id.id().to_string(), &query.node_meta).into()
+                        );
                     }
 
-                    let target = o.target.clone().to_string();
-                    let fqsn = if o.module.is_empty() {
-                        target
-                    } else {
-                        format!("{}::{}", o.module.join("::"), target)
-                    };
+                    let fqsn = o.node_id.target_fqn(&o.target);
 
                     let stmt_srs =
                         srs::Stmt::try_new_from_query::<&'static str, _>(&self.0.query, |query| {
@@ -524,7 +518,7 @@ impl Query {
                     let that_defn = stmt_srs;
 
                     let node = NodeConfig {
-                        id: o.id.clone(),
+                        id: o.node_id.id().to_string(),
                         kind: NodeKind::Script,
                         label,
                         op_type: "trickle::script".to_string(),
@@ -542,7 +536,7 @@ impl Query {
                         None,
                     )?;
                     pipe_ops.insert(id, op);
-                    nodes.insert(common_cow(&o.id), id);
+                    nodes.insert(common_cow(o.node_id.id()), id);
                     outputs.push(id);
                 }
             };

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -19,6 +19,7 @@ pub(crate) mod binary;
 /// custom equality definition - checking for equivalence of different AST nodes
 /// e.g. two different event paths with different metadata
 pub mod eq;
+mod node_id;
 /// Query AST
 pub mod query;
 pub(crate) mod raw;

--- a/tremor-script/src/ast/node_id.rs
+++ b/tremor-script/src/ast/node_id.rs
@@ -1,0 +1,102 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Identifies a node in the AST.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct NodeId {
+    /// The ID of the Node
+    id: String,
+    /// The module of the Node
+    module: Vec<String>,
+}
+
+impl NodeId {
+    /// Create a new `NodeId` from an ID and Module list.
+    pub fn new(id: String, module: Vec<String>) -> Self {
+        Self { id, module }
+    }
+
+    /// The node's id.
+    pub fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    /// The node's module.
+    pub fn module(&self) -> &[String] {
+        &self.module
+    }
+
+    /// Mutate the node's module.
+    pub fn module_mut(&mut self) -> &mut Vec<String> {
+        &mut self.module
+    }
+
+    /// Calculate the fully qualified name from
+    /// the given module path.
+    #[must_use]
+    pub fn fqn(&self) -> String {
+        if self.module.is_empty() {
+            self.id.to_string()
+        } else {
+            format!("{}::{}", self.module.join("::"), self.id)
+        }
+    }
+
+    /// Calculate the fully qualified name of some
+    /// target identifier given this node's module
+    /// path.
+    #[must_use]
+    pub fn target_fqn(&self, target: &str) -> String {
+        if self.module.is_empty() {
+            target.to_string()
+        } else {
+            format!("{}::{}", self.module.join("::"), target)
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_fqn {
+    ($struct:ident) => {
+        impl $struct<'_> {
+            fn fqn(&self) -> String {
+                self.node_id.fqn()
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use super::NodeId;
+
+    #[test]
+    fn fqn() {
+        let no_module = NodeId::new("foo".to_string(), vec![]);
+        assert_eq!(no_module.fqn(), "foo");
+        assert!(no_module.module().is_empty());
+
+        let with_module = NodeId::new(
+            "foo".to_string(),
+            vec!["bar".to_string(), "baz".to_string()],
+        );
+        assert_eq!(with_module.fqn(), "bar::baz::foo");
+        assert_eq!(with_module.module(), &["bar", "baz"]);
+
+        let target = "quux";
+        assert_eq!(no_module.target_fqn(target), target);
+        assert_eq!(with_module.target_fqn(target), "bar::baz::quux");
+    }
+}

--- a/tremor-script/src/ast/to_static.rs
+++ b/tremor-script/src/ast/to_static.rs
@@ -1052,17 +1052,15 @@ impl<'script> WindowDecl<'script> {
     #[must_use]
     pub fn into_static(self) -> WindowDecl<'static> {
         let WindowDecl {
+            node_id,
             mid,
-            module,
-            id,
             kind,
             params,
             script,
         } = self;
         WindowDecl {
+            node_id,
             mid,
-            module,
-            id,
             kind,
             params: params
                 .into_iter()
@@ -1079,17 +1077,15 @@ impl<'script> OperatorDecl<'script> {
     #[must_use]
     pub fn into_static(self) -> OperatorDecl<'static> {
         let OperatorDecl {
+            node_id,
             mid,
             kind,
-            module,
-            id,
             params,
         } = self;
         OperatorDecl {
+            node_id,
             mid,
             kind,
-            module,
-            id,
             params: params.map(|params| {
                 params
                     .into_iter()


### PR DESCRIPTION
# Pull request

## Description

This PR factors out many instances of `id: String` and `module: Vec<String>` into a new type, `NodeId`.

```rust
/// Identifies a node in the AST.
#[derive(Clone, Debug, PartialEq, Serialize)]
pub struct NodeId {
    /// The ID of the Node
    id: String,
    /// The module of the Node
    module: Vec<String>,
}
```

Thoughts / Main changes.
1. Factoring it out will break anything that relies on the serialization, `#[serde(flatten)]` will keep the same functionality. I did not add it in since I passed all of the tests.
2. I created a trait `FullyQualifiedName` with a `fqn` function that calculates the fully qualified name. I then replaced the `fqXn` methods with `fqn`. It feels cleaner. 
3. `NodeId` feels like an ok name, could use suggestions.
4. Might get some performance boosts by switching to an inline string crate. Something like [smartstring](https://github.com/bodil/smartstring) might help, I think it's worth making an issue for. You could also even make `module` an `ArrayVec`.

## Related

* closes #1211

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

I'll update the changelog once we commit to the trait / naming.
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


