### PR TITLE
Fix race condition during quiescence.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,6 @@ tremor-value/proptest-regressions/
 *.release
 tremor-script/current_counterexample.eqc
 /docs
-lalrpop-docgen
+/lalrpop-docgen
 .vscode/configurationCache.log
 .vscode/dryrun.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 ### New features
+
 - Added the `gpubsub-consumer` connector
+
 ### Fixes
+
+- Fix race condition leading to quiescence timeout when shutting down Tremor
 
 
 ## [0.12.1]

--- a/src/connectors/impls/tcp/server.rs
+++ b/src/connectors/impls/tcp/server.rs
@@ -198,7 +198,7 @@ impl Source for TcpServerSource {
             while ctx.quiescence_beacon().continue_reading().await {
                 match listener.accept().timeout(ACCEPT_TIMEOUT).await {
                     Ok(Ok((stream, peer_addr))) => {
-                        debug!("{} new connection from {}", &accept_ctx, peer_addr);
+                        debug!("{accept_ctx} new connection from {peer_addr}");
                         let stream_id: u64 = stream_id_gen.next_stream_id();
                         let connection_meta: ConnectionMeta = peer_addr.into();
                         // Async<T> allows us to read in one thread and write in another concurrently - see its documentation
@@ -271,9 +271,10 @@ impl Source for TcpServerSource {
                         }
                     }
                     Ok(Err(e)) => return Err(e.into()),
-                    Err(_) => continue,
+                    Err(_) => continue, // timeout accepting
                 };
             }
+            debug!("{accept_ctx} stopped accepting connections.");
             Ok(())
         }));
 


### PR DESCRIPTION
The spawn_task function was issueing a connection_lost so that the connector state went to Disconnected and
the source stopped pulling data from the source, ergo it wasn't getting sourcereplies about ending streams
and thus was never finishing quiescence but always timing out after 5 seconds.

This shaves off > 20s of integration test time.

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

