### PR TITLE
Rename split/join/lines processors to `separate`

### DIFF
--- a/demo/configs/tremor/config/main.troy
+++ b/demo/configs/tremor/config/main.troy
@@ -238,7 +238,7 @@ flow
     define connector influxdb from http_client
     with
         codec = "influx",
-        postprocessors = ["join"],
+        postprocessors = ["separate"],
         config = {
             "url": "http://influx:8086/api/v2/write?bucket=tremor&org=tremor&precision=ns",
             "method": "POST",

--- a/src/connectors/tests/file.rs
+++ b/src/connectors/tests/file.rs
@@ -31,7 +31,7 @@ async fn file_connector() -> Result<()> {
         .join("input.txt");
     let defn = literal!({
         "codec": "string",
-        "preprocessors": ["split"],
+        "preprocessors": ["separate"],
         "config": {
             "path": input_path.display().to_string(),
             "mode": "read"

--- a/src/connectors/tests/file_non_existent.rs
+++ b/src/connectors/tests/file_non_existent.rs
@@ -28,7 +28,7 @@ async fn file_connector() -> Result<()> {
         .join("non_existent.txt");
     let defn = literal!({
         "codec": "string",
-        "preprocessors": ["split"],
+        "preprocessors": ["separate"],
         "config": {
             "path": input_path.display().to_string(),
             "mode": "read"

--- a/src/connectors/tests/file_xz.rs
+++ b/src/connectors/tests/file_xz.rs
@@ -31,7 +31,7 @@ async fn file_connector_xz() -> Result<()> {
         .join("input.xz");
     let defn = literal!({
         "codec": "string",
-        "preprocessors": ["split"],
+        "preprocessors": ["separate"],
         "config": {
             "path": input_path.display().to_string(),
             "mode": "read"

--- a/src/connectors/tests/pause_resume.rs
+++ b/src/connectors/tests/pause_resume.rs
@@ -38,7 +38,7 @@ async fn udp_pause_resume() -> Result<()> {
 
     let defn = literal!({
       "codec": "string",
-      "preprocessors": ["split"],
+      "preprocessors": ["separate"],
       "config": {
           "url": format!("udp://127.0.0.1:{free_port}"),
           "buf_size": 4096
@@ -137,7 +137,7 @@ async fn tcp_server_pause_resume() -> Result<()> {
 
     let defn = literal!({
       "codec": "string",
-      "preprocessors": ["split"],
+      "preprocessors": ["separate"],
       "config": {
           "url": format!("tcp://127.0.0.1:{free_port}"),
           "buf_size": 4096

--- a/src/connectors/tests/tcp/client.rs
+++ b/src/connectors/tests/tcp/client.rs
@@ -62,8 +62,8 @@ async fn tcp_client_test(use_tls: bool) -> Result<()> {
            }
         },
         "codec": "json-sorted",
-        "preprocessors": ["split"],
-        "postprocessors": ["join"],
+        "preprocessors": ["separate"],
+        "postprocessors": ["separate"],
         "config": {
             "url": server_addr,
             "no_delay": true,

--- a/src/connectors/tests/tcp/server.rs
+++ b/src/connectors/tests/tcp/server.rs
@@ -32,7 +32,7 @@ async fn server_event_routing() -> Result<()> {
 
     let defn = literal!({
       "codec": "string",
-      "preprocessors": ["split"],
+      "preprocessors": ["separate"],
       "config": {
         "url": format!("tcp://127.0.0.1:{free_port}"),
         "buf_size": 4096

--- a/src/connectors/tests/unix_socket.rs
+++ b/src/connectors/tests/unix_socket.rs
@@ -32,8 +32,8 @@ async fn unix_socket() -> Result<()> {
 
     let server_defn = literal!({
       "codec": "string",
-      "preprocessors": ["split"],
-      "postprocessors": ["join"],
+      "preprocessors": ["separate"],
+      "postprocessors": ["separate"],
       "config": {
           "path": socket_path.display().to_string(),
           "permissions": "=777",
@@ -42,8 +42,8 @@ async fn unix_socket() -> Result<()> {
     });
     let client_defn = literal!({
       "codec": "string",
-      "preprocessors": ["split"],
-      "postprocessors": ["join"],
+      "preprocessors": ["separate"],
+      "postprocessors": ["separate"],
       "config": {
           "path": socket_path.display().to_string(),
           "buf_size": 4096

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -309,9 +309,9 @@ error_chain! {
             description("Connector not found")
                 display("Connector \"{}\" not found in Flow \"{}\"", alias, flow_id)
         }
-        InvalidLines {
-            description("Invalid Lines")
-                display("Invalid Lines")
+        InvalidInputData(msg: &'static str) {
+            description("Invalid Input data")
+                display("Invalid Input data: {}", msg)
         }
     }
 }

--- a/src/postprocessor.rs
+++ b/src/postprocessor.rs
@@ -14,7 +14,7 @@
 
 mod gelf;
 pub(crate) use gelf::Gelf;
-pub(crate) mod join;
+pub(crate) mod separate;
 
 use crate::config::Postprocessor as PostprocessorConfig;
 use crate::errors::Result;
@@ -59,8 +59,7 @@ pub trait Postprocessor: Send + Sync {
 
 pub fn lookup_with_config(config: &PostprocessorConfig) -> Result<Box<dyn Postprocessor>> {
     match config.name.as_str() {
-        "join" => Ok(Box::new(join::Join::from_config(&config.config)?)),
-        "lines" => Ok(Box::new(join::Join::default())),
+        "separate" => Ok(Box::new(separate::Separate::from_config(&config.config)?)),
         "base64" => Ok(Box::new(Base64::default())),
         "gzip" => Ok(Box::new(Gzip::default())),
         "zlib" => Ok(Box::new(Zlib::default())),
@@ -322,7 +321,7 @@ mod test {
     use super::*;
 
     const LOOKUP_TABLE: [&str; 12] = [
-        "join",
+        "separate",
         "base64",
         "gzip",
         "zlib",

--- a/src/postprocessor/join.rs
+++ b/src/postprocessor/join.rs
@@ -1,0 +1,124 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Postprocessor appending a configured `separator` to each byte array it processes.
+//! The separator defaults to `\n`, line-break.
+
+use super::Postprocessor;
+use crate::errors::{Kind as ErrorKind, Result};
+use crate::preprocessor::split::{default_separator, DEFAULT_SEPARATOR};
+use tremor_pipeline::{ConfigImpl, ConfigMap};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(default = "default_separator")]
+    separator: String,
+}
+
+impl ConfigImpl for Config {}
+
+pub(crate) struct Join {
+    separator: u8,
+}
+
+impl Default for Join {
+    fn default() -> Self {
+        Self {
+            separator: DEFAULT_SEPARATOR,
+        }
+    }
+}
+
+impl Join {
+    pub(super) fn from_config(config: &ConfigMap) -> Result<Self> {
+        let separator = if let Some(raw_config) = config {
+            let config = Config::new(raw_config)?;
+            if config.separator.len() != 1 {
+                return Err(ErrorKind::InvalidConfiguration(
+                    String::from("join postprocessor"),
+                    format!(
+                        "Invalid 'separator': \"{}\", must be 1 byte.",
+                        config.separator
+                    ),
+                )
+                .into());
+            }
+            config.separator.as_bytes()[0]
+        } else {
+            DEFAULT_SEPARATOR
+        };
+        Ok(Self { separator })
+    }
+}
+
+impl Postprocessor for Join {
+    fn name(&self) -> &str {
+        "join"
+    }
+
+    fn process(&mut self, _ingres_ns: u64, _egress_ns: u64, data: &[u8]) -> Result<Vec<Vec<u8>>> {
+        // padding capacity with 1 to account for the new line char we will be pushing
+        let mut framed: Vec<u8> = Vec::with_capacity(data.len() + 1);
+        framed.extend_from_slice(data);
+        framed.push(self.separator);
+        Ok(vec![framed])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tremor_value::literal;
+
+    #[test]
+    fn join_postprocessor() -> Result<()> {
+        let config = Some(literal!({
+            "separator": "|"
+        }));
+        let mut join = Join::from_config(&config)?;
+        let data: [u8; 0] = [];
+        assert_eq!(Ok(vec![vec![b'|']]), join.process(0, 0, &data));
+        assert_eq!(
+            Ok(vec![vec![b'f', b'o', b'o', b'b', b'|']]),
+            join.process(0, 0, b"foob")
+        );
+        assert!(join.finish(None)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn join_postprocessor_default() -> Result<()> {
+        let mut join = Join::from_config(&None)?;
+        let data: [u8; 0] = [];
+        assert_eq!(Ok(vec![vec![b'\n']]), join.process(0, 0, &data));
+        assert_eq!(
+            Ok(vec![vec![b'f', b'o', b'o', b'b', b'\n']]),
+            join.process(0, 0, b"foob")
+        );
+        assert!(join.finish(None)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn from_config_invalid_separator() -> Result<()> {
+        let config = Some(literal!({
+            "separator": "abc"
+        }));
+        let res = Join::from_config(&config).err().unwrap();
+
+        assert_eq!("Invalid Configuration for join postprocessor: Invalid 'separator': \"abc\", must be 1 byte.", res.to_string().as_str());
+        Ok(())
+    }
+}

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -62,6 +62,7 @@ pub trait Preprocessor: Sync + Send {
 pub fn lookup_with_config(config: &PreprocessorConfig) -> Result<Box<dyn Preprocessor>> {
     match config.name.as_str() {
         "split" => Ok(Box::new(Split::from_config(&config.config)?)),
+        "lines" => Ok(Box::new(Split::default())),
         "base64" => Ok(Box::new(Base64::default())),
         "gzip" => Ok(Box::new(Gzip::default())),
         "zlib" => Ok(Box::new(Zlib::default())),
@@ -455,7 +456,7 @@ impl Preprocessor for Zstd {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::postprocessor::{self as post, Join, Postprocessor};
+    use crate::postprocessor::{self as post, join::Join, Postprocessor};
     use crate::preprocessor::{self as pre, Preprocessor};
     #[test]
     fn ingest_ts() -> Result<()> {
@@ -748,6 +749,7 @@ mod test {
         let egress_ns = 1_u64;
 
         let r = post.process(ingest_ns, egress_ns, int);
+        assert!(r.is_ok(), "Expected Ok(...), Got: {r:?}");
         let ext = &r?[0];
         let ext = ext.as_slice();
         // Assert actual encoded form is as expected

--- a/src/preprocessor/split.rs
+++ b/src/preprocessor/split.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, The Tremor Team
+// Copyright 2022, The Tremor Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ use crate::errors::{Kind as ErrorKind, Result};
 use memchr::memchr_iter;
 use tremor_pipeline::{ConfigImpl, ConfigMap};
 
-const DEFAULT_SEPARATOR: u8 = b'\n';
+pub(crate) const DEFAULT_SEPARATOR: u8 = b'\n';
 const INITIAL_LINES_PER_CHUNK: usize = 64;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,8 +34,8 @@ pub struct Config {
     buffered: bool,
 }
 
-fn default_separator() -> String {
-    "\n".to_string()
+pub(crate) fn default_separator() -> String {
+    String::from_utf8_lossy(&[DEFAULT_SEPARATOR]).into_owned()
 }
 
 impl ConfigImpl for Config {}
@@ -62,7 +62,7 @@ impl Split {
             let separator = {
                 if config.separator.len() != 1 {
                     return Err(ErrorKind::InvalidConfiguration(
-                        String::from("lines preprocessor"),
+                        String::from("split preprocessor"),
                         format!(
                             "Invalid 'separator': \"{}\", must be 1 byte.",
                             config.separator
@@ -271,7 +271,7 @@ mod test {
         }));
         let res = Split::from_config(&config).err().unwrap();
 
-        assert_eq!("Invalid Configuration for lines preprocessor: Invalid 'separator': \"abc\", must be 1 byte.", res.to_string().as_str());
+        assert_eq!("Invalid Configuration for split preprocessor: Invalid 'separator': \"abc\", must be 1 byte.", res.to_string().as_str());
         Ok(())
     }
 

--- a/tremor-cli/src/cli.rs
+++ b/tremor-cli/src/cli.rs
@@ -154,10 +154,10 @@ pub(crate) struct Run {
     #[clap(short, long, default_value = "-")]
     pub(crate) outfile: String,
     /// Preprocessors to pass data through before decoding
-    #[clap(long, default_value = "split")]
+    #[clap(long, default_value = "separate")]
     pub(crate) preprocessor: String,
     /// Postprocessor to pass data through after encoding
-    #[clap(long, default_value = "join")]
+    #[clap(long, default_value = "separate")]
     pub(crate) postprocessor: String,
     /// Specifies the port that is printed to the output
 

--- a/tremor-cli/tests/integration/file-connector-append/config.troy
+++ b/tremor-cli/tests/integration/file-connector-append/config.troy
@@ -8,7 +8,7 @@ flow
   define connector out_file from file
   with 
     codec = "json-sorted",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
       "path": "out.log",
       "mode": "append"

--- a/tremor-cli/tests/integration/file-connector-overwrite/config.troy
+++ b/tremor-cli/tests/integration/file-connector-overwrite/config.troy
@@ -8,7 +8,7 @@ flow
   define connector out_file from file
   with 
     codec = "json-sorted",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
       "path": "out.log",
       "mode": "overwrite"

--- a/tremor-cli/tests/integration/file-connector/config.troy
+++ b/tremor-cli/tests/integration/file-connector/config.troy
@@ -8,7 +8,7 @@ flow
   define connector out_file from file
   with 
     codec = "json-sorted",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
       "path": "out.log",
       "mode": "truncate"
@@ -18,7 +18,7 @@ flow
   define connector in_file from file
   with 
     codec = "json",
-    preprocessors = ["split"],
+    preprocessors = ["separate"],
     config = {
       "path": "in.json",
       "mode": "read"

--- a/tremor-cli/tests/integration/string-codec/config.troy
+++ b/tremor-cli/tests/integration/string-codec/config.troy
@@ -5,7 +5,7 @@ flow
   define connector in from file
   with
     codec = "string",
-    preprocessors = ["split"],
+    preprocessors = ["separate"],
     config = {"path": "in.json", "mode": "read"}
   end;
 

--- a/tremor-cli/tests/integration/system-metrics/config.troy
+++ b/tremor-cli/tests/integration/system-metrics/config.troy
@@ -21,7 +21,7 @@ flow
   with
     metrics_interval_s = 3,
     codec = "json-sorted",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
       "path": "events.log",
       "mode": "write"

--- a/tremor-cli/tests/integration/tcp-tls/config.troy
+++ b/tremor-cli/tests/integration/tcp-tls/config.troy
@@ -6,8 +6,8 @@ flow
 
   define connector tcp_server from tcp_server
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "url": "0.0.0.0:65535",
@@ -49,8 +49,8 @@ flow
 
   define connector tcp_client from tcp_client
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "url": "127.0.0.1:65535",

--- a/tremor-cli/tests/integration/tcp/config.troy
+++ b/tremor-cli/tests/integration/tcp/config.troy
@@ -6,8 +6,8 @@ flow
 
   define connector tcp_server from tcp_server
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "url": "0.0.0.0:65535",
@@ -45,8 +45,8 @@ flow
 
   define connector tcp_client from tcp_client
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "url": "127.0.0.1:65535",

--- a/tremor-cli/tests/integration/udp-postprocessors/before/config.troy
+++ b/tremor-cli/tests/integration/udp-postprocessors/before/config.troy
@@ -16,7 +16,7 @@ flow
   define connector out from file
   with
     codec = "string",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
       "path": "../gen.log",
       "mode": "truncate"

--- a/tremor-cli/tests/integration/udp-postprocessors/config.troy
+++ b/tremor-cli/tests/integration/udp-postprocessors/config.troy
@@ -8,7 +8,7 @@ flow
   define connector in from file
   with
     codec = "json",
-    preprocessors = ["split"],
+    preprocessors = ["separate"],
     config = {
         "path": "in.json",
         "mode": "read"

--- a/tremor-cli/tests/integration/unix-socket/config.troy
+++ b/tremor-cli/tests/integration/unix-socket/config.troy
@@ -6,8 +6,8 @@ flow
 
   define connector server from unix_socket_server
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "path": "/tmp/unix-socket.sock",
@@ -48,8 +48,8 @@ flow
 
   define connector client from unix_socket_client
   with
-    preprocessors = ["split"],
-    postprocessors = ["join"],
+    preprocessors = ["separate"],
+    postprocessors = ["separate"],
     codec = "json",
     config = {
       "path": "/tmp/unix-socket.sock",

--- a/tremor-cli/tests/lib/integration.troy
+++ b/tremor-cli/tests/lib/integration.troy
@@ -13,7 +13,7 @@ args
     file = "out.log"
 with 
     codec = "json-sorted",
-    postprocessors = ["join"],
+    postprocessors = ["separate"],
     config = {
         "path": args.file,
         "mode": "truncate"
@@ -25,7 +25,7 @@ args
     file = "in.json"
 with 
     codec = "json-sorted",
-    preprocessors = ["split"],
+    preprocessors = ["separate"],
     config = {
         "path": args.file,
         "mode": "read"

--- a/tremor-erl/samples/01.troy
+++ b/tremor-erl/samples/01.troy
@@ -8,7 +8,7 @@ flow
     with
         metrics_interval_s = 1,
         codec = "string",
-        postprocessors = ["join"],
+        postprocessors = ["separate"],
         config = {
             "mode": "truncate",
             "path": "/tmp/tremor_eqc_outfile"
@@ -34,7 +34,7 @@ flow
     with
         metrics_interval_s = 5,
         codec = "string",
-        preprocessors = ["split"],
+        preprocessors = ["separate"],
         config = {
             "mode": "read",
             "path": "README.md"
@@ -45,7 +45,7 @@ flow
     define connector non_existent_file from file
     with
         codec = "string",
-        preprocessors = ["split"],
+        preprocessors = ["separate"],
         config = {
             "mode": "read",
             "path": "path/to/nowhere/i_do_no_exist.txt"

--- a/tremor-script/lib/troy/connectors.troy
+++ b/tremor-script/lib/troy/connectors.troy
@@ -8,7 +8,7 @@ define connector metrics from metrics;
 ## A line seperated stdio based connector
 define connector console from stdio
 with
-  preprocessors = ["split"],
-  postprocessors = ["join"],
+  preprocessors = ["separate"],
+  postprocessors = ["separate"],
   codec = "string"
 end;


### PR DESCRIPTION
# Pull request

## Description
Rename `split`, `join` and `lines` processors to `separate`.

## Related


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No impact

