### PR TITLE
Stop integration tests after 5 minutes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./lcov.txt # optional
           flags: cli${{ matrix.kind }} # optional
           fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -28,6 +28,7 @@ jobs:
     env:
       TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib:${{ github.workspace }}/tremor-cli/tests/lib"
       RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
+      RUST_LOG: debug
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -50,7 +50,7 @@ jobs:
         run: docker-compose --version
 
       - name: run ${{ matrix.kind }} tests
-        run: cargo llvm-cov run -p tremor-cli --lcov --output-path lcov.txt -- test ${{ matrix.kind }} tremor-cli/tests ${{ matrix.exclude_tests }}
+        run: cargo llvm-cov run -p tremor-cli --lcov --output-path lcov.txt -- test --timeout 300 ${{ matrix.kind }} tremor-cli/tests ${{ matrix.exclude_tests }}
 
       - name: Upload error logs
         uses: actions/upload-artifact@v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,3 +28,4 @@ comment:
 
 ignore:
   - "tremor-cli"
+  - "depricated"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    after_n_builds: 4
 
 coverage:
   precision: 2
@@ -23,3 +25,6 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+
+ignore:
+  - "tremor-cli"

--- a/tremor-cli/src/cli.rs
+++ b/tremor-cli/src/cli.rs
@@ -89,6 +89,9 @@ pub(crate) struct Test {
     /// Sets the level of verbosity (does not apply to logging)
     #[clap(short, long)]
     pub(crate) verbose: bool,
+    /// Timeout in seconds for each test
+    #[clap(short, long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 /// Shell type

--- a/tremor-cli/src/main.rs
+++ b/tremor-cli/src/main.rs
@@ -22,6 +22,7 @@
     clippy::unnecessary_unwrap,
     clippy::pedantic
 )]
+#![cfg_attr(coverage, feature(no_coverage))]
 
 #[macro_use]
 extern crate serde_derive;

--- a/tremor-cli/src/main.rs
+++ b/tremor-cli/src/main.rs
@@ -22,8 +22,6 @@
     clippy::unnecessary_unwrap,
     clippy::pedantic
 )]
-#![cfg_attr(coverage, feature(no_coverage))]
-
 #[macro_use]
 extern crate serde_derive;
 

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -160,7 +160,6 @@ async fn suite_integration(
     }
 }
 
-#[cfg_attr(coverage, no_coverage)]
 async fn run_integration(
     root: &Path,
     config: &TestConfig,

--- a/tremor-cli/src/test.rs
+++ b/tremor-cli/src/test.rs
@@ -160,6 +160,7 @@ async fn suite_integration(
     }
 }
 
+#[cfg_attr(coverage, no_coverage)]
 async fn run_integration(
     root: &Path,
     config: &TestConfig,

--- a/tremor-cli/src/test/after.rs
+++ b/tremor-cli/src/test/after.rs
@@ -47,7 +47,25 @@ impl After {
         let err_file = base.join("after.err.log");
         process.stdio_tailer(&out_file, &err_file).await?;
 
+        debug!(
+            "Spawning after: {} in {}",
+            self.cmdline(),
+            current_dir.display()
+        );
+
         Ok(Some(process))
+    }
+
+    fn cmdline(&self) -> String {
+        format!(
+            "{}{} {}",
+            self.env
+                .iter()
+                .map(|(k, v)| format!("{}={} ", k, v))
+                .collect::<String>(),
+            self.cmd,
+            self.args.join(" ")
+        )
     }
 }
 

--- a/tremor-cli/tests/integration/kafka_connectors/before.yaml
+++ b/tremor-cli/tests/integration/kafka_connectors/before.yaml
@@ -23,7 +23,7 @@
     "port-open":
       - "9092"
     "http-ok":
-      - "http://localhost:9644/v1/status/ready"
+      - "http://127.0.0.1:9644/v1/status/ready"
   max-await-secs: 10
 - dir: "."
   cmd: "docker"


### PR DESCRIPTION
Stop integration tests after 5 minutes and print their log files for better debuggability on CI and to avoid infinite runs hogging machines.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


