### PR TITLE
Fix bench connector not stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-# Unreleased
-
 ### Fixes
 
 - Properly terminate after `tremor run ...`
+- Fix the `bench` connector to actually stop after the given amount of events when `iters` is configured.
 
 ## [0.12.0-rc.6]
 

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -397,13 +397,10 @@ pub(crate) type Known =
 pub(crate) async fn spawn(
     alias: &str,
     connector_id_gen: &mut ConnectorIdGen,
-    known_connectors: &Known,
+    builder: &dyn ConnectorBuilder,
     config: ConnectorConfig,
 ) -> Result<Addr> {
-    // lookup and instantiate connector
-    let builder = known_connectors
-        .get(&config.connector_type)
-        .ok_or_else(|| ErrorKind::UnknownConnectorType(config.connector_type.to_string()))?;
+    // instantiate connector
     let connector = builder.build(alias, &config).await?;
     let r = connector_task(
         alias.to_string(),
@@ -1188,7 +1185,7 @@ pub(crate) fn builtin_connector_types() -> Vec<Box<dyn ConnectorBuilder + 'stati
 pub(crate) fn debug_connector_types(world: &World) -> Vec<Box<dyn ConnectorBuilder + 'static>> {
     vec![
         Box::new(impls::cb::Builder::new(world.clone())),
-        Box::new(impls::bench::Builder::default()),
+        Box::new(impls::bench::Builder::new(world.clone())),
         Box::new(impls::null::Builder::default()),
     ]
 }

--- a/src/connectors/impls/gbq/writer/sink.rs
+++ b/src/connectors/impls/gbq/writer/sink.rs
@@ -468,6 +468,7 @@ impl Sink for GbqSink {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::connectors::impls::gbq;
     use crate::connectors::reconnect::ConnectionLostNotifier;
     use crate::connectors::tests::ConnectorHarness;
     use googapis::google::cloud::bigquery::storage::v1::table_field_schema::Mode;
@@ -1109,7 +1110,9 @@ mod test {
             "config": {}
         });
 
-        let result = ConnectorHarness::new(function_name!(), "gbq", &config).await;
+        let result =
+            ConnectorHarness::new(function_name!(), &gbq::writer::Builder::default(), &config)
+                .await;
 
         assert!(result.is_err());
 

--- a/src/connectors/tests/bench.rs
+++ b/src/connectors/tests/bench.rs
@@ -1,0 +1,110 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing perm
+use super::ConnectorHarness;
+use crate::{
+    connectors::{impls::bench, sink::SinkMsg},
+    errors::Result,
+    system::{World, WorldConfig},
+};
+use std::{
+    io::Write,
+    time::{Duration, Instant},
+};
+use tempfile::NamedTempFile;
+use tremor_common::ports::IN;
+use tremor_value::prelude::*;
+
+#[async_std::test]
+async fn stop_after_events() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{}\n")?;
+    file.write_all(b"\"snot\"\n")?;
+    file.write_all(b"\"badger\"\n")?;
+    file.flush()?;
+    let path = file.into_temp_path();
+
+    let defn = literal!({
+      "codec": "binary",
+      "config": {
+        "source": path.display().to_string(),
+        "iters": 2
+      }
+    });
+    let (world, world_handle) = World::start(WorldConfig::default()).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &bench::Builder::new(world.clone()), &defn).await?;
+    let out = harness.out().expect("No out pipeline connected");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    let bg_out = out.clone();
+    let bg_addr = harness.addr.clone();
+    async_std::task::spawn::<_, Result<()>>(async move {
+        // echo pipeline
+        for _ in 0..6 {
+            let event = bg_out.get_event().await?;
+            bg_addr
+                .send_sink(SinkMsg::Event { event, port: IN })
+                .await?;
+        }
+        Ok(())
+    });
+
+    // the bench connector should shut the world down
+    world_handle.await?;
+    Ok(())
+}
+
+#[async_std::test]
+async fn stop_after_secs() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{}\n")?;
+    file.write_all(b"\"snot\"\n")?;
+    file.write_all(b"\"badger\"\n")?;
+    file.flush()?;
+    let path = file.into_temp_path();
+
+    let defn = literal!({
+      "codec": "string",
+      "config": {
+        "source": path.display().to_string(),
+        "stop_after_secs": 1
+      }
+    });
+
+    let (world, world_handle) = World::start(WorldConfig::default()).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &bench::Builder::new(world.clone()), &defn).await?;
+    let out = harness.out().expect("No out pipeline connected");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    let one_sec = Duration::from_secs(1);
+    let start = Instant::now();
+    // echo pipeline
+    while start.elapsed() < one_sec {
+        let event = out.get_event().await?;
+        harness.send_to_sink(event, IN).await?;
+    }
+
+    // the bench connector should shut the world down
+    world_handle.await?;
+    let (_out, err) = harness.stop().await?;
+    assert!(err.is_empty());
+
+    Ok(())
+}

