### PR TITLE
Fix grok extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Avoid acking events that failed while preprocessing or decoding using a codec.
 - Remove acknowledging events when dropped or sent to a dead end (e.g. unconnected port) as this was causing confusing and unwanted behaviour with error events
 - move EXIT connector to debug connectors to avoid shutting down tremor
+- Fix bug in grok extractor that would never return good matches
 
 ### New features
 


### PR DESCRIPTION
# Pull request

## Description

The implementation for `Clone` for the Grok extractor was buggy leading to it loosing all functionality unless the pattern was a full regular expression. This fixes it.


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
