### PR TITLE
Fix args for flow creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-## Breaking Changes
+### Fixes
+
+- fix the use of `args` in the with part of a `create` insode of a `flow`.
+
+### Breaking Changes
 
 - the `-` is no longer a valid part of identifiers.
 - binaries now use `_` to sepoerate type names as `-` is no longer a identifier.

--- a/tests/flows.rs
+++ b/tests/flows.rs
@@ -47,7 +47,6 @@ macro_rules! test_cases {
                     let mut file = file::open(deploy_file)?;
                     let mut contents = String::new();
                     file.read_to_string(&mut contents)?;
-
                     match parse(&contents) {
                         Ok(deployable) => {
                             let (world, h) = World::start(WorldConfig::default()).await?;
@@ -75,5 +74,6 @@ test_cases!(
     pipeline_args,
     pipeline_with,
     // INSERT
+    args_in_create,
     chained_pipelines,
 );

--- a/tests/flows/args_in_create/flow.troy
+++ b/tests/flows/args_in_create/flow.troy
@@ -1,0 +1,29 @@
+define flow test
+args
+  ival,
+flow
+  define connector metronome from metronome
+  args
+    ival
+  with
+    config = {
+      "interval": args.ival
+    }
+  end;
+  define connector exit from exit;
+  define pipeline identity
+  pipeline
+    select event from in into out;
+  end;
+  create connector metronome with ival = args.ival end;
+  create connector exit;
+  create pipeline identity;
+  
+  connect /connector/metronome to /pipeline/identity;
+  connect /pipeline/identity to /connector/exit;
+end;
+
+deploy flow test
+with
+  ival = 1,
+end;


### PR DESCRIPTION
# Pull request

## Description

`args` were not correctly propagated to `create` in `flows`, this fixes it.

## Related


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No runtime changes