--- a/src/connectors/tests/crononome.rs
+++ b/src/connectors/tests/crononome.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::crononome, errors::Result};
 use tremor_value::prelude::*;
 
 #[async_std::test]
@@ -30,7 +30,8 @@ async fn connector_crononome_routing() -> Result<()> {
       },
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "crononome", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &crononome::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'in' port of ws_server connector");

--- a/src/connectors/tests/elastic.rs
+++ b/src/connectors/tests/elastic.rs
@@ -77,7 +77,12 @@ async fn connector_elastic() -> Result<()> {
             ]
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), &elastic::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &elastic::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     let in_pipe = harness.get_pipe(IN).expect("No pipe connected to port IN");

--- a/src/connectors/tests/elastic.rs
+++ b/src/connectors/tests/elastic.rs
@@ -15,6 +15,7 @@
 use std::time::{Duration, Instant};
 
 use super::ConnectorHarness;
+use crate::connectors::impls::elastic;
 use crate::errors::{Error, Result};
 use elasticsearch::{http::transport::Transport, Elasticsearch};
 use futures::TryFutureExt;
@@ -76,7 +77,7 @@ async fn connector_elastic() -> Result<()> {
             ]
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), "elastic", &connector_config).await?;
+    let harness = ConnectorHarness::new(function_name!(), &elastic::Builder::default(), &connector_config).await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     let in_pipe = harness.get_pipe(IN).expect("No pipe connected to port IN");

--- a/src/connectors/tests/file.rs
+++ b/src/connectors/tests/file.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::file, errors::Result};
 use async_std::path::Path;
 use tremor_value::literal;
 use value_trait::ValueAccess;
@@ -38,7 +38,7 @@ async fn file_connector() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "file", &defn).await?;
+    let harness = ConnectorHarness::new(function_name!(), &file::Builder::default(), &defn).await?;
     let out = harness.out().expect("No out pipeline");
     harness.start().await?;
 

--- a/src/connectors/tests/file_non_existent.rs
+++ b/src/connectors/tests/file_non_existent.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::file, errors::Result};
 use async_std::path::Path;
 use tremor_value::prelude::*;
 
@@ -35,7 +35,7 @@ async fn file_connector() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "file", &defn).await?;
+    let harness = ConnectorHarness::new(function_name!(), &file::Builder::default(), &defn).await?;
     assert!(harness.start().await.is_err());
 
     let (out_events, err_events) = harness.stop().await?;

--- a/src/connectors/tests/file_xz.rs
+++ b/src/connectors/tests/file_xz.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::file, errors::Result};
 use async_std::path::Path;
 use tremor_value::literal;
 use value_trait::ValueAccess;
@@ -38,7 +38,7 @@ async fn file_connector_xz() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "file", &defn).await?;
+    let harness = ConnectorHarness::new(function_name!(), &file::Builder::default(), &defn).await?;
     let out = harness.out().expect("No out pipeline");
     harness.start().await?;
     harness.wait_for_connected().await?;

--- a/src/connectors/tests/http/client.rs
+++ b/src/connectors/tests/http/client.rs
@@ -14,6 +14,7 @@
 
 use crate::{
     connectors::{
+        impls::http,
         prelude::Url,
         tests::{free_port::find_free_tcp_port, setup_for_tls, ConnectorHarness},
         utils::url::HttpDefaults,
@@ -141,7 +142,8 @@ async fn rtt(
 
     let mut fake = TestHttpServer::new(url.clone()).await?;
 
-    let harness = ConnectorHarness::new(function_name!(), "http_client", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &http::client::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of connector");
@@ -635,7 +637,7 @@ async fn missing_tls_config_https() -> Result<()> {
       "codec": "influx",
     });
     let id = function_name!();
-    let res = ConnectorHarness::new(id, "http_client", &defn)
+    let res = ConnectorHarness::new(id, &http::client::Builder::default(), &defn)
         .await
         .err()
         .unwrap();
@@ -651,7 +653,7 @@ async fn missing_config() -> Result<()> {
       "codec": "binflux",
     });
     let id = function_name!();
-    let res = ConnectorHarness::new(id, "http_client", &defn)
+    let res = ConnectorHarness::new(id, &http::client::Builder::default(), &defn)
         .await
         .err()
         .unwrap();

--- a/src/connectors/tests/http/server.rs
+++ b/src/connectors/tests/http/server.rs
@@ -19,6 +19,7 @@ use std::{
 // limitations under the License.
 use crate::{
     connectors::{
+        impls::http::server,
         sink::SinkMsg,
         tests::{free_port, setup_for_tls, ConnectorHarness},
         utils::tls::{tls_client_config, TLSClientConfig},
@@ -87,7 +88,8 @@ async fn http_server_test() -> Result<()> {
             "url": url.clone()
         }
     });
-    let connector = ConnectorHarness::new(function_name!(), "http_server", &defn).await?;
+    let connector =
+        ConnectorHarness::new(function_name!(), &server::Builder::default(), &defn).await?;
     connector.start().await?;
     connector.wait_for_connected().await?;
 
@@ -339,7 +341,8 @@ async fn https_server_test() -> Result<()> {
             }
         }
     });
-    let connector = ConnectorHarness::new(function_name!(), "http_server", &defn).await?;
+    let connector =
+        ConnectorHarness::new(function_name!(), &server::Builder::default(), &defn).await?;
     connector.start().await?;
     connector.wait_for_connected().await?;
     let out = connector

--- a/src/connectors/tests/kafka/consumer.rs
+++ b/src/connectors/tests/kafka/consumer.rs
@@ -14,7 +14,10 @@
 
 use super::super::ConnectorHarness;
 use super::redpanda_container;
-use crate::{connectors::{impls::kafka, tests::free_port}, errors::Result};
+use crate::{
+    connectors::{impls::kafka, tests::free_port},
+    errors::Result,
+};
 use async_std::task;
 use beef::Cow;
 use rdkafka::{
@@ -93,8 +96,12 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -326,8 +333,12 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -547,8 +558,12 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -739,8 +754,12 @@ async fn connector_kafka_consumer_unreachable() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     let (out_events, err_events) = harness.stop().await?;
@@ -805,8 +824,12 @@ async fn connector_kafka_consumer_pause_resume() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     harness.start().await?;
     harness.wait_for_connected().await?;

--- a/src/connectors/tests/kafka/consumer.rs
+++ b/src/connectors/tests/kafka/consumer.rs
@@ -14,7 +14,7 @@
 
 use super::super::ConnectorHarness;
 use super::redpanda_container;
-use crate::{connectors::tests::free_port, errors::Result};
+use crate::{connectors::{impls::kafka, tests::free_port}, errors::Result};
 use async_std::task;
 use beef::Cow;
 use rdkafka::{
@@ -94,7 +94,7 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_consumer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -327,7 +327,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_consumer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -548,7 +548,7 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_consumer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     let err = harness.err().expect("No pipe connected to port ERR");
     harness.start().await?;
@@ -740,7 +740,7 @@ async fn connector_kafka_consumer_unreachable() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_consumer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
     assert!(harness.start().await.is_err());
 
     let (out_events, err_events) = harness.stop().await?;
@@ -806,7 +806,7 @@ async fn connector_kafka_consumer_pause_resume() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_consumer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::consumer::Builder::default(), &connector_config).await?;
     let out = harness.out().expect("No pipe connected to port OUT");
     harness.start().await?;
     harness.wait_for_connected().await?;

--- a/src/connectors/tests/kafka/producer.rs
+++ b/src/connectors/tests/kafka/producer.rs
@@ -14,7 +14,7 @@
 
 use super::super::ConnectorHarness;
 use super::redpanda_container;
-use crate::{errors::Result, Event, connectors::impls::kafka};
+use crate::{connectors::impls::kafka, errors::Result, Event};
 use async_std::prelude::FutureExt;
 use futures::StreamExt;
 use rdkafka::{
@@ -89,8 +89,12 @@ async fn connector_kafka_producer() -> Result<()> {
             }
         }
     });
-    let harness =
-        ConnectorHarness::new(function_name!(), &kafka::producer::Builder::default(), &connector_config).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::producer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
     let in_pipe = harness.get_pipe(IN).expect("No pipe connected to port IN");
     harness.start().await?;
     harness.wait_for_connected().await?;

--- a/src/connectors/tests/kafka/producer.rs
+++ b/src/connectors/tests/kafka/producer.rs
@@ -14,7 +14,7 @@
 
 use super::super::ConnectorHarness;
 use super::redpanda_container;
-use crate::{errors::Result, Event};
+use crate::{errors::Result, Event, connectors::impls::kafka};
 use async_std::prelude::FutureExt;
 use futures::StreamExt;
 use rdkafka::{
@@ -90,7 +90,7 @@ async fn connector_kafka_producer() -> Result<()> {
         }
     });
     let harness =
-        ConnectorHarness::new(function_name!(), "kafka_producer", &connector_config).await?;
+        ConnectorHarness::new(function_name!(), &kafka::producer::Builder::default(), &connector_config).await?;
     let in_pipe = harness.get_pipe(IN).expect("No pipe connected to port IN");
     harness.start().await?;
     harness.wait_for_connected().await?;

--- a/src/connectors/tests/metronome.rs
+++ b/src/connectors/tests/metronome.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::metronome, errors::Result};
 use std::time::Duration;
 use tremor_value::prelude::*;
 
@@ -28,7 +28,8 @@ async fn connector_metronome_routing() -> Result<()> {
     });
     let epoch = tremor_common::time::nanotime();
 
-    let harness = ConnectorHarness::new(function_name!(), "metronome", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &metronome::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'in' port of ws_server connector");

--- a/src/connectors/tests/pause_resume.rs
+++ b/src/connectors/tests/pause_resume.rs
@@ -15,7 +15,14 @@
 use std::time::Duration;
 
 use super::ConnectorHarness;
-use crate::{connectors::source::SourceMsg, errors::Result, instance::State};
+use crate::{
+    connectors::{
+        impls::{tcp, udp},
+        source::SourceMsg,
+    },
+    errors::Result,
+    instance::State,
+};
 use async_std::{
     channel::bounded,
     io::WriteExt,
@@ -45,7 +52,8 @@ async fn udp_pause_resume() -> Result<()> {
       }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "udp_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &udp::server::Builder::default(), &defn).await?;
 
     let out_pipeline = harness
         .out()
@@ -143,7 +151,8 @@ async fn tcp_server_pause_resume() -> Result<()> {
           "buf_size": 4096
       }
     });
-    let harness = ConnectorHarness::new(function_name!(), "tcp_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &tcp::server::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of tcp_server connector");

--- a/src/connectors/tests/s3/reader.rs
+++ b/src/connectors/tests/s3/reader.rs
@@ -41,7 +41,7 @@ async fn connector_s3_no_connection() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_reader", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
     Ok(())
 }
@@ -71,7 +71,7 @@ async fn connector_s3_no_credentials() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_reader", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -104,7 +104,7 @@ async fn connector_s3_no_region() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_reader", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -134,7 +134,7 @@ async fn connector_s3_no_bucket() -> Result<()> {
             "endpoint": endpoint
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), "s3_reader", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -194,7 +194,7 @@ async fn connector_s3_reader() -> Result<()> {
 
     let harness = ConnectorHarness::new(
         function_name!(),
-        s3::reader::CONNECTOR_TYPE,
+        &s3::reader::Builder::default(),
         &connector_yaml,
     )
     .await?;

--- a/src/connectors/tests/s3/reader.rs
+++ b/src/connectors/tests/s3/reader.rs
@@ -41,7 +41,12 @@ async fn connector_s3_no_connection() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::reader::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
     Ok(())
 }
@@ -71,7 +76,12 @@ async fn connector_s3_no_credentials() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::reader::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -104,7 +114,12 @@ async fn connector_s3_no_region() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::reader::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -134,7 +149,12 @@ async fn connector_s3_no_bucket() -> Result<()> {
             "endpoint": endpoint
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), &s3::reader::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::reader::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())

--- a/src/connectors/tests/s3/writer.rs
+++ b/src/connectors/tests/s3/writer.rs
@@ -17,6 +17,7 @@ use std::io::Read;
 use super::super::{ConnectorHarness, TestPipeline};
 use super::{get_client, random_bucket_name, spawn_docker, wait_for_s3mock, EnvHelper, IMAGE, TAG};
 use crate::errors::Result;
+use crate::connectors::impls::s3;
 use aws_sdk_s3::Client;
 use bytes::Buf;
 use rand::{distributions::Alphanumeric, Rng};
