### PR TITLE
Remove no longer needed skip for tarpaulin

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,8 +45,8 @@ jobs:
           PROPTEST_CASES: 2500
           RUSTFLAGS: -D warnings -C target-feature=+avx,+avx2,+sse4.2
         with:
-          version: "0.18.0"
-          args: " --avoid-cfg-tarpaulin --exclude-files target* tremor-cli tremor-api **/errors.rs --out Lcov --all"
+          version: "0.18.3"
+          args: " --exclude-files target* tremor-cli tremor-api **/errors.rs --out Lcov --all"
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
# Pull request

## Description

Removes the skip for crates that crates with outdated required :),  also update to 0.18.3

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no code changes

