### PR TITLE
Remove ack-on-drop and ack-on-dead-end.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix detection of `*.troy` files in entrypoint.sh causing duplicate configs to be loaded when using Kubernetes.
 - Fix a one-off error in the `bench` connector leading to it producing one event too much
+- Avoid acking events that failed while preprocessing or decoding using a codec.
+- Remove acknowledging events when dropped or sent to a dead end (e.g. unconnected port) as this was causing confusing and unwanted behaviour with error events
 
 ### New features
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -26,14 +26,14 @@ use beef::Cow;
 use std::{fmt, sync::atomic::Ordering, time::Duration};
 use tremor_common::{ids::OperatorIdGen, time::nanotime};
 use tremor_pipeline::{
-    errors::ErrorKind as PipelineErrorKind, CbAction, Event, ExecutableGraph, GraphReturns,
-    SignalKind,
+    errors::ErrorKind as PipelineErrorKind, CbAction, Event, ExecutableGraph, SignalKind,
 };
 use tremor_script::{ast::DeployEndpoint, highlighter::Dumb, prelude::BaseExpr};
 
 const TICK_MS: u64 = 100;
 type Inputs = halfbrown::HashMap<DeployEndpoint, (bool, InputTarget)>;
 type Dests = halfbrown::HashMap<Cow<'static, str>, Vec<(DeployEndpoint, OutputTarget)>>;
+type EventSet = Vec<(Cow<'static, str>, Event)>;
 /// Address for a pipeline
 #[derive(Clone)]
 pub struct Addr {
@@ -337,13 +337,8 @@ impl OutputTarget {
 }
 
 #[inline]
-async fn send_events(
-    eventset: &mut GraphReturns,
-    dests: &mut Dests,
-    pipeline: &mut ExecutableGraph,
-    inputs: &Inputs,
-) -> Result<()> {
-    for (output, event) in eventset.output.drain(..) {
+async fn send_events(eventset: &mut EventSet, dests: &mut Dests) -> Result<()> {
+    for (output, event) in eventset.drain(..) {
         if let Some(destinations) = dests.get_mut(&output) {
             if let Some((last, rest)) = destinations.split_last_mut() {
                 for (id, dest) in rest {
@@ -352,20 +347,8 @@ async fn send_events(
                 }
                 let last_port = last.0.port().to_string().into();
                 last.1.send_event(last_port, event).await?;
-            } else if event.transactional {
-                // We send to a non connected output port, so we acknowledge the event
-                // TODO: some kind of linter here so we don't create silent errors?
-                handle_cf_msg(CfMsg::Insight(event.insight_ack()), pipeline, inputs).await?;
             }
-        } else if event.transactional {
-            // We send to a non connected output port, so we acknowledge the event
-            // TODO: some kind of linter here so we don't create silent errors?
-            handle_cf_msg(CfMsg::Insight(event.insight_ack()), pipeline, inputs).await?;
-        };
-    }
-    // Events dropped or send to a dead end
-    for event in eventset.dead_ends.drain(..) {
-        handle_cf_msg(CfMsg::Insight(event.insight_ack()), pipeline, inputs).await?;
+        }
     }
     Ok(())
 }
@@ -470,7 +453,7 @@ pub(crate) async fn pipeline_task(
 
     let mut dests: Dests = halfbrown::HashMap::new();
     let mut inputs: Inputs = halfbrown::HashMap::new();
-    let mut eventset = GraphReturns::default();
+    let mut eventset = Vec::new();
 
     let mut state: State = State::Initializing;
 
@@ -491,9 +474,7 @@ pub(crate) async fn pipeline_task(
                 match pipeline.enqueue(&input, event, &mut eventset).await {
                     Ok(()) => {
                         handle_insights(&mut pipeline, &inputs).await;
-                        maybe_send(
-                            send_events(&mut eventset, &mut dests, &mut pipeline, &inputs).await,
-                        );
+                        maybe_send(send_events(&mut eventset, &mut dests).await);
                     }
                     Err(e) => {
                         let err_str = if let PipelineErrorKind::Script(script_kind) = e.0 {
@@ -520,9 +501,7 @@ pub(crate) async fn pipeline_task(
                 } else {
                     maybe_send(send_signal(&alias, signal, &mut dests).await);
                     handle_insights(&mut pipeline, &inputs).await;
-                    maybe_send(
-                        send_events(&mut eventset, &mut dests, &mut pipeline, &inputs).await,
-                    );
+                    maybe_send(send_events(&mut eventset, &mut dests).await);
                 }
             }
             AnyMsg::Mgmt(MgmtMsg::ConnectInput {

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -16,7 +16,7 @@ use std::io::prelude::*;
 use tremor_common::{file, ids::OperatorIdGen};
 use tremor_pipeline::query::Query;
 use tremor_pipeline::ExecutableGraph;
-use tremor_pipeline::{Event, EventId, GraphReturns};
+use tremor_pipeline::{Event, EventId};
 use tremor_script::FN_REGISTRY;
 
 use serial_test::serial;
@@ -67,9 +67,9 @@ macro_rules! test_cases {
                         ingest_ns: id as u64,
                         ..Event::default()
                     };
-                    let mut r = GraphReturns::default();
+                    let mut r = vec![];
                     pipeline.enqueue("in", event, &mut r).await?;
-                    results.append(&mut r.output);
+                    results.append(&mut r);
                 }
                 assert_eq!(results.len(), out_json.len(), "Number of events differ error");
                 for (_, result) in results {

--- a/tests/query_runtime_error.rs
+++ b/tests/query_runtime_error.rs
@@ -18,7 +18,7 @@ use tremor_common::{file, ids::OperatorIdGen};
 
 use tremor_pipeline::query::Query;
 use tremor_pipeline::ExecutableGraph;
-use tremor_pipeline::{Event, EventId, GraphReturns};
+use tremor_pipeline::{Event, EventId};
 use tremor_script::FN_REGISTRY;
 
 use serial_test::serial;
@@ -85,7 +85,7 @@ macro_rules! test_cases {
                         ingest_ns: id as u64,
                         ..Event::default()
                     };
-                    let mut r = GraphReturns::default();
+                    let mut r = vec![];
                     // run the pipeline, if an error occurs, dont stop but check for equivalence with `error.txt`
                     match pipeline.enqueue("in", event, &mut r).await {
                         Err(PipelineError(PipelineErrorKind::Script(e), o)) => {
@@ -105,7 +105,7 @@ macro_rules! test_cases {
                         }
                         Ok(()) => {}
                     }
-                    results.append(&mut r.output);
+                    results.append(&mut r);
                 }
                 assert_eq!(results.len(), out_json.len(), "Number of events differ error");
                 for (_, result) in results {

--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -19,7 +19,7 @@ use crate::util::{get_source_kind, highlight, slurp_string, SourceKind};
 use std::io::prelude::*;
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use tremor_common::{file, ids::OperatorIdGen, time::nanotime};
-use tremor_pipeline::{Event, EventId, GraphReturns};
+use tremor_pipeline::{Event, EventId};
 use tremor_runtime::{
     codec::Codec,
     config,
@@ -350,7 +350,7 @@ impl Run {
             &move |runnable, id, egress, _state, at, event| {
                 let value = EventPayload::new(vec![], |_| ValueAndMeta::from(event.clone_static()));
 
-                let mut continuation = GraphReturns::default();
+                let mut continuation = vec![];
 
                 if let Err(e) = async_std::task::block_on(runnable.enqueue(
                     "in",
@@ -398,7 +398,7 @@ impl Run {
                 }
                 *id += 1;
 
-                for (port, rvalue) in continuation.output.drain(..) {
+                for (port, rvalue) in continuation.drain(..) {
                     egress.process(
                         &simd_json::to_string_pretty(&value.suffix().value())?,
                         &event,

--- a/tremor-cli/tests/integration/cb-drop-dead-ends/assert.yaml
+++ b/tremor-cli/tests/integration/cb-drop-dead-ends/assert.yaml
@@ -3,7 +3,9 @@ name: cb-drop-dead-ends
 asserts:
   - source: fg.err.log
     contains:
-      - All required CB events received.
+      - "Expected CB events up to id 6."
+      - "Got acks: [6]"
+      - "Got fails: []"
   - source: fg.out.log
     contains:
       - passthrough

--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod op;
 /// Tools to turn tremor query into pipelines
 pub mod query;
 pub use crate::event::{Event, ValueIter, ValueMetaIter};
-pub use crate::executable_graph::{ExecutableGraph, OperatorNode, Returns as GraphReturns};
+pub use crate::executable_graph::{ExecutableGraph, OperatorNode};
 pub(crate) use crate::executable_graph::{NodeMetrics, State};
 pub use op::{ConfigImpl, InitializableOperator, Operator};
 pub use tremor_script::prelude::EventOriginUri;

--- a/tremor-pipeline/src/op/trickle/script.rs
+++ b/tremor-pipeline/src/op/trickle/script.rs
@@ -62,18 +62,6 @@ impl Operator for Script {
             }
         });
 
-        Ok(if let Some(port) = port {
-            EventAndInsights {
-                events: vec![(port, event)],
-                ..EventAndInsights::default()
-            }
-        } else if event.transactional {
-            EventAndInsights {
-                insights: vec![event.insight_ack()],
-                ..EventAndInsights::default()
-            }
-        } else {
-            EventAndInsights::default()
-        })
+        Ok(port.map_or_else(EventAndInsights::default, |port| vec![(port, event)].into()))
     }
 }


### PR DESCRIPTION
Those behaviours were producing edge cases where error events (from source connectors) were acked, though not handled and thus acked the original failed event.

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
The performance should be back to where it was before, before we introduced `ack-on-drop` etc.

