### PR TITLE
Move exit connector into debug connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix a one-off error in the `bench` connector leading to it producing one event too much
 - Avoid acking events that failed while preprocessing or decoding using a codec.
 - Remove acknowledging events when dropped or sent to a dead end (e.g. unconnected port) as this was causing confusing and unwanted behaviour with error events
+- move EXIT connector to debug connectors to avoid shutting down tremor
 
 ### New features
 
@@ -441,6 +442,9 @@
 - Allow using err for errors in tremor run [#592](https://github.com/tremor-rs/tremor-runtime/pull/592)
 - Update to rust toolchain 1.48
 
+[0.12.0-rc.7]: https://github.com/tremor-rs/tremor-runtime/compare/v0.12.0-rc.6...v0.12.0-rc.7
+[0.12.0-rc.6]: https://github.com/tremor-rs/tremor-runtime/compare/v0.12.0-rc.5...v0.12.0-rc.6
+[0.12.0-rc.2 - 0.12.0-rc.5]: https://github.com/tremor-rs/tremor-runtime/compare/v0.12.0-rc.1...v0.12.0-rc.5
 [0.12.0-rc.1]: https://github.com/tremor-rs/tremor-runtime/compare/v0.11.12...v0.12.0-rc.1
 [0.11.12]: https://github.com/tremor-rs/tremor-runtime/compare/v0.11.10...v0.11.12
 [0.11.10]:https://github.com/tremor-rs/tremor-runtime/compare/v0.11.9...v0.11.10
@@ -460,4 +464,3 @@
 [0.9.4]:https://github.com/tremor-rs/tremor-runtime/compare/v0.9.3...v0.9.4
 [0.9.3]:https://github.com/tremor-rs/tremor-runtime/compare/v0.9.2...v0.9.3
 [0.9.2]:https://github.com/tremor-rs/tremor-runtime/compare/v0.9.1...v0.9.2
-

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -1203,9 +1203,8 @@ pub(crate) async fn register_builtin_connector_types(world: &World, debug: bool)
         for builder in debug_connector_types(world) {
             world.register_builtin_connector_type(builder).await?;
         }
-        world
-            .register_builtin_connector_type(Box::new(impls::exit::Builder::new(world)))
-            .await?;
+        let builder = Box::new(impls::exit::Builder::new(world));
+        world.register_builtin_connector_type(builder).await?;
     }
 
     Ok(())

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -1203,10 +1203,10 @@ pub(crate) async fn register_builtin_connector_types(world: &World, debug: bool)
         for builder in debug_connector_types(world) {
             world.register_builtin_connector_type(builder).await?;
         }
+        world
+            .register_builtin_connector_type(Box::new(impls::exit::Builder::new(world)))
+            .await?;
     }
-    world
-        .register_builtin_connector_type(Box::new(impls::exit::Builder::new(world)))
-        .await?;
 
     Ok(())
 }

--- a/tests/flows.rs
+++ b/tests/flows.rs
@@ -49,7 +49,11 @@ macro_rules! test_cases {
                     file.read_to_string(&mut contents)?;
                     match parse(&contents) {
                         Ok(deployable) => {
-                            let (world, h) = World::start(WorldConfig::default()).await?;
+                            let config = WorldConfig{
+                                debug_connectors: true,
+                                ..WorldConfig::default()
+                            };
+                            let (world, h) = World::start(config).await?;
                             for flow in deployable.iter_flows() {
                                 world.start_flow(flow).await?;
                             }

--- a/tremor-cli/tests/integration/udp-postprocessors/before.yaml
+++ b/tremor-cli/tests/integration/udp-postprocessors/before.yaml
@@ -6,6 +6,7 @@
       "run",
       "-p",
       "../before.pid",
+      "--debug-connectors",
       "-n",
       "./config.troy"
     ],

--- a/tremor-cli/tests/integration/ws/before.yaml
+++ b/tremor-cli/tests/integration/ws/before.yaml
@@ -6,6 +6,7 @@
       "run",
       "-p",
       "../before.pid",
+      "--debug-connectors",
       "-n",
       "config.troy"
     ],


### PR DESCRIPTION
# Pull request

## Description

Move the `exit` connector behind `debug-connectors` as it is one of the potentially destructive connectors

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no impact