### PR TITLE
Fix issue with discord encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixes
 
 - Fix misbehaving stdio connector when stdio is a pipe
-- fix Docker entrypoint script argument ordering
+- Fix Docker entrypoint script argument ordering
+- Fix id encoding for discord connector
 
 ## [0.12.0]
 

--- a/tremor-cli/tests/bench/passthrough/config.troy
+++ b/tremor-cli/tests/bench/passthrough/config.troy
@@ -1,7 +1,7 @@
 define flow main
 flow
   use tremor::pipelines;
-    use bench;
+  use bench;
   create connector bench from bench::bench
   with
     codec = "binary",


### PR DESCRIPTION
# Pull request

## Description

Fix issue with id encoding in the discord connector. ids were encoded as snowflake-strings but expected to be decoded as u64.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance


