### PR TITLE
tremor-cli/test: Refactor large parts of the test code.

### DIFF
--- a/tremor-cli/src/cli.yaml
+++ b/tremor-cli/src/cli.yaml
@@ -96,9 +96,12 @@ subcommands:
             about: One of `all`, `api`, `bench`, `command`, `integration`, `rest`, or `unit`
             takes_value: true
             default_value: "all"
+            index: 1
         - PATH:
             about: The root test path
+            takes_value: true
             default_value: "tests"
+            index: 2
         - REPORT:
             about: Should generate a test report to specified path
             short: o

--- a/tremor-cli/src/report.rs
+++ b/tremor-cli/src/report.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::test::kind::Kind;
 use crate::test::stats;
 use std::collections::HashMap;
 
@@ -24,7 +25,7 @@ pub(crate) struct TestRun {
     pub(crate) includes: Vec<String>,
     pub(crate) excludes: Vec<String>,
     pub(crate) reports: HashMap<String, Vec<TestReport>>,
-    pub(crate) stats: HashMap<String, stats::Stats>,
+    pub(crate) stats: HashMap<Kind, stats::Stats>,
 }
 
 /// A test report is the collection of test suites that

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -14,13 +14,13 @@
 
 use crate::errors::{Error, ErrorKind, Result};
 use crate::job;
-use crate::report;
+use crate::report::{self, TestReport};
 use crate::status;
-use crate::test;
 use crate::test::command::suite_command;
+use crate::test::stats::Stats;
 use crate::util::{basename, slurp_string};
 use clap::ArgMatches;
-use globwalk::{FileType, GlobWalkerBuilder};
+use globwalk::{DirEntry, FileType, GlobWalkerBuilder};
 use kind::Kind;
 pub(crate) use kind::Unknown;
 use metadata::Meta;
@@ -29,24 +29,21 @@ use std::convert::TryInto;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tag::TagFilter;
-use tremor_common::file;
+use tremor_common::file::{self, canonicalize};
 use tremor_common::time::nanotime;
 
 mod after;
 mod assert;
 mod before;
 mod command;
-mod kind;
+pub(crate) mod kind;
 mod metadata;
 mod process;
 pub mod stats;
 pub mod tag;
 mod unit;
 
