### PR TITLE
Strip unused dependencies and get rid of dependency on openssl.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,19 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-tls"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls 0.18.1",
+ "webpki 0.21.4",
+ "webpki-roots 0.20.0",
+]
+
+[[package]]
+name = "async-tls"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
@@ -758,6 +771,31 @@ checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-cipher"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-modes"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
+dependencies = [
+ "block-cipher",
+ "block-padding",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -1066,6 +1104,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.2",
+ "serde",
 ]
 
 [[package]]
@@ -1381,6 +1430,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
@@ -1453,7 +1512,6 @@ checksum = "e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483"
 dependencies = [
  "cc",
  "libc",
- "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1491,6 +1549,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "deadpool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
+dependencies = [
+ "async-trait",
+ "config",
+ "crossbeam-queue 0.3.2",
+ "num_cpus",
+ "serde",
+ "tokio 1.12.0",
+]
+
+[[package]]
 name = "debug-helper"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1577,17 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.10",
  "syn 1.0.78",
+]
+
+[[package]]
+name = "des"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e084b5048dec677e6c9f27d7abc551dde7d127cf4127fea82323c98a30d7fa0d"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1895,17 +1978,6 @@ name = "fluent_builder"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d86fdb1e69d4656dddde580b446329f14946c52fa1aa3057c3e72133bbac97"
-
-[[package]]
-name = "flume"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bebadab126f8120d410b677ed95eee4ba6eb7c6dd8e34a5ec88a08050e26132"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spinning_top",
-]
 
 [[package]]
 name = "fnv"
@@ -2460,6 +2532,16 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+dependencies = [
+ "crypto-mac 0.9.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
@@ -2549,13 +2631,17 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
 dependencies = [
+ "async-h1",
  "async-std",
+ "async-tls 0.10.0",
  "async-trait",
  "cfg-if 1.0.0",
  "dashmap",
+ "deadpool",
+ "futures 0.3.19",
  "http-types",
- "isahc",
  "log",
+ "rustls 0.18.1",
 ]
 
 [[package]]
@@ -2721,19 +2807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.1.0",
- "hyper 0.14.13",
- "native-tls",
- "tokio 1.12.0",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,29 +2919,6 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "isahc"
-version = "0.9.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
-dependencies = [
- "bytes 0.5.6",
- "crossbeam-utils 0.8.5",
- "curl",
- "curl-sys",
- "flume",
- "futures-lite",
- "http 0.2.5",
- "log",
- "once_cell",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url 2.2.2",
- "waker-fn",
-]
 
 [[package]]
 name = "itertools"
@@ -3043,7 +3093,20 @@ version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34e981f88d060a67815388470172638f1af16b3a12e581cb75142f190161bf9"
 dependencies = [
- "lexical-core",
+ "lexical-core 0.8.2",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3144,16 +3207,6 @@ checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "libnghttp2-sys"
-version = "0.1.7+1.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -3496,7 +3549,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "regex",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "webpki 0.21.4",
  "winapi 0.3.9",
 ]
@@ -3566,6 +3619,7 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core 0.7.6",
  "memchr",
  "version_check",
 ]
@@ -3760,15 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "300.0.2+3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,7 +3822,6 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3804,6 +3848,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "p12"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d9bbc57ec03c625d98cf72abe80d5b6ac4e3b5c4fe6e68150be8778da9c7a0"
+dependencies = [
+ "block-modes",
+ "des",
+ "getrandom 0.2.3",
+ "hmac 0.9.0",
+ "lazy_static",
+ "rc2",
+ "sha-1",
+ "yasna",
 ]
 
 [[package]]
