### PR TITLE
Integrates clap_mangen to tremor-cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,14 +133,6 @@ the issue in question.
 
 [closing-keywords]: https://help.github.com/en/articles/closing-issues-using-keywords
 
-Please make sure your pull request is in compliance with Tremor's style
-guidelines by running
-
-    $ sh ./contrib/pre-commit
-
-Make this check before every pull request (and every new commit in a pull
-request); you can add [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
-before every push to make sure you never forget to make this check.
 
 All pull requests are reviewed by another person.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -1042,7 +1042,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
 dependencies = [
- "clap 3.1.1",
+ "clap 3.1.2",
 ]
 
 [[package]]
@@ -6676,7 +6676,7 @@ version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 3.1.1",
+ "clap 3.1.2",
  "clap_complete",
  "criterion",
  "difference",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.54"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
 
 [[package]]
 name = "arc-swap"
@@ -1056,6 +1056,16 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.10",
  "syn 1.0.78",
+]
+
+[[package]]
+name = "clap_mangen"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649fb4156bbd7306896025005596033879a2051f9a3aa7416ab915df1f8fdac"
+dependencies = [
+ "clap 3.1.2",
+ "roff",
 ]
 
 [[package]]
@@ -4933,6 +4943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "route-recognizer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6678,6 +6694,7 @@ dependencies = [
  "async-std",
  "clap 3.1.2",
  "clap_complete",
+ "clap_mangen",
  "criterion",
  "difference",
  "dirs-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
+checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
 dependencies = [
  "atty",
  "bitflags",
@@ -1042,7 +1042,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
 dependencies = [
- "clap 3.1.0",
+ "clap 3.1.1",
 ]
 
 [[package]]
@@ -6665,7 +6665,7 @@ version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 3.1.0",
+ "clap 3.1.1",
  "clap_complete",
  "criterion",
  "difference",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.6"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678db4c39c013cc68b54d372bce2efc58e30a0337c497c9032fd196802df3bc3"
+checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
 dependencies = [
  "clap 3.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,7 +3878,7 @@ dependencies = [
  "hmac 0.9.0",
  "lazy_static",
  "rc2",
- "sha-1",
+ "sha-1 0.9.8",
  "yasna",
 ]
 
@@ -5370,6 +5370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.0",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6858,7 +6869,7 @@ dependencies = [
  "tremor-pipeline",
  "tremor-script",
  "tremor-value",
- "tungstenite 0.16.0",
+ "tungstenite 0.17.2",
  "url 2.2.2",
  "value-trait",
  "xz2",
@@ -7005,7 +7016,7 @@ dependencies = [
  "input_buffer",
  "log",
  "rand 0.7.3",
- "sha-1",
+ "sha-1 0.9.8",
  "url 2.2.2",
  "utf-8",
 ]
@@ -7023,7 +7034,26 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url 2.2.2",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.1.0",
+ "http 0.2.6",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.10.0",
  "thiserror",
  "url 2.2.2",
  "utf-8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5971,15 +5971,15 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "1.2.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e5f048404b43e8ae66dce036163515b6057024cf58c6377be501f250bd3c6a"
+checksum = "4f7d58e237f65d5fe5eaf1105188c94c9a441e1fbc298ed5df45ec9c9af236d3"
 dependencies = [
  "cfg-if 1.0.0",
+ "proc-macro-error",
  "proc-macro2",
  "quote 1.0.10",
  "syn 1.0.78",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ pretty_assertions = "1.1.0"
 proptest = "1.0"
 regex = "1"
 tempfile = { version = "3.2" }
-test-case = "1.2"
+test-case = "2.0"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ reqwest = { version = "0.11.9", default-features = false, features = [
 
 [dependencies.tungstenite]
 default-features = false
-version = "0.16"
+version = "0.17"
 
 [dev-dependencies]
 matches = "0.1"

--- a/bench/run
+++ b/bench/run
@@ -46,7 +46,7 @@ echo "TARGET_ROOT: ${TARGET_ROOT}"
 
 if [ -d ${BENCH_ROOT}/$1 ]
 then
-  TREMOR_PATH="${BENCH_ROOT}/../tremor-script/lib" ${BENCH_EXTRA} ${TARGET_ROOT}/${TARGET_MODE}/tremor server run --no-api -f $file bench/link.yaml ./bench/$1/*.trickle
+  TREMOR_PATH="${BENCH_ROOT}/../tremor-script/lib" ${BENCH_EXTRA} ${TARGET_ROOT}/${TARGET_MODE}/tremor server run --no-api $file bench/link.yaml ./bench/$1/*.trickle
 else
-  TREMOR_PATH="${BENCH_ROOT}/../tremor-script/lib" ${BENCH_EXTRA} ${TARGET_ROOT}/${TARGET_MODE}/tremor server run --no-api -f $file bench/link.yaml
+  TREMOR_PATH="${BENCH_ROOT}/../tremor-script/lib" ${BENCH_EXTRA} ${TARGET_ROOT}/${TARGET_MODE}/tremor server run --no-api $file bench/link.yaml
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -54,7 +54,7 @@ else
 
     if [ ! -z "${ARTEFACTS}" ]
     then
-        ARGS="${ARGS} -f ${ARTEFACTS}"
+        ARGS="${ARGS} ${ARTEFACTS}"
     fi
 fi
 

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -10,8 +10,13 @@ version = "0.11.4"
 default-target = "x86_64-unknown-linux-gnu"
 
 [build-dependencies]
+clap = { version = "3", features = ["derive", "cargo", "env"] }
+clap_complete = "3"
+clap_mangen = "0.1"
 lalrpop = "0.19"
 matches = "0.1.9"
+serde = "1"
+serde_derive = "1"
 
 [dev-dependencies]
 criterion = "0.3"
@@ -22,7 +27,7 @@ pretty_assertions = "1.1.0"
 [dependencies]
 anyhow = "1"
 async-std = { version = "1.10", features = ["unstable"] }
-clap = { version = "3", features = ["color", "derive"] }
+clap = { version = "3", features = ["derive", "color"] }
 clap_complete = "3"
 difference = "2"
 dirs-next = "2"

--- a/tremor-cli/build.rs
+++ b/tremor-cli/build.rs
@@ -1,0 +1,43 @@
+use clap::IntoApp;
+use clap_mangen::Man;
+use std::{
+    env,
+    fs::File,
+    io::Error,
+    path::{Path, PathBuf},
+};
+
+include!("src/cli.rs");
+
+
+fn build_manpages(outdir: &Path) -> Result<(), Error> {
+    let app = Cli::command();
+
+    let file = Path::new(&outdir).join("tremor-cli-man-page.1");
+    let mut file = File::create(&file)?;
+
+    Man::new(app).render(&mut file)?;
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+    println!("cargo:rerun-if-changed=man");
+
+    let outdir = match env::var_os("OUT_DIR") {
+        None => return Ok(()),
+        Some(outdir) => outdir,
+    };
+
+    // Create `target/man-pages/` folder.
+    let out_path = PathBuf::from(outdir);
+    let mut path = out_path.ancestors().nth(4).unwrap().to_owned();
+    path.push("man-pages");
+    std::fs::create_dir_all(&path).unwrap();
+
+    // build_shell_completion(&path)?;
+    build_manpages(&path)?;
+
+    Ok(())
+}

--- a/tremor-cli/build.rs
+++ b/tremor-cli/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::IntoApp;
 use clap_mangen::Man;
 use std::{

--- a/tremor-cli/build.rs
+++ b/tremor-cli/build.rs
@@ -9,7 +9,6 @@ use std::{
 
 include!("src/cli.rs");
 
-
 fn build_manpages(outdir: &Path) -> Result<(), Error> {
     let app = Cli::command();
 

--- a/tremor-cli/src/cli.rs
+++ b/tremor-cli/src/cli.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use clap::{ArgEnum, Parser};
+use serde::Deserialize;
 
 /// Tremor cli - Command Line Interface
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Integrates clap_mangen into tremor-cli and exports man pages to 'target/man-page/' directory

# Pull request

## Description
As discussed earlier with @mfelsche, this PR adds man page generation to tremor-cli by using the clap-mangen crate and exports the man page to the ```man-page``` directory under ```target```. This PR adds a ```build.rs``` to the tremor-cli project and allows the pages to be generated when building the project

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related Issues: fixes #1469 
* Related repository [clap-mangen example](https://github.com/sondr3/clap-man-example)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

Throughput numbers from cli-manpage-gen branch:
```
Throughput   (data): 200.7 MB/s
Throughput (events): 334.5k events/s
```

Throughput numbers from main
```
Throughput   (data): 200.0 MB/s
Throughput (events): 333.3k events/s

```

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->
r? @mfelsche 


