### PR TITLE
Remove '-' as a valid char in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Breaking Changes
 
 - the `-` is no longer a valid part of identifiers.
-- binaries now use `_` to sepoerate type names as `-` is no longer a identifyer.
+- binaries now use `_` to sepoerate type names as `-` is no longer a identifier.
 
 ## [0.12.0-rc.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Breaking Changes
 
-- the `-` is no longer a valid part of identifiers
+- the `-` is no longer a valid part of identifiers.
+- binaries now use `_` to sepoerate type names as `-` is no longer a identifyer.
 
 ## [0.12.0-rc.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Breaking Changes
+
+- the `-` is no longer a valid part of identifiers
+
 ## [0.12.0-rc.1]
 
 ### New featues

--- a/tests/scripts/bytes_create/script.tremor
+++ b/tests/scripts/bytes_create/script.tremor
@@ -1,2 +1,2 @@
 use std::string;
-string::from_utf8_lossy(<< << event/binary, 32 >>/binary, 0x22/signed-integer, "snot"/binary, 0x2122:16/big-integer >>)
+string::from_utf8_lossy(<< << event/binary, 32 >>/binary, 0x22/signed_integer, "snot"/binary, 0x2122:16/big_integer >>)

--- a/tremor-script/lib/std/type.tremor
+++ b/tremor-script/lib/std/type.tremor
@@ -12,7 +12,7 @@
 ## > "string" == type::as_string("snot");
 ## > "array" == type::as_string([null,true,"snot"]);
 ## > "record" == type::as_string({"snot": [1, 1.e23, "badger"]});
-## > "bytes" == type::as_string(<< 1/unsigned-integer >>);
+## > "bytes" == type::as_string(<< 1/unsigned_integer >>);
 ## > ```
 ##
 ## Returns a `string`
@@ -110,7 +110,7 @@ intrinsic fn is_record(value) as type::is_record;
 ##
 ## > ```tremor
 ## > use std::type;
-## > true == type::is_binary(<< 1/unsigned-integer >>);;
+## > true == type::is_binary(<< 1/unsigned_integer >>);;
 ## > false == type::is_binary(true);
 ## > ```
 ##

--- a/tremor-script/src/ast/eq/tests.rs
+++ b/tremor-script/src/ast/eq/tests.rs
@@ -115,8 +115,8 @@ fn test_list_eq() -> Result<()> {
     test_ast_eq(
         r#"
         let x = event.len;
-        [1, -x, <<x:7/unsigned-integer>>, "foo"];
-        [1, -x, <<x:7/unsigned-integer>>, "foo"]
+        [1, -x, <<x:7/unsigned_integer>>, "foo"];
+        [1, -x, <<x:7/unsigned_integer>>, "foo"]
         "#,
         true,
     )
@@ -126,8 +126,8 @@ fn test_list_not_eq() -> Result<()> {
     test_ast_eq(
         r#"
         let x = event.len;
-        [1, -x, <<x:7/unsigned-integer>>, "foo"];
-        [1, -x, <<x:7/signed-integer>>, "foo"]
+        [1, -x, <<x:7/unsigned_integer>>, "foo"];
+        [1, -x, <<x:7/signed_integer>>, "foo"]
         "#,
         false,
     )

--- a/tremor-script/src/ast/raw.rs
+++ b/tremor-script/src/ast/raw.rs
@@ -206,7 +206,7 @@ impl<'script> Upable<'script> for BytesPartRaw<'script> {
     // We allow this for casting the bits
     #[allow(clippy::cast_sign_loss)]
     fn up<'registry>(self, helper: &mut Helper<'script, 'registry>) -> Result<Self::Target> {
-        let data_type: Vec<&str> = self.data_type.id.split('-').collect();
+        let data_type: Vec<&str> = self.data_type.id.split('_').collect();
         let (data_type, endianess) = match data_type.as_slice() {
             ["binary"] => (BytesDataType::Binary, Endian::Big),
             []

--- a/tremor-script/src/lexer.rs
+++ b/tremor-script/src/lexer.rs
@@ -57,12 +57,12 @@ fn is_ws(ch: char) -> bool {
 }
 
 fn is_ident_start(ch: char) -> bool {
-    UnicodeXID::is_xid_start(ch) || ch == '_' || ch == '-'
+    UnicodeXID::is_xid_start(ch) || ch == '_'
 }
 
 fn is_ident_continue(ch: char) -> bool {
     let ch = ch as char;
-    UnicodeXID::is_xid_continue(ch) || ch == '_' || ch == '-'
+    UnicodeXID::is_xid_continue(ch) || ch == '_'
 }
 
 fn is_test_start(ch: char) -> bool {

--- a/tremor-script/src/lexer/test.rs
+++ b/tremor-script/src/lexer/test.rs
@@ -113,8 +113,8 @@ fn number_parsing() -> Result<()> {
 #[test]
 fn paths() -> Result<()> {
     lex_ok! {
-        "  hello-hahaha8ABC ",
-        "  ~~~~~~~~~~~~~~~~ " => Token::Ident("hello-hahaha8ABC".into(), false),
+        "  hello_hahaha8ABC ",
+        "  ~~~~~~~~~~~~~~~~ " => Token::Ident("hello_hahaha8ABC".into(), false),
     };
     lex_ok! {
         "  .florp ",


### PR DESCRIPTION
# Pull request

## Description

This pull request removes `-` as a character that can be used in idents, this prevents ambiguity and removes inconsistency with other operators.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No runtime changes