-fn suite_bench(
-    root: &Path,
-    config: &TestConfig,
-) -> Result<(stats::Stats, Vec<report::TestReport>)> {
+fn suite_bench(root: &Path, config: &TestConfig) -> Result<(Stats, Vec<report::TestReport>)> {
     if let Ok(benches) = GlobWalkerBuilder::new(root, &config.meta.includes)
         .case_insensitive(true)
         .file_type(FileType::DIR)
@@ -55,38 +52,33 @@ fn suite_bench(
         let benches = benches.filter_map(std::result::Result::ok);
 
         let mut suite = vec![];
-        let mut stats = stats::Stats::new();
+        let mut test_stats = Stats::new();
 
         status::h0("Framework", "Finding benchmark test scenarios")?;
 
         for bench in benches {
-            let (s, t) = run_bench(bench.path(), config, stats)?;
-
-            stats = s;
+            let (s, t) = run_bench(bench.path(), config)?;
+            test_stats.merge(&s);
             if let Some(report) = t {
                 suite.push(report);
             }
         }
 
-        Ok((stats, suite))
+        Ok((test_stats, suite))
     } else {
         Err("Unable to walk test path for benchmarks".into())
     }
 }
 
-fn run_bench(
-    root: &Path,
-    config: &TestConfig,
-    mut stats: stats::Stats,
-) -> Result<(stats::Stats, Option<report::TestReport>)> {
-    let bench_root = root.to_string_lossy();
+fn run_bench(root: &Path, config: &TestConfig) -> Result<(Stats, Option<report::TestReport>)> {
     let tags = tag::resolve(config.base_directory.as_path(), root)?;
+    let mut test_stats = Stats::new();
 
     let (matched, is_match) = config.matches(&tags);
     if is_match {
-        status::h1("Benchmark", &format!("Running {}", &basename(&bench_root)))?;
+        status::h1("Benchmark", &format!("Running {}", &root.display()))?;
         let cwd = std::env::current_dir()?;
-        std::env::set_current_dir(Path::new(&root))?;
+        std::env::set_current_dir(&root)?;
         status::tags(&tags, Some(&matched), Some(&config.excludes))?;
         let test_report = process::run_process(
             "bench",
@@ -100,26 +92,23 @@ fn run_bench(
 
         status::duration(test_report.duration, "  ")?;
         if test_report.stats.is_pass() {
-            stats.pass();
+            test_stats.pass();
         } else {
-            stats.fail(&bench_root);
+            test_stats.fail(&config.base_directory.display().to_string());
         }
-        Ok((stats, Some(test_report)))
+        Ok((test_stats, Some(test_report)))
     } else {
-        stats.skip();
+        test_stats.skip();
         status::h1(
             "  Benchmark",
-            &format!("Skipping {}", &basename(&bench_root)),
+            &format!("Skipping {}", &config.base_directory.display()),
         )?;
         status::tags(&tags, Some(&matched), Some(&config.excludes))?;
-        Ok((stats, None))
+        Ok((test_stats, None))
     }
 }
 
-fn suite_integration(
-    root: &Path,
-    config: &TestConfig,
-) -> Result<(stats::Stats, Vec<report::TestReport>)> {
+fn suite_integration(root: &Path, config: &TestConfig) -> Result<(Stats, Vec<report::TestReport>)> {
     if let Ok(tests) = GlobWalkerBuilder::new(root, &config.meta.includes)
         .case_insensitive(true)
         .file_type(FileType::DIR)
@@ -128,22 +117,22 @@ fn suite_integration(
         let tests = tests.filter_map(std::result::Result::ok);
 
         let mut suite = vec![];
-        let mut stats = stats::Stats::new();
+        let mut test_stats = Stats::new();
 
         status::h0("Framework", "Finding integration test scenarios")?;
 
         for test in tests {
-            let (s, t) = run_integration(test.path(), config, stats)?;
+            let (s, t) = run_integration(test.path(), config)?;
 
-            stats = s;
+            test_stats = s;
             if let Some(report) = t {
                 suite.push(report);
             }
         }
 
-        status::rollups("\n  Integration", &stats)?;
+        status::rollups("\n  Integration", &test_stats)?;
 
-        Ok((stats, suite))
+        Ok((test_stats, suite))
     } else {
         Err("Unable to walk test path for integration tests".into())
     }
@@ -152,11 +141,11 @@ fn suite_integration(
 fn run_integration(
     root: &Path,
     config: &TestConfig,
-    mut stats: stats::Stats,
-) -> Result<(stats::Stats, Option<report::TestReport>)> {
+) -> Result<(Stats, Option<report::TestReport>)> {
     let base = config.base_directory.as_path();
     let bench_root = root.to_string_lossy();
     let tags = tag::resolve(base, root)?;
+    let mut test_stats = Stats::new();
 
     let (matched, is_match) = config.matches(&tags);
     if is_match {
@@ -169,34 +158,33 @@ fn run_integration(
         std::env::set_current_dir(&root)?;
         status::tags(&tags, Some(&matched), Some(&config.excludes))?;
 
-        // Run integration tests
         let test_report = process::run_process("integration", base, root, &tags)?;
 
         // Restore cwd
         file::set_current_dir(&cwd)?;
 
         if test_report.stats.is_pass() {
-            stats.pass();
+            test_stats.pass();
         } else {
-            stats.fail(&bench_root);
+            test_stats.fail(&bench_root);
         }
-        stats.assert += &test_report.stats.assert;
+        test_stats.assert += &test_report.stats.assert;
 
         status::stats(&test_report.stats, "  ")?;
         status::duration(test_report.duration, "    ")?;
-        Ok((stats, Some(test_report)))
+        Ok((test_stats, Some(test_report)))
     } else {
-        stats.skip();
+        test_stats.skip();
         status::h1(
             "Integration",
             &format!("Skipping {}", &basename(&bench_root)),
         )?;
         status::tags(&tags, Some(&matched), Some(&config.excludes))?;
-        Ok((stats, None))
+        Ok((test_stats, None))
     }
 }
 
-fn suite_unit(root: &Path, conf: &TestConfig) -> Result<(stats::Stats, Vec<report::TestReport>)> {
+fn suite_unit(root: &Path, conf: &TestConfig) -> Result<(Stats, Vec<report::TestReport>)> {
     let base = conf.base_directory.as_path();
     let suites = GlobWalkerBuilder::new(root, "all.tremor")
         .case_insensitive(true)
@@ -205,8 +193,8 @@ fn suite_unit(root: &Path, conf: &TestConfig) -> Result<(stats::Stats, Vec<repor
         .map_err(|e| format!("Unable to walk test path for unit tests: {}", e))?;
 
     let suites = suites.filter_map(std::result::Result::ok);
-    let mut reports = vec![];
-    let mut stats = stats::Stats::new();
+    let mut test_reports = vec![];
+    let mut test_stats = Stats::new();
 
     status::h0("Framework", "Finding unit test scenarios")?;
 
@@ -215,17 +203,18 @@ fn suite_unit(root: &Path, conf: &TestConfig) -> Result<(stats::Stats, Vec<repor
         let scenario_tags = tag::resolve(base, root)?;
         status::tags(&scenario_tags, Some(&conf.includes), Some(&conf.excludes))?;
         let report = unit::run_suite(suite.path(), &scenario_tags, conf)?;
-        stats.merge(&report.stats);
+        test_stats.merge(&report.stats);
         status::stats(&report.stats, "  ")?;
         status::duration(report.duration, "    ")?;
-        reports.push(report);
+        test_reports.push(report);
     }
 
-    status::rollups("  Unit", &stats)?;
+    status::rollups("  Unit", &test_stats)?;
 
-    Ok((stats, reports))
+    Ok((test_stats, test_reports))
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct TestConfig {
     pub(crate) quiet: bool,
     pub(crate) verbose: bool,
@@ -233,68 +222,167 @@ pub(crate) struct TestConfig {
     pub(crate) includes: Vec<String>,
     pub(crate) excludes: Vec<String>,
     pub(crate) meta: Meta,
+    pub(crate) report: Option<String>,
     pub(crate) base_directory: PathBuf,
 }
 impl TestConfig {
     fn matches(&self, filter: &TagFilter) -> (Vec<String>, bool) {
         filter.matches(self.sys_filter, &self.includes, &self.excludes)
     }
+
+    fn from_matches(args: &ArgMatches) -> Result<TestConfig> {
+        let base_directory = canonicalize(args.value_of("PATH").unwrap_or_default())?;
+        let report = args
+            .value_of("REPORT")
+            .map(std::string::ToString::to_string);
+        let quiet = args.is_present("QUIET");
+        let verbose = args.is_present("verbose");
+        let includes = match args.values_of("INCLUDES") {
+            Some(matches) => matches.map(std::string::ToString::to_string).collect(),
+            None => vec![],
+        };
+
+        let excludes = match args.values_of("EXCLUDES") {
+            Some(matches) => matches.map(std::string::ToString::to_string).collect(),
+            None => vec![],
+        };
+
+        Ok(TestConfig {
+            quiet,
+            verbose,
+            includes,
+            excludes,
+            report,
+            sys_filter: &[],
+            meta: Meta::default(),
+            base_directory,
+        })
+    }
 }
 
-#[allow(clippy::too_many_lines)]
+fn run_single_test(config: &TestConfig) -> Result<(Stats, Vec<TestReport>)> {
+    // Our starting point in running a single test is also the directory we're
+    // trying to run. No further tests hide somewhere down the directory
+    // hierarchy.
+    let path = config.base_directory.as_path();
+
+    match config.meta.kind {
+        Kind::Bench => {
+            let (stats, test_report) = run_bench(path, config)?;
+            Ok((stats, vec![test_report].into_iter().flatten().collect()))
+        }
+        Kind::Integration => {
+            let (stats, test_report) = run_integration(path, config)?;
+            Ok((stats, vec![test_report].into_iter().flatten().collect()))
+        }
+        // Command tests are their own beast, one singular folder might
+        // well result in many tests run
+        Kind::Command => command::suite_command(path, config),
+        Kind::Unit => suite_unit(path, config),
+        Kind::All => {
+            Err(Error::from("No tests run: Can't run this test without being told what type it is. Rerun with `bench`, `integration`, `command` or `unit`."))
+        }
+        Kind::Unknown(ref x) => {
+            Err(Error::from(format!(
+                "No tests run: Unknown kind of test: {}",
+                x
+            )))
+        }
+    }
+}
+
+fn run_suite(
+    config: &TestConfig,
+    meta_path: &DirEntry,
+) -> Result<(Stats, Vec<report::TestReport>, Kind)> {
+    let mut config = config.clone();
+    let root = match meta_path.path().parent() {
+        Some(root) => root,
+        None => return Err(Error::from("")),
+    };
+    let mut meta_str = slurp_string(&meta_path.path())?;
+    let local_meta: Meta = simd_json::from_str(meta_str.as_mut_str())?;
+
+    if config.meta.kind == Kind::All || local_meta.kind == config.meta.kind {
+        if config.meta.kind == Kind::All {
+            config.includes.push("all".into());
+        }
+
+        // Set config meta to the local file for the duration of the test run.
+        let old_meta = config.meta;
+        config.meta = local_meta.clone();
+
+        // This dispatches on the type specified in the local `meta.json`,
+        // therefore we can't be sure we haven't already ruled out not-matching
+        // suite types .
+        let (stats, reports) = match config.meta.kind {
+            Kind::Bench => suite_bench(root, &config),
+            Kind::Integration => suite_integration(root, &config),
+            Kind::Command => suite_command(root, &config),
+            Kind::Unit => suite_unit(root, &config),
+            Kind::All => {
+                status::h1(
+                    &meta_path.path().to_string_lossy(),
+                    "Skipping suite due to invalid local kind: All",
+                )?;
+                Ok((Stats::new(), Vec::new()))
+            }
+            Kind::Unknown(x) => {
+                status::h1(
+                    &meta_path.path().to_string_lossy(),
+                    &format!("Skipping suite due to invalid kind: {}", x),
+                )?;
+                Ok((Stats::new(), Vec::new()))
+            }
+        }?;
+
+        config.meta = old_meta;
+        Ok((stats, reports, local_meta.kind))
+    } else {
+        // Skip test if not of the kind that is being run (bench,
+        // integration, unit, command)
+        Ok((Stats::new(), Vec::new(), local_meta.kind))
+    }
+}
+
 pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
     env_logger::init();
-
-    let kind: test::Kind = matches.value_of("MODE").unwrap_or_default().try_into()?;
-    let path = matches.value_of("PATH").unwrap_or_default();
-    let report = matches.value_of("REPORT");
-    let quiet = matches.is_present("QUIET");
-    let verbose = matches.is_present("verbose");
-    let includes: Vec<String> = if matches.is_present("INCLUDES") {
-        if let Some(matches) = matches.values_of("INCLUDES") {
-            matches.map(std::string::ToString::to_string).collect()
-        } else {
-            vec![]
-        }
-    } else {
-        vec![]
-    };
-
-    let excludes: Vec<String> = if matches.is_present("EXCLUDES") {
-        if let Some(matches) = matches.values_of("EXCLUDES") {
-            matches.map(std::string::ToString::to_string).collect()
-        } else {
-            vec![]
-        }
-    } else {
-        vec![]
-    };
-    let base_directory = tremor_common::file::canonicalize(&path)?;
-    let mut config = TestConfig {
-        quiet,
-        verbose,
-        includes,
-        excludes,
-        sys_filter: &[],
-        meta: Meta::default(),
-        base_directory,
-    };
-
+    let mut config = TestConfig::from_matches(matches)?;
     let found = GlobWalkerBuilder::new(&config.base_directory, "meta.json")
         .case_insensitive(true)
         .build()
-        .map_err(|e| Error::from(format!("failed to walk directory `{}`: {}", path, e)))?;
+        .map_err(|e| {
+            Error::from(format!(
+                "failed to walk directory `{}`: {}",
+                &config.base_directory.display(),
+                e
+            ))
+        })?;
 
-    let mut reports = HashMap::new();
-    let mut bench_stats = stats::Stats::new();
-    let mut unit_stats = stats::Stats::new();
-    let mut cmd_stats = stats::Stats::new();
-    let mut integration_stats = stats::Stats::new();
+    let mut test_stats: HashMap<Kind, Stats> = HashMap::new();
+    test_stats.insert(Kind::Bench, Stats::new());
+    test_stats.insert(Kind::Unit, Stats::new());
+    test_stats.insert(Kind::Command, Stats::new());
+    test_stats.insert(Kind::Integration, Stats::new());
+
+    let mut test_reports = HashMap::new();
 
     let found: Vec<_> = found.filter_map(std::result::Result::ok).collect();
     let start = nanotime();
 
-    if found.is_empty() {
+    if found.len() > 1 {
+        for meta in found {
+            let (stats, reports, kind_run) = run_suite(&config, &meta)?;
+            test_stats
+                .get_mut(&kind_run)
+                .ok_or_else(|| Error::from(format!("No stats for test kind {:?}", &kind_run)))?
+                .merge(&stats);
+
+            test_reports.insert(meta.path().to_string_lossy().to_string(), reports);
+
+            status::hr();
+        }
+    } else {
         // No meta.json was found, therefore we might have the path to a
         // specific folder. Let's apply some heuristics to see if we have
         // something runnable.
@@ -308,147 +396,71 @@ pub(crate) fn run_cmd(matches: &ArgMatches) -> Result<()> {
         .filter_map(std::result::Result::ok);
 
         if files.count() >= 1 {
-            let stats = stats::Stats::new();
             // Use CLI kind instead of default kind, since we don't have a
             // meta.json to override the default with.
-            config.meta.kind = kind;
-            let test_report = match config.meta.kind {
-                Kind::Bench => {
-                    let (s, t) = run_bench(PathBuf::from(path).as_path(), &config, stats)?;
-                    match t {
-                        Some(x) => {
-                            bench_stats.merge(&s);
-                            vec![x]
-                        }
-                        None => {
-                            return Err(Error::from(
-                                "Specified test folder is excluded from running.",
-                            ))
-                        }
-                    }
-                }
-                Kind::Integration => {
-                    let (s, t) = run_integration(PathBuf::from(path).as_path(), &config, stats)?;
-                    match t {
-                        Some(x) => {
-                            integration_stats.merge(&s);
-                            vec![x]
-                        }
-                        None => {
-                            return Err(Error::from(
-                                "Specified test folder is excluded from running.",
-                            ))
-                        }
-                    }
-                }
-                // Command tests are their own beast, one singular folder might
-                // well result in many tests run
-                Kind::Command => {
-                    let (s, t) = command::suite_command(PathBuf::from(path).as_path(), &config)?;
-                    cmd_stats.merge(&s);
-                    t
-                }
-                Kind::Unit => {
-                    let (s, t) = suite_unit(&PathBuf::from("/"), &config)?;
-                    unit_stats.merge(&s);
-                    t
-                }
-                Kind::All => {
-                    eprintln!("No tests run: Don't know how to run test of kind All");
-                    Vec::new()
-                }
-                Kind::Unknown(ref x) => {
-                    eprintln!("No tests run: Unknown kind of test: {}", x);
-                    Vec::new()
-                }
-            };
-            reports.insert(config.meta.kind.to_string(), test_report);
+            config.meta.kind = matches.value_of("MODE").unwrap_or_default().try_into()?;
+            let (stats, report) = run_single_test(&config)?;
+            test_stats
+                .get_mut(&config.meta.kind)
+                .ok_or_else(|| {
+                    Error::from(format!("No stats for test kind {:?}", &config.meta.kind))
+                })?
+                .merge(&stats);
+            test_reports.insert(config.base_directory.to_string_lossy().to_string(), report);
         } else {
             return Err(Error::from(
                 "Specified folder does not contain a runnable test",
             ));
         }
-    } else {
-        for meta in found {
-            if let Some(root) = meta.path().parent() {
-                let mut meta_str = slurp_string(&meta.path())?;
-                let meta: Meta = simd_json::from_str(meta_str.as_mut_str())?;
-                config.meta = meta;
-
-                if config.meta.kind == Kind::All {
-                    config.includes.push("all".into());
-                }
-
-                if !(kind == Kind::All || kind == config.meta.kind) {
-                    continue;
-                }
-
-                let test_reports = match config.meta.kind {
-                    Kind::Bench => {
-                        let (s, t) = suite_bench(root, &config)?;
-                        bench_stats.merge(&s);
-                        t
-                    }
-                    Kind::Integration => {
-                        let (s, t) = suite_integration(root, &config)?;
-                        integration_stats.merge(&s);
-                        t
-                    }
-                    Kind::Command => {
-                        let (s, t) = suite_command(root, &config)?;
-                        cmd_stats.merge(&s);
-                        t
-                    }
-                    Kind::Unit => {
-                        let (s, t) = suite_unit(root, &config)?;
-                        unit_stats.merge(&s);
-                        t
-                    }
-                    Kind::All | Kind::Unknown(_) => continue,
-                };
-                reports.insert(config.meta.kind.to_string(), test_reports);
-                status::hr();
-            }
-        }
-    }
+    };
     let elapsed = nanotime() - start;
 
     status::hr();
     status::hr();
-    status::rollups("All Benchmark", &bench_stats)?;
-    status::rollups("All Integration", &integration_stats)?;
-    status::rollups("All Command", &cmd_stats)?;
-    status::rollups("All Unit", &unit_stats)?;
-    let mut all_stats = stats::Stats::new();
-    all_stats.merge(&bench_stats);
-    all_stats.merge(&integration_stats);
-    all_stats.merge(&cmd_stats);
-    all_stats.merge(&unit_stats);
+    status::rollups(
+        "All Benchmark",
+        test_stats.get(&Kind::Bench).unwrap_or(&Stats::new()),
+    )?;
+    status::rollups(
+        "All Integration",
+        test_stats.get(&Kind::Integration).unwrap_or(&Stats::new()),
+    )?;
+    status::rollups(
+        "All Command",
+        test_stats.get(&Kind::Command).unwrap_or(&Stats::new()),
+    )?;
+    status::rollups(
+        "All Unit",
+        test_stats.get(&Kind::Unit).unwrap_or(&Stats::new()),
+    )?;
+
+    let mut all_stats = Stats::new();
+    for s in test_stats.values() {
+        all_stats.merge(s);
+    }
+
     status::rollups("Total", &all_stats)?;
-    let mut stats_map = HashMap::new();
-    stats_map.insert("all".to_string(), all_stats.clone());
-    stats_map.insert("bench".to_string(), bench_stats);
-    stats_map.insert("integration".to_string(), integration_stats);
-    stats_map.insert("command".to_string(), cmd_stats);
-    stats_map.insert("unit".to_string(), unit_stats);
+
+    test_stats.insert(Kind::All, all_stats.clone());
+
     status::total_duration(elapsed)?;
 
-    let test_run = report::TestRun {
-        metadata: report::metadata(),
-        includes: config.includes,
-        excludes: config.excludes,
-        reports,
-        stats: stats_map,
-    };
-    if let Some(report) = report {
-        let mut file = file::create(report)?;
+    if let Some(report) = config.report {
+        let test_run = report::TestRun {
+            metadata: report::metadata(),
+            includes: config.includes,
+            excludes: config.excludes,
+            reports: test_reports,
+            stats: test_stats,
+        };
+        let mut file = file::create(&report)?;
         let result = simd_json::to_string(&test_run)?;
         file.write_all(result.as_bytes())
             .map_err(|e| Error::from(format!("Failed to write report to `{}`: {}", report, e)))?;
     }
 
     if all_stats.fail > 0 {
-        Err(ErrorKind::TestFailures(all_stats).into())
+        Err(ErrorKind::TestFailures(all_stats.clone()).into())
     } else {
         Ok(())
     }

--- a/tremor-cli/src/test/kind.rs
+++ b/tremor-cli/src/test/kind.rs
@@ -14,7 +14,7 @@
 
 use std::{convert::TryFrom, error::Error, fmt::Debug, fmt::Display};
 /// Specifies a kind of test framework, or a composite `all` to capture all framework variants
-#[derive(Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Hash, Eq)]
 pub(crate) enum Kind {
     Bench,
     Integration,

--- a/tremor-cli/src/test/metadata.rs
+++ b/tremor-cli/src/test/metadata.rs
@@ -15,7 +15,7 @@
 use crate::test::kind;
 use crate::test::tag::Tags;
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub(crate) struct Meta {
     pub(crate) about: Option<String>,
     pub(crate) kind: kind::Kind,


### PR DESCRIPTION
# Pull request

## Description

This is a refactoring of large parts of `test.rs`, in order to make the code more readable and to get rid of one of the very long functions mentioned in #20. It's essentially a spillover from my other patch at #1283. 

Tests are still rather hard to write for this (since I didn't touch the functionality), but it's starting to be easier to test and it might end up with being able to test parts of the testing module. I've done my best to 

There is no external impact to this change except for 1-2 added messages when something is skipped.

## Related

- This is part of an effort to resolve the "functions too long" issue, #20. 

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* (N/A) Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* (N/A) The performance impact of the change is measured (see below)

## Performance

Performance impact should not occur, and if anything be very mildly positive from removing a couple of duplicate checks :) 

