### PR TITLE
Allow 0.1% coverage drop to handle property based tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status: # see https://docs.codecov.com/docs/commit-status
+    project:
+      default:
+        # basic
+        threshold: 0.1%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
# Pull request

## Description


The property based tests can be mean and stop covering a line they covered before randomly, this means we have some variation coverage. This PR should allow for that to make everyone's life easier, so I hope.

## Related

* every dependabot pr ever
* Related Issues: I got so many issues

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no code change