### PR TITLE
Circuit breaker renaming

### DIFF
--- a/src/connectors/impls/cb.rs
+++ b/src/connectors/impls/cb.rs
@@ -155,11 +155,11 @@ impl Sink for CbSink {
                 let cb = if cb_cmds.contains(&"close".to_string())
                     || cb_cmds.contains(&"trigger".to_string())
                 {
-                    CbAction::Close
+                    CbAction::Trigger
                 } else if cb_cmds.contains(&"open".to_string())
                     || cb_cmds.contains(&"restore".to_string())
                 {
-                    CbAction::Open
+                    CbAction::Restore
                 } else {
                     CbAction::None
                 };

--- a/src/connectors/impls/metrics.rs
+++ b/src/connectors/impls/metrics.rs
@@ -209,7 +209,7 @@ impl Sink for MetricsSink {
                 // channel is closed
                 SinkReply {
                     ack: SinkAck::Fail,
-                    cb: CbAction::Close,
+                    cb: CbAction::Trigger,
                 }
             }
             Err(TrySendError::Full(_)) => SinkReply::FAIL,

--- a/src/connectors/sink/channel_sink.rs
+++ b/src/connectors/sink/channel_sink.rs
@@ -375,7 +375,7 @@ where
             // no streams available :sob:
             return Ok(SinkReply {
                 ack: SinkAck::Fail,
-                cb: CbAction::Close,
+                cb: CbAction::Trigger,
             });
         }
 

--- a/src/connectors/source.rs
+++ b/src/connectors/source.rs
@@ -776,7 +776,7 @@ where
                 }
                 Control::Continue
             }