@@ -4558,6 +4618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a067463a4086ea7aab0cc815bbb0c8d473798657643734850bd0c6660846643"
+dependencies = [
+ "block-cipher",
+ "opaque-debug",
+]
+
+[[package]]
 name = "rdkafka"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,7 +4789,7 @@ dependencies = [
  "http 0.2.5",
  "http-body 0.3.1",
  "hyper 0.13.10",
- "hyper-tls 0.4.3",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -4755,23 +4825,21 @@ dependencies = [
  "http-body 0.4.3",
  "hyper 0.14.13",
  "hyper-rustls",
- "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.7",
  "rustls 0.20.2",
+ "rustls-native-certs 0.6.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio 1.12.0",
- "tokio-native-tls",
  "tokio-rustls 0.23.1",
  "tokio-util 0.6.8",
  "url 2.2.2",
@@ -4957,6 +5025,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-connector"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffaf21b0bac725875490d079bb503cf88684618310c2dff167640fa006217cb"
+dependencies = [
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4964,6 +5044,18 @@ checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -5426,17 +5518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sluice"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "smallvec"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5519,15 +5600,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spinning_top"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
-dependencies = [
- "lock_api 0.4.5",
-]
 
 [[package]]
 name = "sse-codec"
@@ -5696,6 +5768,7 @@ dependencies = [
  "mime_guess",
  "once_cell",
  "pin-project-lite 0.2.7",
+ "rustls 0.18.1",
  "serde",
  "serde_json",
  "web-sys",
@@ -5807,8 +5880,8 @@ checksum = "9a29af643fc448ecb2d9b8a74aa2c60c72c36cb447bcf490b866797b58f00f13"
 dependencies = [
  "cfg-if 1.0.0",
  "mio 0.7.13",
- "native-tls",
- "pem",
+ "p12",
+ "rustls-connector",
 ]
 
 [[package]]
@@ -6194,16 +6267,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.10",
  "syn 1.0.78",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.12.0",
 ]
 
 [[package]]
@@ -6697,7 +6760,7 @@ dependencies = [
  "async-nats",
  "async-std",
  "async-std-resolver",
- "async-tls",
+ "async-tls 0.11.0",
  "async-trait",
  "async-tungstenite 0.16.1",
  "base64 0.13.0",
@@ -6709,7 +6772,6 @@ dependencies = [
  "csv",
  "either",
  "elastic",
- "env_logger 0.9.0",
  "error-chain 0.12.4",
  "file-mode",
  "futures 0.3.19",
@@ -6729,11 +6791,9 @@ dependencies = [
  "lazy_static",
  "libflate",
  "log",
- "log4rs",
  "lz4",
  "mapr",
  "matches",
- "openssl",
  "pin-project-lite 0.2.7",
  "port_scanner",
  "postgres",
@@ -7510,6 +7570,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,13 @@ hex = "0.4"
 hostname = "0.3"
 http-types = "2.12"
 indexmap = { version = "1", features = ["serde-1"] }
-lapin = "1.9.0"
+lapin = { version = "1.9.0", features = [
+  "rustls",
+  "rustls-native-certs",
+], default-features = false }
 lazy_static = "1"
 libflate = "1.1"
 log = "0.4"
-log4rs = "1.0"
 lz4 = "1.23.2"
 pin-project-lite = "0.2"
 rand = "0.8"
@@ -81,7 +83,11 @@ serde_yaml = "0.8"
 simd-json = { version = "0.4", features = ["known-key"] }
 simd-json-derive = "0.2"
 snap = "1"
-surf = "=2.3.2"
+surf = { version = "=2.3.2", default-features = false, features = [
+  "encoding",
+  "h1-client-rustls",
+  "middleware-logger",
+] }
 syslog_loose = "0.16"
 tremor-common = { path = "tremor-common" }
 tremor-influx = { path = "tremor-influx" }
@@ -96,7 +102,6 @@ async-tls = "0.11"
 rustls = "0.19"
 
 mapr = "0.8"
-tempfile = { version = "3.2" }
 
 # blaster / blackhole
 hdrhistogram = "7"
@@ -127,15 +132,11 @@ cron = "0.9.0"
 # logstash grok patterns
 grok = "1"
 
-# not used directly in tremor codebase, but present here so that we can turn
-# on features for these (see static-ssl feature here)
-openssl = { version = "0.10", features = ["vendored"] }
-
 # rest onramp
 tide = "0.16"
 
 # sse-onramp
-surf-sse = { git = "https://github.com/dak-x/surf-sse", tag = "2.0" }
+surf-sse = { git = "https://github.com/dak-x/surf-sse", tag = "2.0", default-features = false }
 
 # nats
 async-nats = "0.10.1"
@@ -166,7 +167,10 @@ googapis = { version = "0.5", default-features = false, features = [
 ] }
 gouth = { version = "0.2" }
 http = "0.2.5"
-reqwest = "0.11.8"
+reqwest = { version = "0.11.8", default-features = false, features = [
+  "rustls-tls",
+  "rustls-tls-native-roots",
+] }
 
 [dependencies.tungstenite]
 default-features = false
@@ -174,12 +178,12 @@ version = "0.16"
 
 [dev-dependencies]
 matches = "0.1"
-# criterion = "0.2"
-env_logger = "0.9"
 pretty_assertions = "1.0.0"
 proptest = "1.0"
 regex = "1"
+tempfile = { version = "3.2" }
 test-case = "1.2"
+
 
 [features]
 default = []

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -43,7 +43,11 @@ simd-json = { version = "0.4", features = ["known-key"] }
 #   - https://github.com/SchrodingerZhu/snmalloc-rs/issues/145
 snmalloc-rs = { version = "=0.2.28", optional = false }
 snmalloc-sys = { version = "=0.2.28", optional = false }
-surf = "=2.3.2"
+surf = { version = "=2.3.2", default-features = false, features = [
+    "encoding",
+    "h1-client-rustls",
+    "middleware-logger",
+] }
 tide = "0.16"
 tremor-api = { path = "../tremor-api" }
 tremor-common = { path = "../tremor-common" }


### PR DESCRIPTION
# Pull request

## Description

This gets rid of the dependency on openssl, as this was always compiled in a new build, we might be a little faster for fresh builds, but can also get rid of `openssl` as a dep in our docker container and packages. `ldd ./target/debug/tremor` does not list `libssl` anymore :)

We now use `rustls` for amqp via `lapin`, for http offramp via `surf` and `reqwest`. We might need to reintroduce `openssl` again, when we need support e.g. for kafka.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

not applicable, we have no benches using TLS.


