### PR TITLE
No more sed

### DIFF
--- a/.github/scripts/Bump.sh
+++ b/.github/scripts/Bump.sh
@@ -18,31 +18,3 @@ echo "."
 echo "Updating CHANGELOG.md"
 sed -e "s/^## Unreleased$/## [${new}]/" -i.release "CHANGELOG.md"
 
-echo "Updating tremor dependencies in tremor-script"
-cd tremor-script
-sed -e "s/^tremor-common = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-influx = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-value = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-cd ..
-cd tremor-api
-echo "Updating tremor dependencies in tremor-api"
-sed -e "s/^tremor-runtime = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-common = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-value = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-script = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-pipeline = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-cd ..
-cd tremor-cli
-echo "Updating tremor dependencies in tremor-cli"
-sed -e "s/^tremor-runtime = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-common = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-value = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-script = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-pipeline = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-api = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-cd ..
-cd tremor-pipeline
-echo "Updating tremor dependencies in tremor-pipeline"
-sed -e "s/^tremor-common = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-value = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"
-sed -e "s/^tremor-script = { version = \"${old}\"/tremor-common = { version = \"${new}\"/" -i.release "Cargo.toml"


### PR DESCRIPTION
Signed-off-by: PrimalPimmy <Prashant20.pm@gmail.com>

# Pull request

## Description
Sed is no more (well, for the 99% of the part atleast) :rock: 
<!-- please add a description of what the goal of this pull request is -->


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