@@ -44,7 +45,7 @@ async fn connector_s3_no_connection() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_writer", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
     Ok(())
 }
@@ -74,7 +75,7 @@ async fn connector_s3_no_credentials() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_writer", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -107,7 +108,7 @@ async fn connector_s3_no_region() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_writer", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -137,7 +138,7 @@ async fn connector_s3_no_bucket() -> Result<()> {
             "endpoint": endpoint
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), "s3_writer", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -174,7 +175,7 @@ async fn connector_s3() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "s3_writer", &connector_yaml).await?;
+    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
     let in_pipe = harness
         .get_pipe(IN)
         .expect("No pipe connectored to port IN");

--- a/src/connectors/tests/s3/writer.rs
+++ b/src/connectors/tests/s3/writer.rs
@@ -16,8 +16,8 @@ use std::io::Read;
 
 use super::super::{ConnectorHarness, TestPipeline};
 use super::{get_client, random_bucket_name, spawn_docker, wait_for_s3mock, EnvHelper, IMAGE, TAG};
-use crate::errors::Result;
 use crate::connectors::impls::s3;
+use crate::errors::Result;
 use aws_sdk_s3::Client;
 use bytes::Buf;
 use rand::{distributions::Alphanumeric, Rng};
@@ -45,7 +45,12 @@ async fn connector_s3_no_connection() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::writer::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
     Ok(())
 }
@@ -75,7 +80,12 @@ async fn connector_s3_no_credentials() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::writer::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -108,7 +118,12 @@ async fn connector_s3_no_region() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::writer::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -138,7 +153,12 @@ async fn connector_s3_no_bucket() -> Result<()> {
             "endpoint": endpoint
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::writer::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     assert!(harness.start().await.is_err());
 
     Ok(())
@@ -175,7 +195,12 @@ async fn connector_s3() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &s3::writer::Builder::default(), &connector_yaml).await?;
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &s3::writer::Builder::default(),
+        &connector_yaml,
+    )
+    .await?;
     let in_pipe = harness
         .get_pipe(IN)
         .expect("No pipe connectored to port IN");

--- a/src/connectors/tests/tcp/client.rs
+++ b/src/connectors/tests/tcp/client.rs
@@ -15,7 +15,10 @@
 use std::time::Duration;
 
 use crate::{
-    connectors::tests::{free_port, setup_for_tls, tcp::EchoServer, ConnectorHarness},
+    connectors::{
+        impls::tcp,
+        tests::{free_port, setup_for_tls, tcp::EchoServer, ConnectorHarness},
+    },
     errors::Result,
 };
 use tremor_common::ports::IN;
@@ -71,7 +74,8 @@ async fn tcp_client_test(use_tls: bool) -> Result<()> {
             "tls": tls_config
         }
     });
-    let connector = ConnectorHarness::new(function_name!(), "tcp_client", &config).await?;
+    let connector =
+        ConnectorHarness::new(function_name!(), &tcp::client::Builder::default(), &config).await?;
     let out = connector
         .out()
         .expect("No pipeline connected to tcp_client OUT port.");

--- a/src/connectors/tests/tcp/server.rs
+++ b/src/connectors/tests/tcp/server.rs
@@ -14,6 +14,7 @@
 
 use std::time::Duration;
 
+use crate::connectors::impls::tcp;
 use crate::connectors::tests::{free_port, ConnectorHarness};
 use crate::errors::Result;
 use async_std::{io::WriteExt, net::TcpStream, prelude::*};
@@ -38,7 +39,8 @@ async fn server_event_routing() -> Result<()> {
         "buf_size": 4096
       }
     });
-    let harness = ConnectorHarness::new(function_name!(), "tcp_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &tcp::server::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of tcp_server connector");

--- a/src/connectors/tests/unix_socket.rs
+++ b/src/connectors/tests/unix_socket.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::unix_socket, errors::Result};
 use async_std::os::unix::net::UnixStream;
 use async_std::prelude::*;
 use tremor_common::ports::IN;
@@ -50,16 +50,24 @@ async fn unix_socket() -> Result<()> {
       }
     });
 
-    let server_harness =
-        ConnectorHarness::new("unix_socket_server", "unix_socket_server", &server_defn).await?;
+    let server_harness = ConnectorHarness::new(
+        "unix_socket_server",
+        &unix_socket::server::Builder::default(),
+        &server_defn,
+    )
+    .await?;
     let server_out = server_harness
         .out()
         .expect("No pipeline connected to 'out' port of unix_socket_server connector");
     server_harness.start().await?;
     server_harness.wait_for_connected().await?;
 
