### PR TITLE
Add the Google PubSub Publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### New features
 
+- Added the `gpubsub_publisher` connector
 - Added the `gpubsub_consumer` connector
 - Added new metadata options to `elastic` connector: `version`, `version_type`, `retry_on_conflict`, `if_primary_term`, `if_seq_no`
 
@@ -10,7 +11,6 @@
 
 - Fix race condition leading to quiescence timeout when shutting down Tremor
 - Fix `timeout` config unit mismatch in `qos::backpressure` and `qos::percentile` operators. Changed to nanoseconds precision. 
-
 
 ## [0.12.1]
 

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -1198,6 +1198,7 @@ pub(crate) fn builtin_connector_types() -> Vec<Box<dyn ConnectorBuilder + 'stati
         Box::new(impls::otel::server::Builder::default()),
         Box::new(impls::gbq::writer::Builder::default()),
         Box::new(impls::gpubsub::consumer::Builder::default()),
+        Box::new(impls::gpubsub::producer::Builder::default()),
     ]
 }
 

--- a/src/connectors/impls/gpubsub.rs
+++ b/src/connectors/impls/gpubsub.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub(crate) mod consumer;
+pub(crate) mod producer;

--- a/src/connectors/impls/gpubsub.rs
+++ b/src/connectors/impls/gpubsub.rs
@@ -29,3 +29,16 @@ fn default_request_timeout() -> u64 {
 fn default_skip_authentication() -> bool {
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::connectors::impls::gpubsub::default_connect_timeout;
+    use std::time::Duration;
+
+    #[test]
+    pub fn default_connect_timeout_is_1s() {
+        let actual = Duration::from_nanos(default_connect_timeout());
+
+        assert_eq!(actual, Duration::from_secs(1));
+    }
+}

--- a/src/connectors/impls/gpubsub.rs
+++ b/src/connectors/impls/gpubsub.rs
@@ -14,3 +14,18 @@
 
 pub(crate) mod consumer;
 pub(crate) mod producer;
+
+fn default_endpoint() -> String {
+    "https://pubsub.googleapis.com".into()
+}
+fn default_connect_timeout() -> u64 {
+    1_000_000_000u64 // 1 second
+}
+fn default_request_timeout() -> u64 {
+    10_000_000_000u64 // 10 seconds
+}
+
+#[cfg(test)]
+fn default_skip_authentication() -> bool {
+    false
+}

--- a/src/connectors/impls/gpubsub/consumer.rs
+++ b/src/connectors/impls/gpubsub/consumer.rs
@@ -37,31 +37,18 @@ use tremor_pipeline::ConfigImpl;
 
 #[derive(Deserialize, Clone)]
 struct Config {
-    #[serde(default = "default_connect_timeout")]
+    #[serde(default = "crate::connectors::impls::gpubsub::default_connect_timeout")]
     pub connect_timeout: u64,
     #[serde(default = "default_ack_deadline")]
     pub ack_deadline: u64,
     pub subscription_id: String,
-    #[serde(default = "default_endpoint")]
+    #[serde(default = "crate::connectors::impls::gpubsub::default_endpoint")]
     pub endpoint: String,
     #[cfg(test)]
-    #[serde(default = "default_skip_authentication")]
+    #[serde(default = "crate::connectors::impls::gpubsub::default_skip_authentication")]
     pub skip_authentication: bool,
 }
 impl ConfigImpl for Config {}
-
-fn default_endpoint() -> String {
-    "https://pubsub.googleapis.com".into()
-}
-
-#[cfg(test)]
-fn default_skip_authentication() -> bool {
-    false
-}
-
-fn default_connect_timeout() -> u64 {
-    1_000_000_000u64 // 1 second
-}
 
 fn default_ack_deadline() -> u64 {
     10_000_000_000u64 // 10 seconds

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -185,8 +185,8 @@ impl Sink for GpubSink {
 
         for (value, meta) in event.value_meta_iter() {
             for payload in serializer.serialize(value, event.ingest_ns)? {
-
-                let ordering_key = ctx.extract_meta(meta)
+                let ordering_key = ctx
+                    .extract_meta(meta)
                     .get("ordering_key")
                     .as_str()
                     .map_or_else(|| "".to_string(), ToString::to_string);

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -1,0 +1,173 @@
+use crate::connectors::google::AuthInterceptor;
+use crate::connectors::prelude::{
+    Attempt, ErrorKind, EventSerializer, SinkAddr, SinkContext, SinkManagerBuilder, SinkReply, Url,
+};
+use crate::connectors::sink::Sink;
+use crate::connectors::utils::url::HttpsDefaults;
+use crate::connectors::{
+    CodecReq, Connector, ConnectorBuilder, ConnectorConfig, ConnectorContext, ConnectorType,
+};
+use crate::errors::Result;
+use googapis::google::pubsub::v1::publisher_client::PublisherClient;
+use googapis::google::pubsub::v1::{PublishRequest, PubsubMessage};
+use gouth::Token;
+use std::time::Duration;
+use tonic::codegen::InterceptedService;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig};
+use tonic::Status;
+use tremor_pipeline::{ConfigImpl, Event};
+
+#[derive(Deserialize, Clone)]
+pub struct Config {
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout: u64,
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+    pub topic: String,
+}
+
+fn default_endpoint() -> String {
+    "https://pubsub.googleapis.com".into()
+}
+fn default_connect_timeout() -> u64 {
+    1_000_000_000u64 // 1 second
+}
+
+impl ConfigImpl for Config {}
+
+#[derive(Default, Debug)]
+pub(crate) struct Builder {}
+
+#[async_trait::async_trait()]
+impl ConnectorBuilder for Builder {
+    fn connector_type(&self) -> ConnectorType {
+        ConnectorType("gpubsub_producer".to_string())
+    }
+
+    async fn build(&self, alias: &str, config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
+        if let Some(raw_config) = &config.config {
+            let config = Config::new(raw_config)?;
+
+            Ok(Box::new(GpubConnector { config }))
+        } else {
+            Err(ErrorKind::MissingConfiguration(alias.to_string()).into())
+        }
+    }
+}
+
+struct GpubConnector {
+    config: Config,
+}
+
+#[async_trait::async_trait()]
+impl Connector for GpubConnector {
+    async fn create_sink(
+        &mut self,
+        sink_context: SinkContext,
+        builder: SinkManagerBuilder,
+    ) -> Result<Option<SinkAddr>> {
+        let sink = GpubSink {
+            config: self.config.clone(),
+            url: Url::parse(&self.config.endpoint)?,
+            client: None,
+        };
+        builder.spawn(sink, sink_context).map(Some)
+    }
+
+    async fn connect(&mut self, _ctx: &ConnectorContext, _attempt: &Attempt) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn codec_requirements(&self) -> CodecReq {
+        CodecReq::Required
+    }
+}
+
+struct GpubSink {
+    config: Config,
+    url: Url<HttpsDefaults>,
+
+    client: Option<PublisherClient<InterceptedService<Channel, AuthInterceptor>>>,
+}
+
+#[async_trait::async_trait()]
+impl Sink for GpubSink {
+    async fn connect(&mut self, _ctx: &SinkContext, _attempt: &Attempt) -> Result<bool> {
+        let mut channel = Channel::from_shared(self.config.endpoint.clone())?
+            .connect_timeout(Duration::from_nanos(self.config.connect_timeout));
+        if self.url.scheme() == "https" {
+            let tls_config = ClientTlsConfig::new()
+                .ca_certificate(Certificate::from_pem(googapis::CERTIFICATES))
+                .domain_name(
+                    self.url
+                        .host_str()
+                        .ok_or_else(|| Status::unavailable("The endpoint is missing a hostname"))?
+                        .to_string(),
+                );
+
+            channel = channel.tls_config(tls_config)?;
+        }
+
+        let channel = channel.connect().await?;
+        let token = Token::new()?;
+
+        let client = PublisherClient::with_interceptor(
+            channel.clone(),
+            AuthInterceptor {
+                token: Box::new(move || {
+                    token.header_value().map_err(|_| {
+                        Status::unavailable("Failed to retrieve authentication token.")
+                    })
+                }),
+            },
+        );
+
+        self.client = Some(client);
+
+        Ok(true)
+    }
+
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        event: Event,
+        _ctx: &SinkContext,
+        serializer: &mut EventSerializer,
+        _start: u64,
+    ) -> Result<SinkReply> {
+        let client = self.client.as_mut().ok_or(ErrorKind::ClientNotAvailable(
+            "PubSub",
+            "The publisher is not connected",
+        ))?;
+
+        let mut messages = vec![];
+
+        for e in event.value_iter() {
+            messages.push(PubsubMessage {
+                data: serializer.serialize(e, event.ingest_ns).unwrap()[0].clone(),
+                attributes: Default::default(),
+                message_id: "".to_string(),
+                publish_time: None,
+                ordering_key: "".to_string(),
+            });
+        }
+
+        client
+            .publish(PublishRequest {
+                topic: self.config.topic.clone(),
+                messages,
+            })
+            .await
+            .unwrap();
+
+        Ok(SinkReply::ACK)
+    }
+
+    fn auto_ack(&self) -> bool {
+        false
+    }
+
+    fn asynchronous(&self) -> bool {
+        true
+    }
+}

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -44,9 +44,6 @@ pub struct Config {
     #[serde(default = "crate::connectors::impls::gpubsub::default_endpoint")]
     pub endpoint: String,
     pub topic: String,
-    #[cfg(test)]
-    #[serde(default = "crate::connectors::impls::gpubsub::default_skip_authentication")]
-    pub skip_authentication: bool,
 }
 
 impl ConfigImpl for Config {}
@@ -267,7 +264,6 @@ mod tests {
                 request_timeout: 0,
                 endpoint: "".to_string(),
                 topic: "".to_string(),
-                skip_authentication: false,
             },
             url: Default::default(),
             hostname: "".to_string(),
@@ -285,7 +281,6 @@ mod tests {
                 request_timeout: 0,
                 endpoint: "".to_string(),
                 topic: "".to_string(),
-                skip_authentication: false,
             },
             url: Default::default(),
             hostname: "".to_string(),

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -241,3 +241,44 @@ impl Sink for GpubSink {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn is_not_auto_ack() {
+        let sink = GpubSink {
+            config: Config {
+                connect_timeout: 0,
+                request_timeout: 0,
+                endpoint: "".to_string(),
+                topic: "".to_string(),
+                skip_authentication: false,
+            },
+            url: Default::default(),
+            hostname: "".to_string(),
+            client: None,
+        };
+
+        assert!(!sink.auto_ack());
+    }
+
+    #[test]
+    pub fn is_async() {
+        let sink = GpubSink {
+            config: Config {
+                connect_timeout: 0,
+                request_timeout: 0,
+                endpoint: "".to_string(),
+                topic: "".to_string(),
+                skip_authentication: false,
+            },
+            url: Default::default(),
+            hostname: "".to_string(),
+            client: None,
+        };
+
+        assert!(sink.asynchronous());
+    }
+}

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -1,3 +1,17 @@
+// Copyright 2020-2021, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::connectors::google::AuthInterceptor;
 use crate::connectors::prelude::{
     Attempt, ErrorKind, EventSerializer, SinkAddr, SinkContext, SinkManagerBuilder, SinkReply, Url,

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -263,11 +263,6 @@ impl Sink for GpubSink {
                 Ok(SinkReply::ACK)
             }
         } else {
-            ctx.swallow_err(
-                ctx.notifier.connection_lost().await,
-                "Failed to notify about PubSub connection loss",
-            );
-
             Ok(SinkReply::FAIL)
         }
     }

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
-use tonic::{Code};
+use tonic::Code;
 use tremor_pipeline::{ConfigImpl, Event};
 use tremor_value::Value;
 use value_trait::ValueAccess;

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -34,6 +34,7 @@ use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 use tonic::{Code, Status};
 use tremor_pipeline::{ConfigImpl, Event};
+use tremor_value::Value;
 use value_trait::ValueAccess;
 
 #[derive(Deserialize, Clone)]
@@ -61,14 +62,15 @@ impl ConnectorBuilder for Builder {
         ConnectorType("gpubsub_producer".to_string())
     }
 
-    async fn build(&self, alias: &str, config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
-        if let Some(raw_config) = &config.config {
-            let config = Config::new(raw_config)?;
+    async fn build_cfg(
+        &self,
+        _alias: &str,
+        _config: &ConnectorConfig,
+        raw_config: &Value,
+    ) -> Result<Box<dyn Connector>> {
+        let config = Config::new(raw_config)?;
 
-            Ok(Box::new(GpubConnector { config }))
-        } else {
-            Err(ErrorKind::MissingConfiguration(alias.to_string()).into())
-        }
+        Ok(Box::new(GpubConnector { config }))
     }
 }
 

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -251,8 +251,7 @@ impl Sink for GpubSink {
                         | Code::ResourceExhausted
                         | Code::Unavailable
                         | Code::Unknown
-                )
-                {
+                ) {
                     ctx.swallow_err(
                         ctx.notifier.connection_lost().await,
                         "Failed to notify about PubSub connection loss",

--- a/src/connectors/tests/gpubsub.rs
+++ b/src/connectors/tests/gpubsub.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod gpub;
 mod gsub;

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -26,6 +26,49 @@ use tonic::transport::Channel;
 use tremor_common::ports::IN;
 use tremor_pipeline::{Event, EventId};
 use tremor_value::{literal, Value};
+use crate::connectors::utils::EnvHelper;
+
+#[async_std::test]
+#[serial(gpubsub)]
+async fn no_connection() -> Result<()> {
+    let _ = env_logger::try_init();
+    let connector_yaml = literal!({
+        "codec": "binary",
+        "config":{
+            "endpoint": "https://localhost:9090",
+            "connect_timeout": 100000000,
+            "topic": "projects/xxx/topics/test-a",
+            "skip_authentication": false
+        }
+    });
+
+    let harness =
+        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await?;
+    assert!(harness.start().await.is_err());
+    Ok(())
+}
+
+#[async_std::test]
+#[serial(gpubsub)]
+async fn no_token() -> Result<()> {
+    let _ = env_logger::try_init();
+    let mut env = EnvHelper::new();
+    env.remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+    let connector_yaml = literal!({
+        "codec": "binary",
+        "config":{
+            "endpoint": "https://localhost:9090",
+            "connect_timeout": 100000000,
+            "topic": "projects/xxx/topics/test-a",
+            "skip_authentication": false
+        }
+    });
+
+    let harness =
+        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await?;
+    assert!(harness.start().await.is_err());
+    Ok(())
+}
 
 #[async_std::test]
 #[serial(gpubsub)]

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -50,6 +50,25 @@ async fn no_connection() -> Result<()> {
 
 #[async_std::test]
 #[serial(gpubsub)]
+async fn no_hostname() -> Result<()> {
+    let _ = env_logger::try_init();
+    let connector_yaml = literal!({
+        "codec": "binary",
+        "config":{
+            "endpoint": "https://:9090",
+            "connect_timeout": 100000000,
+            "topic": "projects/xxx/topics/test-a",
+            "skip_authentication": false
+        }
+    });
+
+    let harness = ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await;
+    assert!(harness.is_err());
+    Ok(())
+}
+
+#[async_std::test]
+#[serial(gpubsub)]
 async fn no_token() -> Result<()> {
     let _ = env_logger::try_init();
 

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -209,6 +209,8 @@ async fn simple_publish() -> Result<()> {
         );
     }
 
+    harness.stop().await?;
+
     Ok(())
 }
 
@@ -291,6 +293,8 @@ async fn simple_publish_with_timeout() -> Result<()> {
         .timeout(Duration::from_secs(10))
         .await?
         .unwrap();
+
+    harness.stop().await?;
 
     Ok(())
 }

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -21,12 +21,15 @@ use googapis::google::pubsub::v1::subscriber_client::SubscriberClient;
 use googapis::google::pubsub::v1::{PullRequest, Subscription, Topic};
 use serial_test::serial;
 use std::collections::HashSet;
+use std::time::Duration;
+use async_std::prelude::FutureExt;
 use testcontainers::clients::Cli;
 use testcontainers::RunnableImage;
 use tonic::transport::Channel;
 use tremor_common::ports::IN;
 use tremor_pipeline::{Event, EventId};
 use tremor_value::{literal, Value};
+use crate::instance::State;
 
 #[async_std::test]
 #[serial(gpubsub)]
@@ -205,6 +208,85 @@ async fn simple_publish() -> Result<()> {
             received_messages.len()
         );
     }
+
+    Ok(())
+}
+
+#[async_std::test]
+#[serial(gpubsub)]
+async fn simple_publish_with_timeout() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let runner = Cli::docker();
+
+    let (pubsub, pubsub_args) =
+        testcontainers::images::google_cloud_sdk_emulators::CloudSdk::pubsub();
+    let runnable_image = RunnableImage::from((pubsub, pubsub_args));
+    let container = runner.run(runnable_image);
+
+    let port =
+        container.get_host_port(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+    let endpoint = format!("http://localhost:{}", port);
+    let endpoint_clone = endpoint.clone();
+
+    let connector_yaml: Value = literal!({
+        "codec": "binary",
+        "config":{
+            "endpoint": endpoint,
+            "connect_timeout": 30000000000u64,
+            "topic": "projects/test/topics/test",
+            "skip_authentication": true
+        }
+    });
+
+    let channel = Channel::from_shared(endpoint_clone)?.connect().await?;
+    let mut subscriber = SubscriberClient::new(channel.clone());
+    let mut publisher = PublisherClient::new(channel.clone());
+    publisher
+        .create_topic(Topic {
+            name: "projects/test/topics/test".to_string(),
+            labels: Default::default(),
+            message_storage_policy: None,
+            kms_key_name: "".to_string(),
+            schema_settings: None,
+            satisfies_pzs: false,
+            message_retention_duration: None,
+        })
+        .await?;
+    subscriber
+        .create_subscription(Subscription {
+            name: "projects/test/subscriptions/test-subscription-a".to_string(),
+            topic: "projects/test/topics/test".to_string(),
+            push_config: None,
+            ack_deadline_seconds: 0,
+            retain_acked_messages: false,
+            message_retention_duration: None,
+            labels: Default::default(),
+            enable_message_ordering: false,
+            expiration_policy: None,
+            filter: "".to_string(),
+            dead_letter_policy: None,
+            retry_policy: None,
+            detached: false,
+            topic_message_retention_duration: None,
+        })
+        .await?;
+
+    let harness =
+        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await?;
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+    harness.consume_initial_sink_contraflow().await?;
+
+    drop(container);
+
+    let event = Event {
+        id: EventId::default(),
+        data: (Value::String(format!("Event X").into()), literal!({})).into(),
+        ..Event::default()
+    };
+    harness.send_to_sink(event, IN).await?;
+    harness.wait_for_state(State::Failed).timeout(Duration::from_secs(10)).await?.unwrap();
 
     Ok(())
 }

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -1,0 +1,134 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::connectors::impls::gpubsub::producer::Builder;
+use crate::connectors::tests::ConnectorHarness;
+use crate::errors::Result;
+use googapis::google::pubsub::v1::publisher_client::PublisherClient;
+use googapis::google::pubsub::v1::subscriber_client::SubscriberClient;
+use googapis::google::pubsub::v1::{PullRequest, Subscription, Topic};
+use serial_test::serial;
+use std::collections::HashSet;
+use testcontainers::clients::Cli;
+use testcontainers::RunnableImage;
+use tonic::transport::Channel;
+use tremor_common::ports::IN;
+use tremor_pipeline::{Event, EventId};
+use tremor_value::{literal, Value};
+
+#[async_std::test]
+#[serial(gpubsub)]
+async fn simple_publish() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let runner = Cli::docker();
+
+    let (pubsub, pubsub_args) =
+        testcontainers::images::google_cloud_sdk_emulators::CloudSdk::pubsub();
+    let runnable_image = RunnableImage::from((pubsub, pubsub_args));
+    let container = runner.run(runnable_image);
+
+    let port =
+        container.get_host_port(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+    let endpoint = format!("http://localhost:{}", port);
+    let endpoint_clone = endpoint.clone();
+
+    let connector_yaml: Value = literal!({
+        "codec": "binary",
+        "config":{
+            "endpoint": endpoint,
+            "ack_deadline": 30000000000u64,
+            "connect_timeout": 30000000000u64,
+            "topic": "projects/test/topics/test",
+            "skip_authentication": true
+        }
+    });
+
+    let channel = Channel::from_shared(endpoint_clone)?.connect().await?;
+    let mut subscriber = SubscriberClient::new(channel.clone());
+    let mut publisher = PublisherClient::new(channel.clone());
+    publisher
+        .create_topic(Topic {
+            name: "projects/test/topics/test".to_string(),
+            labels: Default::default(),
+            message_storage_policy: None,
+            kms_key_name: "".to_string(),
+            schema_settings: None,
+            satisfies_pzs: false,
+            message_retention_duration: None,
+        })
+        .await?;
+    subscriber
+        .create_subscription(Subscription {
+            name: "projects/test/subscriptions/test-subscription-a".to_string(),
+            topic: "projects/test/topics/test".to_string(),
+            push_config: None,
+            ack_deadline_seconds: 0,
+            retain_acked_messages: false,
+            message_retention_duration: None,
+            labels: Default::default(),
+            enable_message_ordering: false,
+            expiration_policy: None,
+            filter: "".to_string(),
+            dead_letter_policy: None,
+            retry_policy: None,
+            detached: false,
+            topic_message_retention_duration: None,
+        })
+        .await?;
+
+    let harness =
+        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await?;
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+    harness.consume_initial_sink_contraflow().await?;
+
+    for i in 0..100 {
+        let event = Event {
+            id: EventId::default(),
+            data: (Value::String(format!("Event {}", i).into()), literal!({})).into(),
+            ..Event::default()
+        };
+        harness.send_to_sink(event, IN).await?;
+    }
+
+    let mut received_messages = HashSet::new();
+    let mut iter_count = 0;
+
+    while received_messages.len() < 100 && iter_count <= 100 {
+        let result = subscriber
+            .pull(PullRequest {
+                subscription: "projects/test/subscriptions/test-subscription-a".to_string(),
+                max_messages: 1000,
+                ..Default::default()
+            })
+            .await?;
+
+        for msg in result.into_inner().received_messages {
+            let body = msg.message.unwrap();
+            received_messages.insert(String::from_utf8(body.data).unwrap());
+        }
+
+        iter_count += 1;
+    }
+
+    if received_messages.len() != 100 {
+        panic!(
+            "Received an unexpected number of messages - {}",
+            received_messages.len()
+        );
+    }
+
+    Ok(())
+}

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -14,7 +14,6 @@
 
 use crate::connectors::impls::gpubsub::producer::Builder;
 use crate::connectors::tests::ConnectorHarness;
-use crate::connectors::utils::EnvHelper;
 use crate::errors::Result;
 use crate::instance::State;
 use async_std::prelude::FutureExt;

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -86,7 +86,7 @@ async fn no_token() -> Result<()> {
     let container = runner.run(runnable_image);
 
     let port =
-        container.get_host_port(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
 
     let mut env = EnvHelper::new();
@@ -120,7 +120,7 @@ async fn simple_publish() -> Result<()> {
     let container = runner.run(runnable_image);
 
     let port =
-        container.get_host_port(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
     let endpoint_clone = endpoint.clone();
 
@@ -225,7 +225,7 @@ async fn simple_publish_with_timeout() -> Result<()> {
     let container = runner.run(runnable_image);
 
     let port =
-        container.get_host_port(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
     let endpoint_clone = endpoint.clone();
 

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -75,40 +75,6 @@ async fn no_hostname() -> Result<()> {
 
 #[async_std::test]
 #[serial(gpubsub)]
-async fn no_token() -> Result<()> {
-    let _ = env_logger::try_init();
-
-    let runner = Cli::docker();
-
-    let (pubsub, pubsub_args) =
-        testcontainers::images::google_cloud_sdk_emulators::CloudSdk::pubsub();
-    let runnable_image = RunnableImage::from((pubsub, pubsub_args));
-    let container = runner.run(runnable_image);
-
-    let port = container
-        .get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
-    let endpoint = format!("http://localhost:{}", port);
-
-    let mut env = EnvHelper::new();
-    env.remove_var("GOOGLE_APPLICATION_CREDENTIALS");
-    let connector_yaml = literal!({
-        "codec": "binary",
-        "config":{
-            "endpoint": endpoint,
-            "connect_timeout": 30000000000u64,
-            "topic": "projects/test/topics/test",
-            "skip_authentication": false
-        }
-    });
-
-    let harness =
-        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await?;
-    assert!(harness.start().await.is_err());
-    Ok(())
-}
-
-#[async_std::test]
-#[serial(gpubsub)]
 async fn simple_publish() -> Result<()> {
     let _ = env_logger::try_init();
 

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -16,20 +16,20 @@ use crate::connectors::impls::gpubsub::producer::Builder;
 use crate::connectors::tests::ConnectorHarness;
 use crate::connectors::utils::EnvHelper;
 use crate::errors::Result;
+use crate::instance::State;
+use async_std::prelude::FutureExt;
 use googapis::google::pubsub::v1::publisher_client::PublisherClient;
 use googapis::google::pubsub::v1::subscriber_client::SubscriberClient;
 use googapis::google::pubsub::v1::{PullRequest, Subscription, Topic};
 use serial_test::serial;
 use std::collections::HashSet;
 use std::time::Duration;
-use async_std::prelude::FutureExt;
 use testcontainers::clients::Cli;
 use testcontainers::RunnableImage;
 use tonic::transport::Channel;
 use tremor_common::ports::IN;
 use tremor_pipeline::{Event, EventId};
 use tremor_value::{literal, Value};
-use crate::instance::State;
 
 #[async_std::test]
 #[serial(gpubsub)]
@@ -85,8 +85,8 @@ async fn no_token() -> Result<()> {
     let runnable_image = RunnableImage::from((pubsub, pubsub_args));
     let container = runner.run(runnable_image);
 
-    let port =
-        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+    let port = container
+        .get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
 
     let mut env = EnvHelper::new();
@@ -119,8 +119,8 @@ async fn simple_publish() -> Result<()> {
     let runnable_image = RunnableImage::from((pubsub, pubsub_args));
     let container = runner.run(runnable_image);
 
-    let port =
-        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+    let port = container
+        .get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
     let endpoint_clone = endpoint.clone();
 
@@ -224,8 +224,8 @@ async fn simple_publish_with_timeout() -> Result<()> {
     let runnable_image = RunnableImage::from((pubsub, pubsub_args));
     let container = runner.run(runnable_image);
 
-    let port =
-        container.get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
+    let port = container
+        .get_host_port_ipv4(testcontainers::images::google_cloud_sdk_emulators::PUBSUB_PORT);
     let endpoint = format!("http://localhost:{}", port);
     let endpoint_clone = endpoint.clone();
 
@@ -286,7 +286,11 @@ async fn simple_publish_with_timeout() -> Result<()> {
         ..Event::default()
     };
     harness.send_to_sink(event, IN).await?;
-    harness.wait_for_state(State::Failed).timeout(Duration::from_secs(10)).await?.unwrap();
+    harness
+        .wait_for_state(State::Failed)
+        .timeout(Duration::from_secs(10))
+        .await?
+        .unwrap();
 
     Ok(())
 }

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -55,7 +55,7 @@ async fn no_hostname() -> Result<()> {
     let connector_yaml = literal!({
         "codec": "binary",
         "config":{
-            "endpoint": "https://:9090",
+            "endpoint": "file:///etc/passwd",
             "connect_timeout": 100000000,
             "topic": "projects/xxx/topics/test-a",
             "skip_authentication": false
@@ -64,7 +64,9 @@ async fn no_hostname() -> Result<()> {
 
     let harness =
         ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await;
+
     assert!(harness.is_err());
+
     Ok(())
 }
 

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -14,6 +14,7 @@
 
 use crate::connectors::impls::gpubsub::producer::Builder;
 use crate::connectors::tests::ConnectorHarness;
+use crate::connectors::utils::EnvHelper;
 use crate::errors::Result;
 use googapis::google::pubsub::v1::publisher_client::PublisherClient;
 use googapis::google::pubsub::v1::subscriber_client::SubscriberClient;
@@ -26,7 +27,6 @@ use tonic::transport::Channel;
 use tremor_common::ports::IN;
 use tremor_pipeline::{Event, EventId};
 use tremor_value::{literal, Value};
-use crate::connectors::utils::EnvHelper;
 
 #[async_std::test]
 #[serial(gpubsub)]

--- a/src/connectors/tests/gpubsub/gpub.rs
+++ b/src/connectors/tests/gpubsub/gpub.rs
@@ -62,7 +62,8 @@ async fn no_hostname() -> Result<()> {
         }
     });
 
-    let harness = ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await;
+    let harness =
+        ConnectorHarness::new(function_name!(), &Builder::default(), &connector_yaml).await;
     assert!(harness.is_err());
     Ok(())
 }


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/204)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


