### PR TITLE
Raw payload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## Unreleased
+
 ### Fixes
 
 - Properly terminate after `tremor run ...`
 - Fix the `bench` connector to actually stop after the given amount of events when `iters` is configured.
+
+### New features
+
+- Support `elastic.raw_payload` for `update`
 
 ## [0.12.0-rc.6]
 

--- a/src/connectors/impls/elastic.rs
+++ b/src/connectors/impls/elastic.rs
@@ -564,10 +564,13 @@ impl<'a, 'value> ESMeta<'a, 'value> {
                 let mut op = self
                     .get_id()
                     .map(|id| {
-                        BulkOperation::update(
-                            id,
-                            literal!({ "doc": data.clone_static() }), // TODO: find a way to not .clone_static()
-                        )
+                        // TODO: find a way to not .clone_static()
+                        let src = if self.get_raw_payload() {
+                            data.clone_static()
+                        } else {
+                            literal!({ "doc": data.clone_static() })
+                        };
+                        BulkOperation::update(id, src)
                     })
                     .ok_or_else(|| Error::from(Self::MISSING_ID))?;
                 if let Some(index) = self.get_index() {
@@ -634,6 +637,10 @@ impl<'a, 'value> ESMeta<'a, 'value> {
 
     fn get_action(&self) -> Option<&str> {
         self.meta.get_str("action")
+    }
+
+    fn get_raw_payload(&self) -> bool {
+        self.meta.get_bool("raw_payload").unwrap_or_default()
     }
 
     /// supported values: `true`, `false`, `"wait_for"`

--- a/src/connectors/tests/elastic.rs
+++ b/src/connectors/tests/elastic.rs
@@ -155,6 +155,71 @@ async fn connector_elastic() -> Result<()> {
         event.data.suffix().value()
     );
 
+    // upsert
+
+    let data = literal!({
+        "doc": {
+            "field1": 13.4,
+            "field2": "strong",
+            "field3": [false, true],
+            "field4": {
+                "nested": false
+            }
+        },
+        "doc_as_upsert": true,
+    });
+    let meta = literal!({
+        "elastic": {
+            "_index": "my_index",
+            "_id": "1234",
+            "action": "update",
+            "raw_payload": true
+        },
+    });
+    let event_not_batched = Event {
+        id: EventId::default(),
+        data: (data, meta).into(),
+        transactional: false,
+        ..Event::default()
+    };
+    harness.send_to_sink(event_not_batched, IN).await?;
+    let err_events = err.get_events()?;
+    assert!(err_events.is_empty(), "Received err msgs: {:?}", err_events);
+    let event = out.get_event().await?;
+    assert_eq!(
+        &literal!({
+            "elastic": {
+                "_id": "1234",
+                "_index": "my_index",
+                "_type": "_doc",
+                "version": 1,
+                "action": "update",
+                "success": true
+            },
+        }),
+        event.data.suffix().meta()
+    );
+    assert_eq!(
+        &literal!({
+            "update": {
+                "_primary_term": 1,
+                "_shards": {
+                    "total": 2,
+                    "successful": 1,
+                    "failed": 0,
+                },
+                "_type": "_doc",
+                "_index": "my_index",
+                "result": "created",
+                "_id": "1234",
+                "_seq_no": 1,
+                "status": 201,
+                "_version": 1
+            }
+        }),
+        event.data.suffix().value()
+    );
+
     let batched_data = literal!([{
             "data": {
                 "value": {
@@ -244,7 +309,7 @@ async fn connector_elastic() -> Result<()> {
                 "_type": "_doc",
                 "_index": "my_index",
                 "result": "created",
-                "_seq_no": 1,
+                "_seq_no": 2,
                 "status": 201,
                 "_version": 1
             }


### PR DESCRIPTION
# Pull request

## Description

This adds `elastic.raw_payload` to the elastic connector. For `update` actions this will not wrap the body into `{"doc": ...}` but instead let the user provide the whole raw body with any additional items they desire.

## Related

* Related Issues: fixes #1652 

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

The added overhead is one `if` which will not impact performance on an elastic search endpoint