### PR TITLE
Fix failing metadata fetch in kafka onramp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
 - Fix gcs go-auth token refresh
 - Fix `create script` syntax for aliased scripts with overridden `params`
 - Add benchmark names to benchmark tags
+- Kafka onramp: Remove failing metadata fetch in order to verify topic existance. Instead detect subscription errors and stop the onramp in that case.
+
 
 ## 0.11.4
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -635,7 +635,10 @@ where
                             self.source.fail(original_id);
                         }
                     }
-                    Ok(SourceReply::StateChange(SourceState::Disconnected)) => return Ok(()),
+                    Ok(SourceReply::StateChange(SourceState::Disconnected)) => {
+                        warn!("[Source::{}] Disconnected.", self.source_id);
+                        return Ok(());
+                    }
                     Ok(SourceReply::StateChange(SourceState::Connected)) => (),
                     Ok(SourceReply::Empty(sleep_ms)) => {
                         task::sleep(Duration::from_millis(sleep_ms)).await;


### PR DESCRIPTION

# Pull request

## Description

This is a port of the bugfix in 0.11.9 to our `main` branch.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