-    let client_harness =
-        ConnectorHarness::new("unix_socket_client", "unix_socket_client", &client_defn).await?;
+    let client_harness = ConnectorHarness::new(
+        "unix_socket_client",
+        &unix_socket::client::Builder::default(),
+        &client_defn,
+    )
+    .await?;
     let client_out = client_harness
         .out()
         .expect("No pipeline connected to 'out' port of unix_socket_server connector");

--- a/src/connectors/tests/wal.rs
+++ b/src/connectors/tests/wal.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use super::ConnectorHarness;
-use crate::errors::Result;
+use crate::{connectors::impls::wal, errors::Result};
 use std::time::Duration;
 use tremor_common::{
     ids::{Id, SourceId},
@@ -34,7 +34,8 @@ async fn wal() -> Result<()> {
             "max_chunks": 100
         }
     });
-    let harness = ConnectorHarness::new(function_name!(), "wal", &config).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &wal::Builder::default(), &config).await?;
     harness.start().await?;
     harness.wait_for_connected().await?;
     harness.consume_initial_sink_contraflow().await?;
@@ -96,7 +97,8 @@ async fn wal() -> Result<()> {
     assert!(err.is_empty());
 
     // start harness again with same config, expect the second event to be re-emitted
-    let harness = ConnectorHarness::new(function_name!(), "wal", &config).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &wal::Builder::default(), &config).await?;
     harness.start().await?;
     harness.wait_for_connected().await?;
     harness.consume_initial_sink_contraflow().await?;

--- a/src/connectors/tests/ws.rs
+++ b/src/connectors/tests/ws.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::{free_port::find_free_tcp_port, setup_for_tls, ConnectorHarness};
+use crate::connectors::impls::ws;
 use crate::connectors::{impls::ws::WsDefaults, utils::url::Url};
 use crate::errors::{Error, Result, ResultExt};
 use async_std::{
@@ -271,7 +272,8 @@ async fn ws_client_bad_config() -> Result<()> {
       }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_client", &defn).await;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::client::Builder::default(), &defn).await;
     assert!(harness.is_err());
     Ok(())
 }
@@ -289,7 +291,8 @@ async fn ws_server_text_routing() -> Result<()> {
       }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::server::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of ws_server connector");
@@ -369,7 +372,8 @@ async fn ws_client_binary_routing() -> Result<()> {
       }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_client", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::client::Builder::default(), &defn).await?;
     harness.start().await?;
     harness.wait_for_connected().await?;
 
@@ -424,7 +428,8 @@ async fn ws_client_text_routing() -> Result<()> {
       }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_client", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::client::Builder::default(), &defn).await?;
 
     harness.start().await?;
     harness.wait_for_connected().await?;
@@ -487,7 +492,8 @@ async fn wss_server_text_routing() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::server::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of ws_server connector");
@@ -579,7 +585,8 @@ async fn wss_server_binary_routing() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), "ws_server", &defn).await?;
+    let harness =
+        ConnectorHarness::new(function_name!(), &ws::server::Builder::default(), &defn).await?;
     let out_pipeline = harness
         .out()
         .expect("No pipeline connected to 'out' port of ws_server connector");

--- a/src/system/flow_supervisor.rs
+++ b/src/system/flow_supervisor.rs
@@ -71,7 +71,7 @@ impl FlowSupervisor {
         }
     }
 
-    fn handle_register_connecor_type(
+    fn handle_register_connector_type(
         &mut self,
         connector_type: ConnectorType,
         builder: Box<dyn ConnectorBuilder>,
@@ -195,7 +195,7 @@ impl FlowSupervisor {
                         connector_type,
                         builder,
                         ..
-                    } => self.handle_register_connecor_type(connector_type, builder),
+                    } => self.handle_register_connector_type(connector_type, builder),
                     Msg::StartDeploy { flow, sender } => {
                         self.handle_start_deploy(*flow, sender).await;
                     }


### PR DESCRIPTION
# Pull request

## Description

The bench connector actually wasn't stopping when `stop_after_secs` wasn't configured, only `iters`.
Adapted it to stop after the expected number of events in that case.
Also added tests and switched it to not terminate the process directly, but to stop the world.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

Didn't test yet.

