### PR TITLE
Remove coveralls upload

### DIFF
--- a/.github/scripts/lcov-wrap.sh
+++ b/.github/scripts/lcov-wrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+echo "PWD: $PWD"
+echo "CWD: $CWD"
+export
+echo $@
+cargo llvm-cov run --no-report -p tremor-cli -- $@

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -64,6 +64,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./lcov.txt # optional
-          flags: CLI${{ matrix.kind }} # optional
+          flags: cli${{ matrix.kind }} # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)      

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  tests-linux:
+  tests-linux:Ferror_to_string
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,11 +26,6 @@ jobs:
           RUSTFLAGS: -D warnings -C target-feature=+avx,+avx2,+sse4.2
           RUST_BACKTRACE: 1
         run: cargo llvm-cov --workspace --lcov --output-path lcov.txt --features integration
-      - name: Upload to Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov.txt
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  tests-linux:Ferror_to_string
+  tests-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Pull request

## Description

This removes the coveralls integration, we ran it in parallel with codecov and already switched to the CI demanding codecov instead of coveralls. We don't need this any longer and it makes PR's less spammy.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no code changes