-            CbAction::Close => {
+            CbAction::Trigger => {
                 // TODO: execute pause strategy chosen by source / connector / configured by user
                 info!("{ctx} Circuit Breaker: Close.");
                 let res = self.source.on_cb_close(ctx).await;
@@ -784,7 +784,7 @@ where
                 self.state = SourceState::Paused;
                 Control::Continue
             }
-            CbAction::Open => {
+            CbAction::Restore => {
                 info!("{ctx} Circuit Breaker: Open.");
                 self.cb_open_received += 1;
                 ctx.swallow_err(self.source.on_cb_open(ctx).await, "on_cb_open failed");

--- a/src/connectors/tests/elastic.rs
+++ b/src/connectors/tests/elastic.rs
@@ -32,7 +32,7 @@ use tremor_pipeline::{CbAction, Event, EventId};
 use tremor_value::{literal, value::StaticValue};
 use value_trait::{Mutable, Value, ValueAccess};
 
-const ELASTICSEARCH_VERSION: &str = "7.17.3";
+const ELASTICSEARCH_VERSION: &str = "7.17.4";
 
 #[async_std::test]
 #[serial(elastic)]

--- a/src/connectors/tests/mod.rs
+++ b/src/connectors/tests/mod.rs
@@ -166,7 +166,7 @@ impl ConnectorHarness {
 
         // send a CBAction::open to the connector, so it starts pulling data
         self.addr
-            .send_source(SourceMsg::Cb(CbAction::Open, EventId::default()))
+            .send_source(SourceMsg::Cb(CbAction::Restore, EventId::default()))
             .await?;
 
         Ok(())
@@ -233,7 +233,7 @@ impl ConnectorHarness {
                 in_pipe.get_contraflow().await?,
             ] {
                 assert!(
-                    matches!(cf.cb, CbAction::SinkStart(_) | CbAction::Open),
+                    matches!(cf.cb, CbAction::SinkStart(_) | CbAction::Restore),
                     "Expected SinkStart or Open Contraflow message, got: {cf:?}"
                 );
             }

--- a/src/connectors/tests/tcp/client.rs
+++ b/src/connectors/tests/tcp/client.rs
@@ -137,7 +137,7 @@ async fn tcp_client_test(use_tls: bool) -> Result<()> {
 
     // as the connection is closed we expect a CB close some time after the fail
     let cf = in_pipe.get_contraflow().await?;
-    assert_eq!(CbAction::Close, cf.cb);
+    assert_eq!(CbAction::Trigger, cf.cb);
 
     let (out, err) = connector.stop().await?;
     assert!(out.is_empty());

--- a/tremor-cli/tests/integration/elastic-empty/before.yaml
+++ b/tremor-cli/tests/integration/elastic-empty/before.yaml
@@ -11,7 +11,7 @@
         "discovery.type=single-node",
         "-e",
         "action.auto_create_index=true",
-        "elasticsearch:7.14.2"
+        "elasticsearch:7.17.4"
     ],
     "await": {
         "http-ok": [

--- a/tremor-cli/tests/integration/elastic-verify-gd/before.yaml
+++ b/tremor-cli/tests/integration/elastic-verify-gd/before.yaml
@@ -11,7 +11,7 @@
         "discovery.type=single-node",
         "-e",
         "action.auto_create_index=true",
-        "elasticsearch:7.14.2"
+        "elasticsearch:7.17.4"
     ],
     "await": {
         "http-ok": [

--- a/tremor-cli/tests/integration/elastic/before.yaml
+++ b/tremor-cli/tests/integration/elastic/before.yaml
@@ -11,7 +11,7 @@
         "discovery.type=single-node",
         "-e",
         "action.auto_create_index=true",
-        "elasticsearch:7.14.2"
+        "elasticsearch:7.17.4"
     ],
     "await": {
         "http-ok": [

--- a/tremor-pipeline/src/event.rs
+++ b/tremor-pipeline/src/event.rs
@@ -152,7 +152,7 @@ impl Event {
     pub fn cb_restore(ingest_ns: u64) -> Self {
         Event {
             ingest_ns,
-            cb: CbAction::Open,
+            cb: CbAction::Restore,
             ..Event::default()
         }
     }
@@ -167,7 +167,7 @@ impl Event {
         Self {
             ingest_ns,
             op_meta,
-            cb: CbAction::Open,
+            cb: CbAction::Restore,
             ..Event::default()
         }
     }
@@ -182,7 +182,7 @@ impl Event {
         Self {
             ingest_ns,
             op_meta,
-            cb: CbAction::Close,
+            cb: CbAction::Trigger,
             ..Event::default()
         }
     }
@@ -192,7 +192,7 @@ impl Event {
     pub fn cb_trigger(ingest_ns: u64) -> Self {
         Event {
             ingest_ns,
-            cb: CbAction::Close,
+            cb: CbAction::Trigger,
             ..Event::default()
         }
     }
@@ -631,13 +631,13 @@ mod test {
     fn gd() {
         let mut e = Event::default();
 
-        assert_eq!(Event::restore_or_break(true, 0).cb, CbAction::Open);
-        assert_eq!(Event::cb_restore(0).cb, CbAction::Open);
-        assert_eq!(e.insight_restore().cb, CbAction::Open);
+        assert_eq!(Event::restore_or_break(true, 0).cb, CbAction::Restore);
+        assert_eq!(Event::cb_restore(0).cb, CbAction::Restore);
+        assert_eq!(e.insight_restore().cb, CbAction::Restore);
 
-        assert_eq!(Event::restore_or_break(false, 0).cb, CbAction::Close);
-        assert_eq!(Event::cb_trigger(0).cb, CbAction::Close);
-        assert_eq!(e.insight_trigger().cb, CbAction::Close);
+        assert_eq!(Event::restore_or_break(false, 0).cb, CbAction::Trigger);
+        assert_eq!(Event::cb_trigger(0).cb, CbAction::Trigger);
+        assert_eq!(e.insight_trigger().cb, CbAction::Trigger);
     }
 
     #[test]

--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -271,9 +271,9 @@ pub enum CbAction {
     /// Nothing of note
     None,
     /// The circuit breaker is triggerd and should break
-    Close,
+    Trigger,
     /// The circuit breaker is restored and should work again
-    Open,
+    Restore,
     // TODO: add stream based CbAction variants once their use manifests
     /// Acknowledge delivery of messages up to a given ID.
     /// All messages prior to and including  this will be considered delivered.
@@ -312,7 +312,7 @@ impl CbAction {
     /// This is a Circuit Breaker related message
     #[must_use]
     pub fn is_cb(self) -> bool {
-        matches!(self, CbAction::Close | CbAction::Open)
+        matches!(self, CbAction::Trigger | CbAction::Restore)
     }
     /// This is a Guaranteed Delivery related message
     #[must_use]
@@ -954,8 +954,8 @@ mod test {
         assert_eq!(CbAction::Fail.is_gd(), true);
         assert_eq!(CbAction::Ack.is_gd(), true);
 
-        assert_eq!(CbAction::Open.is_gd(), false);
-        assert_eq!(CbAction::Close.is_gd(), false);
+        assert_eq!(CbAction::Restore.is_gd(), false);
+        assert_eq!(CbAction::Trigger.is_gd(), false);
     }
 
     #[test]
@@ -965,8 +965,8 @@ mod test {
         assert_eq!(CbAction::Fail.is_cb(), false);
         assert_eq!(CbAction::Ack.is_cb(), false);
 
-        assert_eq!(CbAction::Open.is_cb(), true);
-        assert_eq!(CbAction::Close.is_cb(), true);
+        assert_eq!(CbAction::Restore.is_cb(), true);
+        assert_eq!(CbAction::Trigger.is_cb(), true);
     }
 
     #[test]

--- a/tremor-pipeline/src/op/debug/history.rs
+++ b/tremor-pipeline/src/op/debug/history.rs
@@ -32,7 +32,6 @@ if let Some(map) = &node.config {
     let config: Config = Config::new(map)?;
     Ok(Box::new(History {
         config,
-        id: node.id.clone(),
     }))
 } else {
     Err(ErrorKind::MissingOpConfig(node.id.clone()).into())
@@ -40,9 +39,8 @@ if let Some(map) = &node.config {
 }});
 
 #[derive(Debug, Clone)]
-pub struct History {
-    pub config: Config,
-    pub id: String,
+struct History {
+    config: Config,
 }
 
 impl Operator for History {
@@ -140,7 +138,6 @@ mod test {
                 op: "green".to_string(),
                 name: "snot".to_string(),
             },
-            id: "badger".into(),
         };
         let operator_id = OperatorId::new(0);
         let event = Event {

--- a/tremor-pipeline/src/op/generic/batch.rs
+++ b/tremor-pipeline/src/op/generic/batch.rs
@@ -29,13 +29,12 @@ pub struct Config {
 impl ConfigImpl for Config {}
 
 #[derive(Debug, Clone)]
-pub struct Batch {
-    pub config: Config,
-    pub data: EventPayload,
-    pub len: usize,
-    pub max_delay_ns: Option<u64>,
-    pub first_ns: u64,
-    pub id: String,
+struct Batch {
+    config: Config,
+    data: EventPayload,
+    len: usize,
+    max_delay_ns: Option<u64>,
+    first_ns: u64,
     /// event id for the resulting batched event
     /// the resulting id will be a new distinct id and will be tracking
     /// all event ids (min and max) in the batched event
@@ -44,7 +43,7 @@ pub struct Batch {
     event_id_gen: EventIdGenerator,
 }
 
-pub fn empty() -> EventPayload {
+fn empty_payload() -> EventPayload {
     EventPayload::new(vec![], |_| ValueAndMeta::from(Value::array()))
 }
 
@@ -54,12 +53,11 @@ if let Some(map) = &node.config {
     let max_delay_ns = config.timeout;
     let mut idgen = EventIdGenerator::for_operator(uid);
     Ok(Box::new(Batch {
-        data: empty(),
+        data: empty_payload(),
         len: 0,
         config,
         max_delay_ns,
         first_ns: 0,
-        id: node.id.clone(),
         batch_event_id: idgen.next_id(),
         is_transactional: false,
         event_id_gen: idgen,
@@ -119,7 +117,7 @@ impl Operator for Batch {
         };
         if flush {
             //TODO: This is ugly
-            let mut data = empty();
+            let mut data = empty_payload();
             swap(&mut data, &mut self.data);
             self.len = 0;
 
@@ -157,7 +155,7 @@ impl Operator for Batch {
                     // create a new event.
 
                     if self.len > 0 {
-                        let mut data = empty();
+                        let mut data = empty_payload();
                         swap(&mut data, &mut self.data);
 
                         self.len = 0; // reset len
@@ -200,9 +198,8 @@ mod test {
             },
             first_ns: 0,
             max_delay_ns: None,
-            data: empty(),
+            data: empty_payload(),
             len: 0,
-            id: "badger".into(),
             batch_event_id: idgen.next_id(),
             is_transactional: false,
             event_id_gen: idgen,
@@ -341,9 +338,8 @@ mod test {
             },
             first_ns: 0,
             max_delay_ns: Some(1_000_000),
-            data: empty(),
+            data: empty_payload(),
             len: 0,
-            id: "badger".into(),
             batch_event_id: idgen.next_id(),
             is_transactional: false,
             event_id_gen: idgen,
@@ -418,9 +414,8 @@ mod test {
             },
             first_ns: 0,
             max_delay_ns: Some(100_000),
-            data: empty(),
+            data: empty_payload(),
             len: 0,
-            id: "badger".into(),
             batch_event_id: idgen.next_id(),
             is_transactional: false,
             event_id_gen: idgen,

--- a/tremor-pipeline/src/op/generic/counter.rs
+++ b/tremor-pipeline/src/op/generic/counter.rs
@@ -17,7 +17,7 @@ use tremor_script::prelude::*;
 
 #[derive(Debug, Clone)]
 // TODO add seed value and field name as config items
-pub struct Counter {}
+struct Counter {}
 
 op!(CounterFactory(_uid, _node) {
     Ok(Box::new(Counter{}))

--- a/tremor-pipeline/src/op/grouper/bucket.rs
+++ b/tremor-pipeline/src/op/grouper/bucket.rs
@@ -81,7 +81,6 @@ op!(BucketGrouperFactory(_uid, node) {
     if node.config.is_none() {
         Ok(Box::new(Grouper {
             buckets: HashMap::new(),
-            _id: node.id.clone(),
         }))
     } else {
         Err(ErrorKind::ExtraOpConfig(node.id.clone()).into())
@@ -89,13 +88,13 @@ op!(BucketGrouperFactory(_uid, node) {
 });
 /// Single bucket specification
 #[derive(Debug)]
-pub struct Rate {
+struct Rate {
     /// the maximum number of events per time range
-    pub rate: u64,
+    rate: u64,
     /// time range in milliseconds, (default: 1000 - 1 second)
-    pub time_range: u64,
+    time_range: u64,
     /// numbers of window in the time_range (default: 100)
-    pub windows: usize,
+    windows: usize,
 }
 
 impl Rate {
@@ -112,7 +111,7 @@ impl Rate {
     }
 }
 
-pub struct Bucket {
+struct Bucket {
     cache: LruCache<String, TimeWindow>,
     pass: u64,
     overflow: u64,
@@ -127,9 +126,8 @@ impl Bucket {
     }
 }
 
-pub struct Grouper {
-    pub _id: String,
-    pub buckets: HashMap<String, Bucket>,
+pub(crate) struct Grouper {
+    buckets: HashMap<String, Bucket>,
 }
 
 // #[cfg_attr(coverage, no_coverage)]
@@ -229,8 +227,6 @@ mod test {
         let operator_id = OperatorId::new(0);
         let mut op = Grouper {
             buckets: HashMap::new(),
-
-            _id: "badger".into(),
         };
         let event1 = Event {
             id: (1, 1, 1).into(),

--- a/tremor-pipeline/src/op/identity/passthrough.rs
+++ b/tremor-pipeline/src/op/identity/passthrough.rs
@@ -15,7 +15,7 @@
 use crate::op::prelude::*;
 
 #[derive(Debug, Clone, Hash)]
-pub struct Passthrough {}
+struct Passthrough {}
 
 op!(PassthroughFactory (_uid, _node) {
     Ok(Box::new(Passthrough{}))

--- a/tremor-pipeline/src/op/qos/percentile.rs
+++ b/tremor-pipeline/src/op/qos/percentile.rs
@@ -55,9 +55,9 @@ pub struct Config {
 impl ConfigImpl for Config {}
 
 #[derive(Debug, Clone)]
-pub struct Percentile {
-    pub config: Config,
-    pub perc: f64,
+struct Percentile {
+    config: Config,
+    perc: f64,
 }
 
 impl From<Config> for Percentile {
@@ -122,7 +122,7 @@ impl Operator for Percentile {
 
         if meta.get("error").is_some()
             || insight.cb == CbAction::Fail
-            || insight.cb == CbAction::Close
+            || insight.cb == CbAction::Trigger
             || meta
                 .get("time")
                 .and_then(Value::cast_f64)

--- a/tremor-pipeline/src/op/qos/percentile.rs
+++ b/tremor-pipeline/src/op/qos/percentile.rs
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Incremental backoff limiter
-//!
-//! The Backoff limiter will start backing off based on the maximum allowed time for results
-//!
-//! ## Configuration
-//!
-//! See [Config](struct.Config.html) for details.
-//!
-//! ## Outputs
-//!
-//! The 1st additional output is used to route data that was decided to
-//! be discarded.
-
 use crate::errors::{ErrorKind, Result};
 use crate::op::prelude::*;
 use beef::Cow;
@@ -41,19 +28,25 @@ pub struct Config {
     /// and `0.0`.
     ///
     /// The default is 5% (`0.05`).
-    #[serde(default = "d_step_down")]
+    #[serde(default = "default_step_down")]
     pub step_down: f64,
 
     /// Percentage to increase on good feedback as a float betwen `1.0`
     /// and `0.0`.
     ///
     /// The default is 0.1% (`0.001`).
-    #[serde(default = "d_step_up")]
+    #[serde(default = "default_step_up")]
     pub step_up: f64,
 }
 
 impl ConfigImpl for Config {}
 
+fn default_step_up() -> f64 {
+    0.001
+}
+fn default_step_down() -> f64 {
+    0.05
+}
 #[derive(Debug, Clone)]
 struct Percentile {
     config: Config,
@@ -64,13 +57,6 @@ impl From<Config> for Percentile {
     fn from(config: Config) -> Self {
         Self { config, perc: 1.0 }
     }
-}
-
-fn d_step_up() -> f64 {
-    0.001
-}
-fn d_step_down() -> f64 {
-    0.05
 }
 
 op!(PercentileFactory(_uid, node) {
@@ -96,7 +82,7 @@ impl Operator for Percentile {
         // if we dont set this, and the event isnt transactional already, we would not receive any CB events,
         // and wouldnt be able to adapt the percentage
         event.transactional = true;
-        // We don't generate a real random number we use the last the 16 bit
+        // We don't generate a real random number we use the last 16 bit
         // of the nanosecond timestamp as a randum number.
         // This is both fairly random and completely deterministic.
         #[allow(clippy::cast_precision_loss)]
@@ -118,16 +104,7 @@ impl Operator for Percentile {
         if !insight.op_meta.contains_key(uid) {
             return;
         }
-        let (_, meta) = insight.data.parts();
-
-        if meta.get("error").is_some()
-            || insight.cb == CbAction::Fail
-            || insight.cb == CbAction::Trigger
-            || meta
-                .get("time")
-                .and_then(Value::cast_f64)
-                .map_or(false, |v| v > self.config.timeout)
-        {
+        if super::is_error_insight(insight, self.config.timeout) {
             self.perc -= self.config.step_down;
             if self.perc < 0.0 {
                 self.perc = 0.0;
@@ -152,8 +129,8 @@ mod test {
         let uid = OperatorId::new(0);
         let mut op: Percentile = Config {
             timeout: 100.0,
-            step_up: d_step_up(),
-            step_down: d_step_down(),
+            step_up: default_step_up(),
+            step_down: default_step_down(),
         }
         .into();
 
@@ -196,8 +173,8 @@ mod test {
     fn drop_on_timeout() {
         let mut op: Percentile = Config {
             timeout: 100.0,
-            step_down: d_step_down(),
-            step_up: d_step_up(),
+            step_down: default_step_down(),
+            step_up: default_step_up(),
         }
         .into();
         let uid = OperatorId::new(42);

--- a/tremor-pipeline/src/op/trickle/operator.rs
+++ b/tremor-pipeline/src/op/trickle/operator.rs
@@ -20,7 +20,7 @@ use tremor_script::{
 };
 #[derive(Debug)]
 pub(crate) struct TrickleOperator {
-    pub op: Box<dyn Operator>,
+    op: Box<dyn Operator>,
 }
 
 fn mk_node_config(id: String, op_type: String, config: Value) -> NodeConfig {

--- a/tremor-pipeline/src/op/trickle/script.rs
+++ b/tremor-pipeline/src/op/trickle/script.rs
@@ -17,9 +17,14 @@ use std::mem;
 use tremor_script::{highlighter, prelude::*};
 
 #[derive(Debug)]
-pub struct Script {
-    pub id: String,
-    pub script: tremor_script::Script,
+pub(crate) struct Script {
+    script: tremor_script::Script,
+}
+
+impl Script {
+    pub(crate) fn new(script: tremor_script::Script) -> Self {
+        Self { script }
+    }
 }
 
 impl Operator for Script {

--- a/tremor-pipeline/src/op/trickle/select.rs
+++ b/tremor-pipeline/src/op/trickle/select.rs
@@ -38,12 +38,11 @@ use tremor_script::{
 };
 
 #[derive(Debug)]
-pub struct Select {
-    pub id: String,
-    pub(crate) select: ast::SelectStmt<'static>,
-    pub windows: Vec<Window>,
-    pub groups: HashMap<String, Group>,
-    pub event_id_gen: EventIdGenerator,
+pub(crate) struct Select {
+    select: ast::SelectStmt<'static>,
+    windows: Vec<Window>,
+    groups: HashMap<String, Group>,
+    event_id_gen: EventIdGenerator,
     recursion_limit: u32,
     dflt_group: Group,
     max_groups: usize,
@@ -52,7 +51,6 @@ pub struct Select {
 impl Select {
     pub fn from_stmt(
         operator_uid: OperatorId,
-        id: String,
         windows: Vec<(String, window::Impl)>,
         select: &ast::SelectStmt<'static>,
     ) -> Self {
@@ -76,7 +74,6 @@ impl Select {
             .min()
             .unwrap_or(0) as usize;
         Self {
-            id,
             windows,
             select: select.clone(),
             groups: HashMap::new(),

--- a/tremor-pipeline/src/op/trickle/select/test.rs
+++ b/tremor-pipeline/src/op/trickle/select/test.rs
@@ -117,8 +117,7 @@ fn test_select(uid: OperatorId, stmt: SelectStmt<'static>) -> Select {
             .into(),
         ),
     ];
-    let id = "select".to_string();
-    Select::from_stmt(uid, id, windows, &stmt)
+    Select::from_stmt(uid, windows, &stmt)
 }
 
 fn try_enqueue(op: &mut Select, event: Event) -> Result<Option<(Cow<'static, str>, Event)>> {
@@ -233,8 +232,7 @@ fn select_stmt_from_query(query_str: &str) -> Result<Select> {
         })
         .collect();
 
-    let id = "select".to_string();
-    Ok(Select::from_stmt(OperatorId::new(42), id, windows, &stmt))
+    Ok(Select::from_stmt(OperatorId::new(42), windows, &stmt))
 }
 
 fn test_tick(ns: u64) -> Event {

--- a/tremor-pipeline/src/op/trickle/simple_select.rs
+++ b/tremor-pipeline/src/op/trickle/simple_select.rs
@@ -28,16 +28,14 @@ use tremor_script::{
 ///
 /// select event from in [where ...] into out [having ...]
 #[derive(Debug)]
-pub struct SimpleSelect {
-    pub id: String,
-    pub(crate) select: ast::SelectStmt<'static>,
+pub(crate) struct SimpleSelect {
+    select: ast::SelectStmt<'static>,
     recursion_limit: u32,
 }
 
 impl SimpleSelect {
-    pub fn with_stmt(id: String, stmt: &ast::SelectStmt<'static>) -> Self {
+    pub fn with_stmt(stmt: &ast::SelectStmt<'static>) -> Self {
         Self {
-            id,
             select: stmt.clone(),
             recursion_limit: tremor_script::recursion_limit(),
         }


### PR DESCRIPTION
# Pull request

## Description

* Rename confusing naming for circuit breaker contraflow messages from `Open` -> `Trigger` and `Close` -> `Restore`. We used the terms in the opposite way they are usually used when talking about the [circuit breaker pattern](https://en.wikipedia.org/wiki/Circuit_breaker_design_pattern#Different_States_of_Circuit_Breaker)
* Make operator structs private, they have been public for no reason, and remove some unused fields

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance



