### PR TITLE
S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "aws-auth"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-types",
+ "pin-project 1.0.8",
+ "smithy-async",
+ "smithy-http",
+ "tokio 1.14.0",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-config"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-http",
+ "aws-hyper",
+ "aws-sdk-sts",
+ "aws-types",
+ "bytes 1.1.0",
+ "http 0.2.5",
+ "smithy-async",
+ "smithy-client",
+ "smithy-http",
+ "smithy-http-tower",
+ "smithy-json",
+ "smithy-types",
+ "tokio 1.14.0",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-types",
+ "http 0.2.5",
+ "regex",
+ "smithy-http",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-types",
+ "http 0.2.5",
+ "lazy_static",
+ "smithy-http",
+ "smithy-types",
+ "thiserror",
+]
+
+[[package]]
+name = "aws-hyper"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-auth",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "bytes 1.1.0",
+ "fastrand",
+ "http 0.2.5",
+ "http-body 0.4.4",
+ "hyper 0.14.15",
+ "hyper-rustls",
+ "pin-project 1.0.8",
+ "smithy-client",
+ "smithy-http",
+ "smithy-http-tower",
+ "smithy-types",
+ "tokio 1.14.0",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.0.19-alpha"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-auth",
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-types",
+ "bytes 1.1.0",
+ "http 0.2.5",
+ "md5",
+ "smithy-client",
+ "smithy-eventstream",
+ "smithy-http",
+ "smithy-types",
+ "smithy-xml",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.0.19-alpha"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-auth",
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-types",
+ "bytes 1.1.0",
+ "http 0.2.5",
+ "smithy-client",
+ "smithy-http",
+ "smithy-query",
+ "smithy-types",
+ "smithy-xml",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "aws-auth",
+ "aws-sigv4",
+ "aws-types",
+ "http 0.2.5",
+ "smithy-eventstream",
+ "smithy-http",
+ "thiserror",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "bytes 1.1.0",
+ "chrono",
+ "form_urlencoded",
+ "hex",
+ "http 0.2.5",
+ "http-body 0.4.4",
+ "percent-encoding 2.1.0",
+ "ring",
+ "smithy-eventstream",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "rustc_version 0.4.0",
+ "smithy-async",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +975,16 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
+dependencies = [
+ "bytes 1.1.0",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -1284,6 +1462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -2423,10 +2610,12 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
+ "ct-logs",
  "futures-util",
  "hyper 0.14.15",
  "log",
  "rustls 0.19.1",
+ "rustls-native-certs",
  "tokio 1.14.0",
  "tokio-rustls",
  "webpki 0.21.4",
@@ -3043,6 +3232,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -4889,6 +5084,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "smithy-async"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "pin-project-lite 0.2.7",
+ "tokio 1.14.0",
+]
+
+[[package]]
+name = "smithy-client"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "bytes 1.1.0",
+ "fastrand",
+ "http 0.2.5",
+ "http-body 0.4.4",
+ "hyper 0.14.15",
+ "hyper-rustls",
+ "pin-project 1.0.8",
+ "smithy-http",
+ "smithy-http-tower",
+ "smithy-types",
+ "tokio 1.14.0",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-eventstream"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "bytes 1.1.0",
+ "crc32fast",
+ "smithy-types",
+]
+
+[[package]]
+name = "smithy-http"
+version = "0.0.1"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "bytes 1.1.0",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.5",
+ "http-body 0.4.4",
+ "hyper 0.14.15",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.8",
+ "smithy-eventstream",
+ "smithy-types",
+ "thiserror",
+ "tokio 1.14.0",
+ "tokio-util 0.6.9",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-http-tower"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "bytes 1.1.0",
+ "http 0.2.5",
+ "http-body 0.4.4",
+ "pin-project 1.0.8",
+ "smithy-http",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-json"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "smithy-types",
+]
+
+[[package]]
+name = "smithy-query"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "smithy-types"
+version = "0.0.1"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "chrono",
+ "itoa",
+ "num-integer",
+ "ryu",
+]
+
+[[package]]
+name = "smithy-xml"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+dependencies = [
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
 name = "smol"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5916,6 +6222,9 @@ dependencies = [
  "async-tls",
  "async-trait",
  "async-tungstenite 0.16.0",
+ "aws-config",
+ "aws-sdk-s3",
+ "aws-types",
  "base64 0.13.0",
  "beef",
  "bimap",
@@ -6267,6 +6576,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
 name = "utf-8"
@@ -6658,6 +6973,12 @@ checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "xz2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,36 +619,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "aws-auth"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "aws-types",
- "pin-project 1.0.8",
- "smithy-async",
- "smithy-http",
- "tokio 1.14.0",
- "tracing",
- "zeroize",
-]
-
-[[package]]
 name = "aws-config"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072f0d08f62093e2a38603307e368bf90d5acd3e3b54b60292cba4698bba38b"
 dependencies = [
  "aws-http",
  "aws-hyper",
  "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.1.0",
- "http 0.2.5",
- "smithy-async",
- "smithy-client",
- "smithy-http",
- "smithy-http-tower",
- "smithy-json",
- "smithy-types",
+ "http",
  "tokio 1.14.0",
  "tower",
  "tracing",
@@ -656,48 +643,51 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4d939891f640c013bbae11180e767470d75c9d61b48d85008fbd19a46e6a46"
 dependencies = [
+ "aws-smithy-http",
  "aws-types",
- "http 0.2.5",
+ "http",
  "regex",
- "smithy-http",
+ "tracing",
 ]
 
 [[package]]
 name = "aws-http"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f685b9441c4e99d478b4e70cd0993ed178029534c296143ae9d37f2a424dde82"
 dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
  "aws-types",
- "http 0.2.5",
+ "http",
  "lazy_static",
- "smithy-http",
- "smithy-types",
- "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "aws-hyper"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f0a1a3500ec4b07ba95b56df754dd1a3b0555b1f27f71592bbfa3ee4a8e2a7"
 dependencies = [
- "aws-auth",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
  "bytes 1.1.0",
  "fastrand",
- "http 0.2.5",
+ "http",
  "http-body 0.4.4",
  "hyper 0.14.15",
  "hyper-rustls",
  "pin-project 1.0.8",
- "smithy-client",
- "smithy-http",
- "smithy-http-tower",
- "smithy-types",
  "tokio 1.14.0",
  "tower",
  "tracing",
@@ -705,83 +695,214 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.0.19-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8787be2f5db0c01ec5b4e89d159cd0d25b536172173c2145463aac669ad2142b"
 dependencies = [
- "aws-auth",
  "aws-endpoint",
  "aws-http",
  "aws-hyper",
  "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-smithy-xml",
  "aws-types",
  "bytes 1.1.0",
- "http 0.2.5",
+ "http",
  "md5",
- "smithy-client",
- "smithy-eventstream",
- "smithy-http",
- "smithy-types",
- "smithy-xml",
+ "tower",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.0.19-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8858771f3809ff70b1c9ebc464b86bf2d7c6ce50a0c2f153484abe45ca76f9"
 dependencies = [
- "aws-auth",
  "aws-endpoint",
  "aws-http",
  "aws-hyper",
  "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
  "aws-types",
  "bytes 1.1.0",
- "http 0.2.5",
- "smithy-client",
- "smithy-http",
- "smithy-query",
- "smithy-types",
- "smithy-xml",
+ "http",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469d7527fc24e3edc32e5edf1b046d7d7c778ed6c4f9c51f869725bb01c101db"
 dependencies = [
- "aws-auth",
  "aws-sigv4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
  "aws-types",
- "http 0.2.5",
- "smithy-eventstream",
- "smithy-http",
+ "http",
  "thiserror",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "bytes 1.1.0",
- "chrono",
- "form_urlencoded",
- "hex",
- "http 0.2.5",
- "http-body 0.4.4",
- "percent-encoding 2.1.0",
- "ring",
- "smithy-eventstream",
  "tracing",
 ]
 
 [[package]]
-name = "aws-types"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
+name = "aws-sigv4"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7d4888513285ec13c9b02c9bf8a3cf264251fc4c51270ca35239e39b18cb57"
 dependencies = [
+ "aws-smithy-eventstream",
+ "bytes 1.1.0",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time 0.3.5",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b323275f9a5118ce0c61c1f509d89d97008f4d6e376826bc744b43b553bf33"
+dependencies = [
+ "pin-project-lite 0.2.7",
+ "tokio 1.14.0",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda35ddfd69ad9623dbb66aeaac1b85bc03974fdb4054fcd05cdb4ce1a78bf12"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes 1.1.0",
+ "fastrand",
+ "http",
+ "http-body 0.4.4",
+ "hyper 0.14.15",
+ "hyper-rustls",
+ "lazy_static",
+ "pin-project 1.0.8",
+ "pin-project-lite 0.2.7",
+ "tokio 1.14.0",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8773ed74ad621f35faac419d0f93778da5b0893780ae8a674aec9d27850335ff"
+dependencies = [
+ "aws-smithy-types",
+ "bytes 1.1.0",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8068bb0c3d2f512ec2ff6c4e74e639266f89bb4bd492f747c4290fe41d17a6e"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "bytes 1.1.0",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body 0.4.4",
+ "hyper 0.14.15",
+ "percent-encoding",
+ "pin-project 1.0.8",
+ "tokio 1.14.0",
+ "tokio-util 0.6.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7beb34a340675391abe55d5ab2619ef2b1c85995126ba1706ba2657ccd602be3"
+dependencies = [
+ "aws-smithy-http",
+ "bytes 1.1.0",
+ "http",
+ "http-body 0.4.4",
+ "pin-project 1.0.8",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721176eec47b71d3226d61ccaa40cebe83ddc644c8981c7c3b34547a62808eb3"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0c0dc09c61921a2104e1487810bd32274d8b57dd00d878895ebc51e2068d85"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a422c3740103fe67102ecbedffe8318dd6a03a209f7e097d1e00a1f3f4d186ac"
+dependencies = [
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.5",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.30.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c884d1dc27ccf45763d42b9f58425493b6cd563a95922f92b87a5d92c4060d4"
+dependencies = [
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.0.26-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4761c3bc4d965b2a3568eaadbfc85eee3cbaa18ba81665f2f472004cb8bb34e9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
  "rustc_version 0.4.0",
- "smithy-async",
  "tracing",
  "zeroize",
 ]
@@ -1470,7 +1591,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -5084,117 +5205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
-name = "smithy-async"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "pin-project-lite 0.2.7",
- "tokio 1.14.0",
-]
-
-[[package]]
-name = "smithy-client"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "bytes 1.1.0",
- "fastrand",
- "http 0.2.5",
- "http-body 0.4.4",
- "hyper 0.14.15",
- "hyper-rustls",
- "pin-project 1.0.8",
- "smithy-http",
- "smithy-http-tower",
- "smithy-types",
- "tokio 1.14.0",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "smithy-eventstream"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "bytes 1.1.0",
- "crc32fast",
- "smithy-types",
-]
-
-[[package]]
-name = "smithy-http"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "bytes 1.1.0",
- "bytes-utils",
- "futures-core",
- "http 0.2.5",
- "http-body 0.4.4",
- "hyper 0.14.15",
- "percent-encoding 2.1.0",
- "pin-project 1.0.8",
- "smithy-eventstream",
- "smithy-types",
- "thiserror",
- "tokio 1.14.0",
- "tokio-util 0.6.9",
- "tracing",
-]
-
-[[package]]
-name = "smithy-http-tower"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "bytes 1.1.0",
- "http 0.2.5",
- "http-body 0.4.4",
- "pin-project 1.0.8",
- "smithy-http",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "smithy-json"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "smithy-types",
-]
-
-[[package]]
-name = "smithy-query"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "smithy-types"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "chrono",
- "itoa",
- "num-integer",
- "ryu",
-]
-
-[[package]]
-name = "smithy-xml"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.19-alpha#74bae11ae1af170e33fb695488f1f514f21884ae"
-dependencies = [
- "thiserror",
- "xmlparser",
-]
-
-[[package]]
 name = "smol"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,6 +5706,15 @@ dependencies = [
  "time-macros",
  "version_check",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6223,6 +6242,7 @@ dependencies = [
  "async-trait",
  "async-tungstenite 0.16.0",
  "aws-config",
+ "aws-endpoint",
  "aws-sdk-s3",
  "aws-types",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,33 +619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "aws-config"
-version = "0.0.26-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072f0d08f62093e2a38603307e368bf90d5acd3e3b54b60292cba4698bba38b"
-dependencies = [
- "aws-http",
- "aws-hyper",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
- "bytes 1.1.0",
- "http",
- "tokio 1.14.0",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "aws-endpoint"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4d939891f640c013bbae11180e767470d75c9d61b48d85008fbd19a46e6a46"
+checksum = "0d3862993d16ce409bbc9beb16744e1e906130c8071ca75e84d967f7ea590eeb"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -656,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f685b9441c4e99d478b4e70cd0993ed178029534c296143ae9d37f2a424dde82"
+checksum = "21902b7009bb5290acab8a297d8c3287b990bdf1c57bb72f331dfaa171854416"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -670,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "aws-hyper"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f0a1a3500ec4b07ba95b56df754dd1a3b0555b1f27f71592bbfa3ee4a8e2a7"
+checksum = "5be61f82810771f547ed72fe9db7e087f555ce1612908ea23b58977272eb2da1"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -695,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8787be2f5db0c01ec5b4e89d159cd0d25b536172173c2145463aac669ad2142b"
+checksum = "0dd39e7e35ae6abe15a7fbe9bf8048ce2e7780026c287f8d43dc5e73b8c0074a"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -718,31 +695,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sts"
-version = "0.0.26-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8858771f3809ff70b1c9ebc464b86bf2d7c6ce50a0c2f153484abe45ca76f9"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-hyper",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes 1.1.0",
- "http",
-]
-
-[[package]]
 name = "aws-sig-auth"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469d7527fc24e3edc32e5edf1b046d7d7c778ed6c4f9c51f869725bb01c101db"
+checksum = "7a16b8c9818854a3a3bba85e970f59d7f09ca0985ff10c9031bb03c95b291323"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-eventstream",
@@ -755,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7d4888513285ec13c9b02c9bf8a3cf264251fc4c51270ca35239e39b18cb57"
+checksum = "f7f531763d106b1f050421d8256ce5d585e75e861d466fe8920157a004d28bf0"
 dependencies = [
  "aws-smithy-eventstream",
  "bytes 1.1.0",
@@ -774,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b323275f9a5118ce0c61c1f509d89d97008f4d6e376826bc744b43b553bf33"
+checksum = "969717af8b7eb7424b67fce3f3c8539b0cf72322f909a30d7ea9e8c5ed2bf929"
 dependencies = [
  "pin-project-lite 0.2.7",
  "tokio 1.14.0",
@@ -784,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda35ddfd69ad9623dbb66aeaac1b85bc03974fdb4054fcd05cdb4ce1a78bf12"
+checksum = "97ffd13190653d37833cf403f7b2963bdd903166933db231a13bdc48ba3fd237"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -808,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8773ed74ad621f35faac419d0f93778da5b0893780ae8a674aec9d27850335ff"
+checksum = "9d1c450819c3918ad7ee8c768a0304edf1f2c53645e0f6b73368bdbbcf540dad"
 dependencies = [
  "aws-smithy-types",
  "bytes 1.1.0",
@@ -819,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8068bb0c3d2f512ec2ff6c4e74e639266f89bb4bd492f747c4290fe41d17a6e"
+checksum = "d4b5992632c561f03699f25d1deda4c73b70be7c9acc0fc3626b270d3cb9a987"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -840,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7beb34a340675391abe55d5ab2619ef2b1c85995126ba1706ba2657ccd602be3"
+checksum = "aaff953c819ed72da79b302ce7ca4464881af23eadc7e5762e9244c90ae6b708"
 dependencies = [
  "aws-smithy-http",
  "bytes 1.1.0",
@@ -854,29 +810,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.30.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721176eec47b71d3226d61ccaa40cebe83ddc644c8981c7c3b34547a62808eb3"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.30.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0c0dc09c61921a2104e1487810bd32274d8b57dd00d878895ebc51e2068d85"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
 name = "aws-smithy-types"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a422c3740103fe67102ecbedffe8318dd6a03a209f7e097d1e00a1f3f4d186ac"
+checksum = "6371c45cde03dc11814f63496366367dacd19af6bfc089c27582bad0c7384fab"
 dependencies = [
  "itoa",
  "num-integer",
@@ -886,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.30.0-alpha"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c884d1dc27ccf45763d42b9f58425493b6cd563a95922f92b87a5d92c4060d4"
+checksum = "167c7e63beace20d29d94143c5a6dd6f4d24142c97ef6c36d8bc7fbf9475c93b"
 dependencies = [
  "thiserror",
  "xmlparser",
@@ -896,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.0.26-alpha"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4761c3bc4d965b2a3568eaadbfc85eee3cbaa18ba81665f2f472004cb8bb34e9"
+checksum = "2d3d5fa5c7fba8b0e9b743ba3da17a14c9f2e882f775d5ed198b602fb331b670"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -6241,8 +6178,6 @@ dependencies = [
  "async-tls",
  "async-trait",
  "async-tungstenite 0.16.0",
- "aws-config",
- "aws-endpoint",
  "aws-sdk-s3",
  "aws-types",
  "base64 0.13.0",
@@ -6596,12 +6531,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,9 +175,11 @@ tonic = { version = "0.5.2", default-features = false, features = [
 tremor-otelapis = { version = "0.2.2" }
 
 # aws-s3
-aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-config" }
-aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-sdk-s3" }
-aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-types" }
+aws-config = "0.0.26-alpha" 
+aws-sdk-s3 = "0.0.26-alpha" 
+aws-types = "0.0.26-alpha" 
+aws-endpoint = "0.0.26-alpha" 
+
 
 # gcp
 googapis = { version = "0.5", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,11 @@ tonic = { version = "0.5.2", default-features = false, features = [
 ] }
 tremor-otelapis = { version = "0.2.2" }
 
+# aws-s3
+aws-config = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-config" }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-sdk-s3" }
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.19-alpha", package = "aws-types" }
+
 # gcp
 googapis = { version = "0.5", default-features = false, features = [
   "google-pubsub-v1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,10 +175,8 @@ tonic = { version = "0.5.2", default-features = false, features = [
 tremor-otelapis = { version = "0.2.2" }
 
 # aws-s3
-aws-config = "0.0.26-alpha" 
-aws-sdk-s3 = "0.0.26-alpha" 
-aws-types = "0.0.26-alpha" 
-aws-endpoint = "0.0.26-alpha" 
+aws-sdk-s3 = "0.2.0" 
+aws-types = "0.2.0" 
 
 
 # gcp

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -21,6 +21,8 @@ pub mod sink;
 
 /// source parts
 pub mod source;
+
+pub(crate) mod s3;
 #[macro_use]
 pub(crate) mod utils;
 
@@ -1157,6 +1159,7 @@ pub fn builtin_connector_types() -> Vec<Box<dyn ConnectorBuilder + 'static>> {
         Box::new(impls::ws::server::Builder::default()),
         Box::new(impls::elastic::Builder::default()),
         Box::new(impls::crononome::Builder::default()),
+        Box::new(s3::Builder::default()),
     ]
 }
 

--- a/src/connectors/s3.rs
+++ b/src/connectors/s3.rs
@@ -1,0 +1,343 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::connectors::prelude::*;
+use crate::Event;
+use async_std::channel;
+use aws_sdk_s3 as s3;
+use s3::model::{CompletedMultipartUpload, CompletedPart};
+use std::{env, mem};
+use value_trait::ValueAccess;
+
+use s3::Client as S3Client;
+struct S3Connector {
+    client_sender: Option<channel::Sender<S3Client>>,
+    config: S3Config,
+}
+
+struct S3Sink {
+    client_receiver: channel::Receiver<S3Client>,
+    bucket: String,
+    client: Option<S3Client>,
+    buffer: Vec<u8>,
+    current_key: String,
+    upload_id: String,
+    part_number: i32,
+    // bookeeping for parts.
+    parts: Vec<CompletedPart>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub struct S3Config {
+    aws_access_token: String,
+    aws_secret_access_key: String,
+    aws_region: String,
+    max_clients: Option<usize>,
+    bucket: String,
+    min_part_size: i32,
+}
+
+impl ConfigImpl for S3Config {}
+
+#[derive(Debug, Default)]
+pub(crate) struct Builder {}
+
+#[async_trait::async_trait]
+impl ConnectorBuilder for Builder {
+    async fn from_config(
+        &self,
+        _id: &TremorUrl,
+        raw_config: &Option<OpConfig>,
+    ) -> Result<Box<dyn Connector>> {
+        if let Some(config) = raw_config {
+            let mut config = S3Config::new(config)?;
+            // Fetch the secrets.
+            config.aws_secret_access_key = env::var(config.aws_secret_access_key)?;
+            config.aws_access_token = env::var(config.aws_access_token)?;
+            Ok(Box::new(S3Connector {
+                client_sender: None,
+                config,
+            }))
+        } else {
+            Err(ErrorKind::MissingConfiguration(String::from("aws-s3")).into())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Sink for S3Sink {
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        event: Event,
+        _ctx: &SinkContext,
+        serializer: &mut EventSerializer,
+        _start: u64,
+    ) -> Result<SinkReply> {
+        // todo!("Working on it!")
+
+        if self.client.is_none() {
+            if let Ok(new_client) = self.client_receiver.recv().await {
+                self.client = Some(new_client);
+            }
+        }
+        // FIXME: Check if a new client is required or not.
+        else if let Ok(new_client) = self.client_receiver.try_recv() {
+            self.client = Some(new_client);
+        }
+
+        let ingest_id = event.ingest_ns;
+
+        for (event, meta) in event.value_meta_iter() {
+            // What to do when meta-data is not present.
+            // FIXME: ayyyyy
+            // let operation = meta.get("operation").map(|value| value.to_string());
+
+            let object_key = meta.get("key").map(|value| value.to_string());
+
+            // Also handle aggreagtion here.
+            // FIXME: what to do for multiple data??
+            let data: Vec<u8> = serializer
+                .serialize(event, ingest_id)?
+                .into_iter()
+                .flatten()
+                .collect();
+
+            // self.upload_object(object_key.unwrap(), data[0].clone())
+            //     .await?;
+
+            if object_key.as_ref().unwrap() != &self.current_key {
+                // Complete the uploads for previous key.
+                self.set_new_key(object_key.unwrap()).await?;
+            }
+
+            self.buffer.extend(data);
+
+            // FIXME: Make a better aggregation logic.
+            if self.buffer.len() > 5 * 1024 * 1024 {
+                self.upload_part().await?;
+            }
+
+            // FIXME: Identify errors which indicate whether the client failed.
+            // then notify.
+        }
+
+        Ok(SinkReply::default())
+    }
+
+    // Required later
+    async fn on_signal(
+        &mut self,
+        _signal: Event,
+        _ctx: &SinkContext,
+        _serializer: &mut EventSerializer,
+    ) -> Result<SinkReply> {
+        // Check if a new client is required or not.
+        if let Ok(new_client) = self.client_receiver.try_recv() {
+            self.client = Some(new_client);
+        }
+        Ok(SinkReply::default())
+    }
+
+    async fn on_stop(&mut self, _ctx: &mut SinkContext) {
+        // Commit the final upload.
+        self.complete_multipart().await.unwrap();
+    }
+
+    fn asynchronous(&self) -> bool {
+        true
+    }
+
+    fn auto_ack(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait::async_trait]
+impl Connector for S3Connector {
+    /// Currently no source
+    async fn create_source(
+        &mut self,
+        _source_context: SourceContext,
+        _builder: SourceManagerBuilder,
+    ) -> Result<Option<SourceAddr>> {
+        Ok(None)
+    }
+
+    /// Stream the events to the bucket
+    // Only runs once.
+    async fn create_sink(
+        &mut self,
+        sink_context: SinkContext,
+        builder: SinkManagerBuilder,
+    ) -> Result<Option<SinkAddr>> {
+        // FIXME: May be wise to increase channel size if you want to have multiple clients.
+        let (client_sender, client_receiver) = channel::bounded(2);
+
+        // set the sender and receiver for a new client
+        self.client_sender = Some(client_sender);
+
+        let s3_sink = S3Sink {
+            client_receiver,
+            bucket: self.config.bucket.clone(),
+            client: None,
+            buffer: Vec::new(),
+            current_key: "".to_owned(),
+            parts: Vec::new(),
+            upload_id: "".to_owned(),
+            part_number: 0,
+        };
+
+        let addr = builder.spawn(s3_sink, sink_context)?;
+        Ok(Some(addr))
+    }
+
+    // Runs on need to connect/reconnect. (multiple times)
+    async fn connect(&mut self, _ctx: &ConnectorContext, _attempt: &Attempt) -> Result<bool> {
+        // Create the client and establish the connection.
+        let shared_config = aws_config::from_env()
+            .credentials_provider(aws_types::Credentials::from_keys(
+                self.config.aws_access_token.clone(),
+                self.config.aws_secret_access_key.clone(),
+                None,
+            ))
+            .region(aws_types::region::Region::new(
+                self.config.aws_region.clone(),
+            ))
+            .load()
+            .await;
+
+        let client = S3Client::new(&shared_config);
+
+        // Check for the existence of the bucket.
+        let exist_bucket = client
+            .head_bucket()
+            .bucket(self.config.bucket.clone())
+            .send()
+            .await;
+
+        if exist_bucket.is_err() {
+            return Err(exist_bucket.unwrap_err().into());
+        }
+
+        // Send the client to the sink.
+        self.client_sender.as_ref().unwrap().send(client).await?;
+
+        Ok(true)
+    }
+
+    // Do argue for plain text..
+    fn default_codec(&self) -> &str {
+        "json"
+    }
+}
+
+impl S3Sink {
+    async fn set_new_key(&mut self, key: String) -> Result<()> {
+        // Finish the previous multipart upload if any.
+        if self.current_key != "" {
+            self.complete_multipart().await?;
+        }
+
+        if key != "" {
+            self.initiate_multipart(key).await?;
+        }
+        // NOTE: The buffers are cleared when the stuff is commited.
+        Ok(())
+    }
+
+    // async fn upload_object(
+    //     &mut self,
+    //     key: String,
+    //     object_bytes: Vec<u8>,
+    // ) -> Result<s3::output::PutObjectOutput> {
+    //     let resp = self
+    //         .client
+    //         .as_ref()
+    //         .unwrap()
+    //         .put_object()
+    //         .bucket(self.bucket.clone())
+    //         .key(key)
+    //         .body(s3::ByteStream::from(object_bytes))
+    //         .send()
+    //         .await?;
+    //     Ok(resp)
+    // }
+
+    async fn initiate_multipart(&mut self, key: String) -> Result<()> {
+        self.current_key = key;
+        self.part_number = 0; // Reset to new sequence.
+        self.upload_id = self
+            .client
+            .as_ref()
+            .unwrap()
+            .create_multipart_upload()
+            .bucket(self.bucket.clone())
+            .key(self.current_key.clone())
+            .send()
+            .await
+            .map(|resp| resp.upload_id.unwrap())?; // This unwrap is safe as we have a successful response.
+        Ok(())
+    }
+
+    async fn upload_part(&mut self) -> Result<()> {
+        let buf = mem::take(&mut self.buffer);
+        self.part_number += 1;
+        let resp = self
+            .client
+            .as_ref()
+            .unwrap()
+            .upload_part()
+            .body(buf.into())
+            .part_number(self.part_number)
+            .upload_id(self.upload_id.clone())
+            .bucket(self.bucket.clone())
+            .key(self.current_key.clone())
+            .send()
+            .await?;
+
+        // Insert into the list of parts to upload.
+        self.parts.push(
+            CompletedPart::builder()
+                .e_tag(resp.e_tag.unwrap())
+                .part_number(self.part_number)
+                .build(),
+        );
+        Ok(())
+    }
+
+    async fn complete_multipart(&mut self) -> Result<()> {
+        // Upload the last part if any.
+        if !self.buffer.is_empty() {
+            self.upload_part().await?;
+        }
+
+        let completed_parts = mem::take(&mut self.parts);
+        self.client
+            .as_ref()
+            .unwrap()
+            .complete_multipart_upload()
+            .bucket(self.bucket.clone())
+            .upload_id(mem::take(&mut self.upload_id))
+            .key(mem::take(&mut self.current_key))
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .set_parts(Some(completed_parts))
+                    .build(),
+            )
+            .send()
+            .await?;
+        Ok(())
+    }
+}

--- a/src/connectors/s3.rs
+++ b/src/connectors/s3.rs
@@ -11,19 +11,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::connectors::prelude::*;
 use crate::Event;
 use async_std::channel;
-use aws_sdk_s3 as s3;
-use s3::model::{CompletedMultipartUpload, CompletedPart};
 use std::{env, mem};
 use value_trait::ValueAccess;
 
+use aws_sdk_s3 as s3;
+use aws_types::{credentials::Credentials, region::Region};
+use s3::model::{CompletedMultipartUpload, CompletedPart};
 use s3::Client as S3Client;
+use s3::Endpoint;
+
+const FIVEMBS: usize = 5 * 1024 * 1024 + 100; // Some extra bytes to keep aws happy.
+
 struct S3Connector {
     client_sender: Option<channel::Sender<S3Client>>,
     config: S3Config,
+    endpoint: Option<http::Uri>,
 }
 
 struct S3Sink {
@@ -32,20 +37,46 @@ struct S3Sink {
     client: Option<S3Client>,
     buffer: Vec<u8>,
     current_key: String,
+
+    // bookeeping for multipart uploads.
     upload_id: String,
     part_number: i32,
-    // bookeeping for parts.
+    min_part_size: usize,
     parts: Vec<CompletedPart>,
 }
 
 #[derive(Deserialize, Debug, Default)]
 pub struct S3Config {
-    aws_access_token: String,
+    #[serde(default = "S3Config::default_access_key_id")]
+    aws_access_key_id: String,
+    #[serde(default = "S3Config::default_secret_token")]
     aws_secret_access_key: String,
+    #[serde(default = "S3Config::default_aws_region")]
     aws_region: String,
-    max_clients: Option<usize>,
+
     bucket: String,
-    min_part_size: i32,
+    #[serde(default = "S3Config::fivembs")]
+    min_part_size: usize,
+    endpoint: Option<String>,
+}
+
+// Defaults for the config.
+impl S3Config {
+    fn fivembs() -> usize {
+        FIVEMBS
+    }
+
+    fn default_access_key_id() -> String {
+        "AWS_ACCESS_KEY_ID".to_string()
+    }
+
+    fn default_secret_token() -> String {
+        "AWS_SECRET_ACCESS_KEY".to_string()
+    }
+
+    fn default_aws_region() -> String {
+        "AWS_REGION".to_string()
+    }
 }
 
 impl ConfigImpl for S3Config {}
@@ -55,23 +86,65 @@ pub(crate) struct Builder {}
 
 #[async_trait::async_trait]
 impl ConnectorBuilder for Builder {
+    fn connector_type(&self) -> ConnectorType {
+        "s3".into()
+    }
+
     async fn from_config(
         &self,
-        _id: &TremorUrl,
+        id: &TremorUrl,
         raw_config: &Option<OpConfig>,
     ) -> Result<Box<dyn Connector>> {
         if let Some(config) = raw_config {
             let mut config = S3Config::new(config)?;
-            // Fetch the secrets.
+
+            // Fetch the secrets from the env.
             config.aws_secret_access_key = env::var(config.aws_secret_access_key)?;
-            config.aws_access_token = env::var(config.aws_access_token)?;
+            config.aws_access_key_id = env::var(config.aws_access_key_id)?;
+            config.aws_region = env::var(config.aws_region)?;
+
+            // Maintain the minimum size of 5 MBs.
+            if config.min_part_size < FIVEMBS {
+                config.min_part_size = FIVEMBS;
+            }
+
+            // Check the validity of given url
+            let endpoint = if let Some(url) = &config.endpoint {
+                let url_parsed = url.parse::<http::Uri>()?;
+                Some(url_parsed)
+            } else {
+                None
+            };
+
             Ok(Box::new(S3Connector {
                 client_sender: None,
                 config,
+                endpoint,
             }))
         } else {
-            Err(ErrorKind::MissingConfiguration(String::from("aws-s3")).into())
+            Err(ErrorKind::MissingConfiguration(id.to_string()).into())
         }
+    }
+}
+
+/// Meta data of an event. convience struct for feature expansion.
+struct S3Meta<'a, 'value> {
+    meta: Option<&'a Value<'value>>,
+}
+
+impl<'a, 'value> S3Meta<'a, 'value> {
+    fn new(meta: &'a Value<'value>) -> Self {
+        Self {
+            meta: if let Some(s3_meta) = meta.get("s3") {
+                Some(s3_meta)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn get_object_key(&self) -> Option<&str> {
+        self.meta.get_str("key")
     }
 }
 
@@ -81,56 +154,48 @@ impl Sink for S3Sink {
         &mut self,
         _input: &str,
         event: Event,
-        _ctx: &SinkContext,
+        ctx: &SinkContext,
         serializer: &mut EventSerializer,
         _start: u64,
     ) -> Result<SinkReply> {
-        // todo!("Working on it!")
-
         if self.client.is_none() {
             if let Ok(new_client) = self.client_receiver.recv().await {
                 self.client = Some(new_client);
             }
-        }
-        // FIXME: Check if a new client is required or not.
-        else if let Ok(new_client) = self.client_receiver.try_recv() {
+        } else if let Ok(new_client) = self.client_receiver.try_recv() {
             self.client = Some(new_client);
         }
 
         let ingest_id = event.ingest_ns;
 
         for (event, meta) in event.value_meta_iter() {
-            // What to do when meta-data is not present.
-            // FIXME: ayyyyy
-            // let operation = meta.get("operation").map(|value| value.to_string());
+            // Handle no key in meta.
 
-            // FIXME: Handle not found case.
-            let object_key = meta.get("key").map(|value| value.to_string());
+            let s3_meta = S3Meta::new(meta);
 
-            // Also handle aggreagtion here.
-            // FIXME: what to do for multiple data??
-            let data = serializer
-                .serialize(event, ingest_id)?
-                .into_iter()
-                .flatten();
+            let object_key = match s3_meta.get_object_key().map(ToString::to_string) {
+                Some(key) => key,
+                None => {
+                    self.current_key.clear();
+                    error!("{}: missing key meta data in event", &ctx);
+                    return Ok(SinkReply::FAIL);
+                }
+            };
 
-            self.buffer.extend(data);
-
-            if *object_key.as_ref().unwrap() != self.current_key {
+            if object_key != self.current_key {
                 // Complete the uploads for previous key.
-                self.set_new_key(object_key.unwrap()).await?;
+                self.set_new_key(object_key, ctx).await?;
             }
 
-            // FIXME: Make a better aggregation logic.
-            if self.buffer.len() > 6 * 1024 * 1024 {
-                self.upload_part().await?;
+            // Handle the aggregation.
+            for data in serializer.serialize(event, ingest_id)?.into_iter() {
+                self.buffer.extend(data);
+                if self.buffer.len() >= self.min_part_size {
+                    self.upload_part(ctx).await?;
+                }
             }
-
-            // FIXME: Identify errors which indicate whether the client failed.
-            // then notify.
         }
-        // warn!("BufferSize: {}", self.buffer.len());
-        Ok(SinkReply::default())
+        Ok(SinkReply::ACK)
     }
 
     // Required later
@@ -147,12 +212,12 @@ impl Sink for S3Sink {
         Ok(SinkReply::default())
     }
 
-    async fn on_stop(&mut self, _ctx: &mut SinkContext) {
-        warn!("Stopping S3 SINK");
+    async fn on_stop(&mut self, ctx: &SinkContext) -> Result<()> {
         // Commit the final upload.
         if self.buffer.len() > 0 {
-            self.complete_multipart().await.unwrap();
+            self.complete_multipart(ctx).await?;
         }
+        Ok(())
     }
 
     fn asynchronous(&self) -> bool {
@@ -191,33 +256,36 @@ impl Connector for S3Connector {
             client_receiver,
             bucket: self.config.bucket.clone(),
             client: None,
-            buffer: Vec::new(),
+            buffer: Vec::with_capacity(self.config.min_part_size),
             current_key: "".to_owned(),
             parts: Vec::new(),
             upload_id: "".to_owned(),
             part_number: 0,
+            min_part_size: self.config.min_part_size,
         };
 
         let addr = builder.spawn(s3_sink, sink_context)?;
         Ok(Some(addr))
     }
 
-    // Runs on need to connect/reconnect. (multiple times)
     async fn connect(&mut self, _ctx: &ConnectorContext, _attempt: &Attempt) -> Result<bool> {
         // Create the client and establish the connection.
-        let shared_config = aws_config::from_env()
-            .credentials_provider(aws_types::Credentials::from_keys(
-                self.config.aws_access_token.clone(),
+        let s3_config = s3::config::Config::builder()
+            .credentials_provider(Credentials::new(
+                self.config.aws_access_key_id.clone(),
                 self.config.aws_secret_access_key.clone(),
                 None,
+                None,
+                "Environment"
             ))
-            .region(aws_types::region::Region::new(
-                self.config.aws_region.clone(),
-            ))
-            .load()
-            .await;
+            .region(Region::new(self.config.aws_region.clone()));
 
-        let client = S3Client::new(&shared_config);
+        let s3_config = match &self.endpoint {
+            Some(uri) => s3_config.endpoint_resolver(Endpoint::immutable(uri.clone())),
+            None => (s3_config),
+        };
+
+        let client = S3Client::from_conf(s3_config.build());
 
         // Check for the existence of the bucket.
         let exist_bucket = client
@@ -231,22 +299,30 @@ impl Connector for S3Connector {
         }
 
         // Send the client to the sink.
-        self.client_sender.as_ref().unwrap().send(client).await?;
+        if let Some(client_sender) = &self.client_sender {
+            client_sender.send(client).await?;
+        }
 
         Ok(true)
     }
 
-    // Do argue for plain text..
+    // FIXME: text or json
     fn default_codec(&self) -> &str {
         "json"
     }
 }
 
 impl S3Sink {
-    async fn set_new_key(&mut self, key: String) -> Result<()> {
+    fn get_client(&self) -> Result<&s3::Client> {
+        self.client
+            .as_ref()
+            .ok_or_else(|| ErrorKind::S3Error("no s3 client available".to_string()).into())
+    }
+
+    async fn set_new_key(&mut self, key: String, ctx: &SinkContext) -> Result<()> {
         // Finish the previous multipart upload if any.
         if self.current_key != "" {
-            self.complete_multipart().await?;
+            self.complete_multipart(ctx).await?;
         }
 
         if key != "" {
@@ -259,31 +335,37 @@ impl S3Sink {
     async fn initiate_multipart(&mut self, key: String) -> Result<()> {
         self.current_key = key;
         self.part_number = 0; // Reset to new sequence.
-        self.upload_id = self
-            .client
-            .as_ref()
-            .unwrap()
+
+        let resp = self
+            .get_client()?
             .create_multipart_upload()
             .bucket(self.bucket.clone())
             .key(self.current_key.clone())
             .send()
-            .await
-            .map(|resp| resp.upload_id.unwrap())?; // This unwrap is safe as we have a successful response.
+            .await?;
+
+        self.upload_id = resp
+            .upload_id
+            .ok_or(ErrorKind::S3Error("upload id not found".to_string()))?;
+
         Ok(())
     }
 
-    async fn upload_part(&mut self) -> Result<()> {
-        warn!(
-            "Uploading part {} with buffer size {}",
+    async fn upload_part(&mut self, ctx: &SinkContext) -> Result<()> {
+        debug!(
+            "{}: key: {} uploading part {}",
+            &ctx,
+            self.current_key.as_str(),
             self.part_number,
-            self.buffer.len()
         );
-        let buf = mem::take(&mut self.buffer);
+
+        let mut buf = Vec::with_capacity(self.min_part_size);
+        mem::swap(&mut buf, &mut self.buffer);
         self.part_number += 1;
+
+        // Upload the part
         let resp = self
-            .client
-            .as_ref()
-            .unwrap()
+            .get_client()?
             .upload_part()
             .body(buf.into())
             .part_number(self.part_number)
@@ -292,33 +374,33 @@ impl S3Sink {
             .key(self.current_key.clone())
             .send()
             .await?;
-        warn!("Completed part upload");
+
+        let e_tag = resp
+            .e_tag
+            .ok_or(ErrorKind::S3Error("response did not have e_tag".to_string()))?;
 
         // Insert into the list of parts to upload.
         self.parts.push(
             CompletedPart::builder()
-                .e_tag(resp.e_tag.unwrap())
+                .e_tag(e_tag)
                 .part_number(self.part_number)
                 .build(),
         );
         Ok(())
     }
 
-    async fn complete_multipart(&mut self) -> Result<()> {
+    async fn complete_multipart(&mut self, ctx: &SinkContext) -> Result<()> {
         // Upload the last part if any.
         if self.buffer.len() > 0 {
-            self.upload_part().await?;
+            self.upload_part(ctx).await?;
         }
 
-        warn!("Completing Multipart Upload");
         let completed_parts = mem::take(&mut self.parts);
-        self.client
-            .as_ref()
-            .unwrap()
+        self.get_client()?
             .complete_multipart_upload()
             .bucket(self.bucket.clone())
             .upload_id(mem::take(&mut self.upload_id))
-            .key(mem::take(&mut self.current_key))
+            .key(self.current_key.clone())
             .multipart_upload(
                 CompletedMultipartUpload::builder()
                     .set_parts(Some(completed_parts))
@@ -326,7 +408,11 @@ impl S3Sink {
             )
             .send()
             .await?;
-        warn!("Completed Multipart Upload");
+
+        debug!(
+            "{}: completed multipart upload for key: {}",
+            &ctx, self.current_key
+        );
         Ok(())
     }
 }

--- a/src/connectors/s3.rs
+++ b/src/connectors/s3.rs
@@ -214,9 +214,7 @@ impl Sink for S3Sink {
 
     async fn on_stop(&mut self, ctx: &SinkContext) -> Result<()> {
         // Commit the final upload.
-        if self.buffer.len() > 0 {
-            self.complete_multipart(ctx).await?;
-        }
+        self.complete_multipart(ctx).await?;
         Ok(())
     }
 
@@ -276,7 +274,7 @@ impl Connector for S3Connector {
                 self.config.aws_secret_access_key.clone(),
                 None,
                 None,
-                "Environment"
+                "Environment",
             ))
             .region(Region::new(self.config.aws_region.clone()));
 
@@ -313,7 +311,7 @@ impl Connector for S3Connector {
 }
 
 impl S3Sink {
-    fn get_client(&self) -> Result<&s3::Client> {
+    fn get_client(&self) -> Result<&S3Client> {
         self.client
             .as_ref()
             .ok_or_else(|| ErrorKind::S3Error("no s3 client available".to_string()).into())
@@ -375,9 +373,9 @@ impl S3Sink {
             .send()
             .await?;
 
-        let e_tag = resp
-            .e_tag
-            .ok_or(ErrorKind::S3Error("response did not have e_tag".to_string()))?;
+        let e_tag = resp.e_tag.ok_or(ErrorKind::S3Error(
+            "response did not have e_tag".to_string(),
+        ))?;
 
         // Insert into the list of parts to upload.
         self.parts.push(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -119,6 +119,13 @@ impl<P> From<std::sync::PoisonError<P>> for Error {
     }
 }
 
+impl<T: std::fmt::Debug> From<aws_sdk_s3::SdkError<T>> for Error {
+    // FIXME: dbg or display trait
+    fn from(e: aws_sdk_s3::SdkError<T>) -> Self {
+        Self::from(ErrorKind::S3Error(format!("{:?}", e)))
+    }
+}
+
 #[cfg(test)]
 impl PartialEq for Error {
     fn eq(&self, _other: &Self) -> bool {
@@ -176,11 +183,17 @@ error_chain! {
         UrlParserError(url::ParseError);
         Utf8Error(std::str::Utf8Error);
         WsError(async_tungstenite::tungstenite::Error);
+        EnvVarError(std::env::VarError);
         YamlError(serde_yaml::Error) #[doc = "Error during yaml parsing"];
         Wal(qwal::Error);
     }
 
     errors {
+        S3Error(n: String) {
+            description("S3 Error")
+            display("S3Error: {}", n)
+        }
+
         UnknownOp(n: String, o: String) {
             description("Unknown operator")
                 display("Unknown operator: {}::{}", n, o)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -181,6 +181,7 @@ error_chain! {
         TryFromIntError(std::num::TryFromIntError);
         ValueError(tremor_value::Error);
         UrlParserError(url::ParseError);
+        UriParserError(http::uri::InvalidUri);
         Utf8Error(std::str::Utf8Error);
         WsError(async_tungstenite::tungstenite::Error);
         EnvVarError(std::env::VarError);

--- a/tests/connector_s3.rs
+++ b/tests/connector_s3.rs
@@ -1,0 +1,398 @@
+// Copyright 2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or imelied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod connectors;
+
+extern crate log;
+
+// use async_std::stream::StreamExt;
+use futures::StreamExt;
+use rand::{distributions::Alphanumeric, Rng};
+use std::env;
+use std::io::Read;
+use std::time::{Duration, Instant};
+// use bytes::buf::buf_impl::Buf;
+use bytes::Buf;
+
+use connectors::{ConnectorHarness, TestPipeline};
+use signal_hook::consts::{SIGINT, SIGQUIT, SIGTERM};
+use signal_hook_async_std::Signals;
+use testcontainers::clients;
+use testcontainers::images::generic::GenericImage;
+use testcontainers::{Docker, RunArgs};
+
+use tremor_common::url::ports::IN;
+use tremor_pipeline::{CbAction, Event, EventId};
+use tremor_runtime::errors::{Error, Result};
+use tremor_value::{literal, value};
+use value_trait::{Builder, Mutable, ValueAccess};
+
+use aws_sdk_s3 as s3;
+use s3::client::Client as S3Client;
+use s3::{Credentials, Endpoint, Region};
+
+#[async_std::test]
+async fn connector_s3() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    // Run the mock s3 locally
+    let docker = clients::Cli::default();
+    let image = GenericImage::new("adobe/s3mock").with_env_var("initialBuckets", "tremor");
+
+    let container = docker.run_with_args(
+        image,
+        RunArgs::default()
+            .with_mapped_port((9090_u16, 9090_u16))
+            .with_mapped_port((9191_u16, 9191_u16)),
+    );
+    // signal handling - stop and rm the container, even if we quit the test in the middle of everything
+    let container_id = container.id().to_string();
+    let mut signals = Signals::new(&[SIGTERM, SIGINT, SIGQUIT])?;
+    let _signal_handle = signals.handle();
+    let _signal_handler_task = async_std::task::spawn(async move {
+        let signal_docker = clients::Cli::default();
+        while let Some(_signal) = signals.next().await {
+            signal_docker.stop(container_id.as_str());
+            signal_docker.rm(container_id.as_str());
+        }
+    });
+
+    let s3_client: S3Client = get_client();
+
+    let wait_for = Duration::from_secs(30);
+    let start = Instant::now();
+
+    while let Err(e) = s3_client
+        .head_bucket()
+        .bucket("tremor".to_string())
+        .send()
+        .await
+    {
+        if start.elapsed() > wait_for {
+            return Err(Error::from(e).chain_err(|| "Waiting for mock-s3 container timed out"));
+        }
+
+        async_std::task::sleep(Duration::from_secs(1)).await;
+    }
+
+    // set the needed environment variables. keys are not required for mock-s3
+    env::set_var("AWS_ACCESS_KEY_ID", "KEY_NOT_REQD");
+    env::set_var("AWS_SECRET_ACCESS_KEY", "KEY_NOT_REQD");
+    env::set_var("AWS_REGION", "ap-south-1");
+
+    // connector setup
+    let connector_yaml = literal!(
+            {
+    "codec": "binary",
+    "config":{
+        "aws_access_token": "AWS_ACCESS_KEY_ID",
+        "aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",
+        "bucket": "tremor",
+        "endpoint": "http://localhost:9090",
+    }
+    });
+
+    let harness = ConnectorHarness::new("s3", connector_yaml).await?;
+    let in_pipe = harness
+        .get_pipe(IN)
+        .expect("No pipe connectored to port IN");
+    harness.start().await?;
+    harness.wait_for_connected(Duration::from_secs(7)).await?;
+
+    let cf_event = in_pipe.get_contraflow().await?;
+    assert_eq!(CbAction::Open, cf_event.cb);
+
+    let (unbatched_event, unbatched_value) = get_unbatched_event();
+    verify_contraflow(&harness, &unbatched_event, in_pipe).await?;
+
+    let (batched_event, batched_value_0, batched_value_1, batched_value_2) = get_batched_event();
+    verify_contraflow(&harness, &batched_event, in_pipe).await?;
+
+    let (large_unbatched_event, large_unbatched_bytes) = large_unbatched_event();
+    verify_contraflow(&harness, &large_unbatched_event, in_pipe).await?;
+
+    let (large_batched_event, large_batched_value) = large_batched_event();
+    verify_contraflow(&harness, &large_batched_event, in_pipe).await?;
+
+    harness.stop().await?;
+    // fetch the commited events from mock s3
+
+    // verify a small unbatched event.
+    let unbatched_value_recv = get_object_value(&s3_client, "tremor", "unbatched_key").await;
+    assert_eq!(unbatched_value, unbatched_value_recv);
+
+    // verify small and different batched events.
+    let batched_value_0_recv = get_object_value(&s3_client, "tremor", "batched_key0").await;
+    assert_eq!(batched_value_0, batched_value_0_recv);
+
+    let batched_value_1_recv = get_object_value(&s3_client, "tremor", "batched_key1").await;
+    assert_eq!(batched_value_1, batched_value_1_recv);
+
+    let batched_value_2_recv = get_object_value(&s3_client, "tremor", "batched_key2").await;
+    assert_eq!(batched_value_2, batched_value_2_recv);
+
+    // verify a large unbatched_event. Checked directly against the bytes.
+    let large_unbatched_bytes_recv =
+        get_object(&s3_client, "tremor", "large_unbatched_event").await;
+    assert_eq!(large_unbatched_bytes, large_unbatched_bytes_recv);
+
+    // verify a large batched event having multiples keys for the same field.
+    let large_batched_value_recv = get_object(&s3_client, "tremor", "large_batched_event").await;
+    assert_eq!(large_batched_value, large_batched_value_recv);
+
+    drop(container);
+    Ok(())
+}
+
+async fn verify_contraflow(
+    harness: &ConnectorHarness,
+    event: &Event,
+    in_pipe: &TestPipeline,
+) -> Result<()> {
+    harness.send_to_sink(event.clone(), IN).await?;
+    let cf_event = in_pipe.get_contraflow().await?;
+    assert_eq!(CbAction::Ack, cf_event.cb);
+    Ok(())
+}
+
+async fn get_object(client: &S3Client, bucket: &str, key: &str) -> Vec<u8> {
+    let resp = client
+        .get_object()
+        .bucket(bucket.clone())
+        .key(key.clone())
+        .send()
+        .await
+        .unwrap();
+
+    let mut v = Vec::new();
+    let read_bytes = resp
+        .body
+        .collect()
+        .await
+        .unwrap()
+        .reader()
+        .read_to_end(&mut v)
+        .unwrap();
+    v.truncate(read_bytes);
+    v
+}
+
+async fn get_object_value(client: &S3Client, bucket: &str, key: &str) -> value::Value<'static> {
+    let mut v = get_object(client, bucket, key).await;
+    let obj = value::parse_to_value(&mut v).unwrap();
+    return obj.into_static();
+}
+
+fn get_unbatched_event() -> (Event, value::Value<'static>) {
+    let data = literal!({
+        "numField": 12.5,
+        "strField": "string",
+        "listField": [true, false],
+        "nestedField" : {
+            "nested": true
+        },
+    });
+    let meta = literal!({
+        "s3": {
+                "key": "unbatched_key"
+            }
+    });
+
+    (
+        Event {
+            id: EventId::from_id(0, 0, 1),
+            data: (data.clone(), meta).into(),
+            transactional: false,
+            ..Event::default()
+        },
+        data,
+    )
+}
+
+// handle seperately because 3 seperate events.
+fn get_batched_event() -> (
+    Event,
+    value::Value<'static>,
+    value::Value<'static>,
+    value::Value<'static>,
+) {
+    let batched_data = literal!([{
+            "data": {
+                "value": {
+                    "field1": 0.1,
+                    "field2": "another_string",
+                    "field3": [],
+                },
+                "meta": {
+                    "s3": {
+                        "key": "batched_key0"
+                    }
+                }
+            }
+        },
+        {
+            "data": {
+                "value": {
+                    "field3": 12,
+                    "field4": {
+                        "nested": false,
+                        "actually": "no"
+                    }
+                },
+                "meta": {
+                    "s3": {
+                        "key": "batched_key1"
+                    }
+                }
+            }
+           },
+        {
+            "data": {
+                "value": {
+                    "some_more_fields" :1,
+                    "vec_field": ["elem1", "elem2", "elem3"],
+                },
+                "meta": {
+                    "s3": {
+                        "key": "batched_key2"
+                    }
+                }
+            }
+        }
+    ]);
+
+    let batched_meta = literal!({});
+    let batched_id = EventId::new(0, 0, 2, 2);
+    (
+        Event {
+            id: batched_id,
+            is_batch: true,
+            transactional: false,
+            data: (batched_data.clone(), batched_meta).into(),
+            ..Event::default()
+        },
+        batched_data[0]
+            .get("data")
+            .unwrap()
+            .get("value")
+            .unwrap()
+            .clone(),
+        batched_data[1]
+            .get("data")
+            .unwrap()
+            .get("value")
+            .unwrap()
+            .clone(),
+        batched_data[2]
+            .get("data")
+            .unwrap()
+            .get("value")
+            .unwrap()
+            .clone(),
+    )
+}
+
+fn large_unbatched_event() -> (Event, Vec<u8>) {
+    let ten_mbs = 10 * 1024 * 1024;
+    let large_text = random_alphanum_string(ten_mbs).into_bytes();
+    let large_data = value::Value::Bytes(large_text.clone().into());
+
+    let large_meta = literal!({
+        "s3": {
+            "key": "large_unbatched_event"
+        }
+    });
+
+    (
+        Event {
+            id: EventId::from_id(0, 0, 3),
+            data: (large_data.clone(), large_meta).into(),
+            transactional: true,
+            ..Event::default()
+        },
+        large_text,
+    )
+}
+
+fn large_batched_event() -> (Event, Vec<u8>) {
+    let mut batched_data = value::Value::array_with_capacity(1000);
+    let mut batched_value = Vec::new();
+
+    let batched_meta = literal!({});
+
+    for idx in 0..1000 {
+        let field = format!("field{}", idx);
+        let field_val = random_alphanum_string(10000);
+
+        let lit = literal! ({field.clone():field_val.clone()});
+        batched_value.append(&mut simd_json::to_vec(&lit).unwrap());
+
+        let event = literal!({
+            "data": {
+                "value": lit,
+                "meta" : {
+                    "s3" : {
+                        "key": "large_batched_event",
+                    }
+                }
+            }
+        });
+
+        batched_data.push(event).unwrap();
+    }
+
+    (
+        Event {
+            id: EventId::from_id(0, 0, 3),
+            data: (batched_data, batched_meta).into(),
+            transactional: true,
+            is_batch: true,
+            ..Event::default()
+        },
+        batched_value,
+    )
+}
+
+fn random_alphanum_string(str_size: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(str_size)
+        .map(char::from)
+        .collect()
+}
+
+// fn random_num_vector(vec_size: usize) -> Vec<usize> {
+//     rand::thread_rnd()
+//         .sample_iter(&Standard)
+//         .take(vec_size)
+//         .collect()
+// }
+
+fn get_client() -> S3Client {
+    let s3_config = s3::config::Config::builder()
+        .credentials_provider(Credentials::new(
+            "KEY_NOT_REQD",
+            "KEY_NOT_REQD",
+            None,
+            None,
+            "Environment",
+        ))
+        .region(Region::new("ap-south-1"))
+        .endpoint_resolver(Endpoint::immutable(
+            "http://localhost:9090".parse().unwrap(),
+        ))
+        .build();
+
+    S3Client::from_conf(s3_config)
+}


### PR DESCRIPTION
# Pull request

## Description
Support for S3 Sink

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #1176 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


