### PR TITLE
Remove coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Quality Checks]][actions-checks]
 [![License Checks]][actions-license-audit]
 [![Security Checks]][actions-security-audit]
-[![Coverage]][coveralls.io]
 [![codecov]][codecov report]
 [![Dependabot Status]][dependabot status]
 [![CII Best Practices]][bestpractices]
@@ -27,8 +26,6 @@
 [License Checks]: https://github.com/tremor-rs/tremor-runtime/workflows/License%20audit/badge.svg
 [actions-security-audit]: https://github.com/tremor-rs/tremor-runtime/actions?query=workflow%3A%22Security+audit%22
 [Security Checks]: https://github.com/tremor-rs/tremor-runtime/workflows/Security%20audit/badge.svg
-[coverage]: https://coveralls.io/repos/github/tremor-rs/tremor-runtime/badge.svg?branch=main
-[coveralls.io]: https://coveralls.io/github/tremor-rs/tremor-runtime?branch=main
 [dependabot status]: https://flat.badgen.net/github/dependabot/tremor-rs/tremor-runtime
 [cii best practices]: https://bestpractices.coreinfrastructure.org/projects/4356/badge
 [bestpractices]: https://bestpractices.coreinfrastructure.org/projects/4356


### PR DESCRIPTION
# Pull request

## Description

We moved to codecov, coveralls is no longer reflecting the reality of our coverage.

## Related


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no impact