### PR TITLE
Move logger config to top level

### DIFF
--- a/tremor-cli/src/cli.rs
+++ b/tremor-cli/src/cli.rs
@@ -20,6 +20,9 @@ pub(crate) struct Cli {
     /// Instance identifier
     #[clap(short, long, default_value = "tremor")]
     pub(crate) instance: String,
+    /// Configuration for Log4RS
+    #[clap(short, long)]
+    pub(crate) logger_config: Option<String>,
     #[clap(subcommand)]
     pub(crate) command: Command,
 }
@@ -243,9 +246,6 @@ pub(crate) struct ServerRun {
     /// The `host:port` to listen for the API
     #[clap(short, long, default_value = "0.0.0.0:9898")]
     pub(crate) api_host: String,
-    /// Configuration for Log4RS
-    #[clap(short, long)]
-    pub(crate) logger_config: Option<String>,
     /// function tail-recursion stack depth limit
     #[clap(short, long, default_value = "1024")]
     pub(crate) recursion_limit: u32,

--- a/tremor-cli/src/main.rs
+++ b/tremor-cli/src/main.rs
@@ -110,8 +110,8 @@ async fn main() -> Result<()> {
 async fn run(cli: Cli) -> Result<()> {
     // Logging
     if let Some(logger_config) = &cli.logger_config {
-        log4rs::init_file(logger_config, Default::default())
-            .with_context(|| format!("Error loading logger-config from '{}'", logger_config))?
+        log4rs::init_file(logger_config, log4rs::config::Deserializers::default())
+            .with_context(|| format!("Error loading logger-config from '{}'", logger_config))?;
     } else {
         env_logger::init();
     }

--- a/tremor-cli/src/main.rs
+++ b/tremor-cli/src/main.rs
@@ -30,6 +30,7 @@ extern crate serde_derive;
 extern crate log;
 
 use crate::errors::Result;
+use anyhow::Context;
 use clap::Parser;
 use cli::{Cli, Command};
 use std::fs::{self, File};
@@ -107,6 +108,14 @@ async fn main() -> Result<()> {
 }
 
 async fn run(cli: Cli) -> Result<()> {
+    // Logging
+    if let Some(logger_config) = &cli.logger_config {
+        log4rs::init_file(logger_config, Default::default())
+            .with_context(|| format!("Error loading logger-config from '{}'", logger_config))?
+    } else {
+        env_logger::init();
+    }
+
     match cli.command {
         Command::Completions { shell } => completions::run_cmd(shell),
         Command::Server { command } => {

--- a/tremor-cli/src/run.rs
+++ b/tremor-cli/src/run.rs
@@ -419,8 +419,6 @@ impl Run {
     }
 
     async fn run_troy_source(&self) -> Result<()> {
-        env_logger::init();
-
         let config = WorldConfig {
             debug_connectors: true,
             ..WorldConfig::default()

--- a/tremor-cli/src/server.rs
+++ b/tremor-cli/src/server.rs
@@ -17,7 +17,6 @@ use crate::{
     cli::{ServerCommand, ServerRun},
     errors::{Error, ErrorKind, Result},
 };
-use anyhow::Context;
 use async_std::stream::StreamExt;
 use futures::future;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
@@ -75,19 +74,6 @@ impl ServerRun {
 
         let mut result = 0;
 
-        // Logging
-        if let Some(logger_config) = &self.logger_config {
-            if let Err(e) =
-                log4rs::init_file(logger_config, log4rs::config::Deserializers::default())
-                    .with_context(|| {
-                        format!("Error loading logger-config from '{}'", logger_config)
-                    })
-            {
-                return Err(e.into());
-            }
-        } else {
-            env_logger::init();
-        }
         version::log();
         eprintln!("allocator: {}", crate::alloc::get_allocator_name());
 

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -251,8 +251,6 @@ impl TestConfig {
 impl Test {
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn run(&self) -> Result<()> {
-        env_logger::init();
-
         let base_directory = tremor_common::file::canonicalize(&self.path)?;
         let mut config = TestConfig {
             verbose: self.verbose,

--- a/tremor-cli/tests/integration/ws/before.yaml
+++ b/tremor-cli/tests/integration/ws/before.yaml
@@ -2,6 +2,8 @@
     "dir": "./before",
     "cmd": "tremor",
     "args": [
+      "-l",
+      "logger.yaml",
       "server",
       "run",
       "-p",

--- a/tremor-cli/tests/integration/ws/before/logger.yaml
+++ b/tremor-cli/tests/integration/ws/before/logger.yaml
@@ -1,0 +1,24 @@
+# Scan this file for changes every 30 seconds
+refresh_rate: 30 seconds
+
+appenders:
+  # An appender named "stdout" that writes to stdout
+  stdout:
+    kind: console
+
+root:
+  level: warn
+  appenders:
+    - stdout
+
+loggers:
+  tremor_runtime:
+    level: debug
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: debug
+    appenders:
+      - stdout
+    additive: false


### PR DESCRIPTION
# Pull request

## Description

This moves the `--logger-config` to the top-level CLI so it's shared between all subcommands

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

no change

