### PR TITLE
Fix docker file to put logger config in the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Fix misbehaving stdio connector when stdio is a pipe
-- Fix Docker entrypoint script argument ordering
+- Fix^2 Docker entrypoint script argument ordering
 - Fix id encoding for discord connector
 
 ## [0.12.0]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -42,7 +42,7 @@ else
     TROYS=$(find /etc/tremor/config/ -not -path '*/.*' -type f,l -name '*.troy' -print 2>/dev/null | sort)
     [ ! -z "$TROYS" ] && ARTEFACTS="$ARTEFACTS $TROYS"
 
-    ARGS="server --logger-config ${LOGGER_FILE} run"
+    ARGS="--logger-config ${LOGGER_FILE} server run"
 
     if [ ! -z "${ARTEFACTS}" ]
     then


### PR DESCRIPTION
# Pull request

## Description

Fixes the docker file to work again.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
no change