### PR TITLE
Separated cargo publish jobs

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -42,26 +42,9 @@ jobs:
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Publish tremor-common to crates.io
-        uses: katyo/publish-crates@v1
-        with:
-          path: './tremor-common'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish tremor-value to crates.io
-        uses: katyo/publish-crates@v1
-        with:
-          path: './tremor-value'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish tremor-value to crates.io
-        uses: katyo/publish-crates@v1
-        with:
-          path: './tremor-influx'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish tremor-script to crates.io
-        run: |
-          cd tremor-script
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Trigger publish crates workflow
+        uses: benc-uk/workflow-dispatch@v1
+         with:
+          workflow: Publish crates
+          token: ${{ secrets.PAT_TOKEN }}
+

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
       - name: Trigger publish crates workflow
         uses: benc-uk/workflow-dispatch@v1
-         with:
+        with:
           workflow: Publish crates
           token: ${{ secrets.PAT_TOKEN }}
 

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -3,8 +3,8 @@ name: "Publish crates"
 on: workflow_dispatch 
 
 jobs:
-  draft-new-release:
-    name: "Publish crat"es
+  publish-crates:
+    name: "Publish crates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -1,0 +1,35 @@
+name: "Publish crates"
+
+on: workflow_dispatch 
+
+jobs:
+  draft-new-release:
+    name: "Publish crat"es
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Publish tremor-common to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          path: './tremor-common'
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish tremor-value to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          path: './tremor-value'
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish tremor-influx to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          path: './tremor-influx'
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish tremor-script to crates.io
+        run: |
+          cd tremor-script
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -30,6 +30,11 @@ jobs:
           path: './tremor-influx'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish tremor-script to crates.io
-        run: |
-          cd tremor-script
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        uses: Wandalen/wretry.action@v1.0.11
+        with:
+          action: katyo/publish-crates@v1
+          with: |
+            path: './tremor-script'
+            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          attempt_limit: 6
+          attempt_delay: 10000

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   publish-crates:
-    name: "Publish crates
+    name: Publish crates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 - http headers to allow strings and arrays
 
-## [0.12.0-rc.2]
+## [0.12.0-rc.2 - 0.12.0-rc.5]
 
 ### New features
 


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->
- Separated publishing cargo packages into a separate job for easy re running in case of failure
- Updated Changelog

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


