### PR TITLE
Fix timeout config of backpressure and percentile operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Unreleased
 ### New features
 
-- Added the `gpubsub-consumer` connector
+- Added the `gpubsub_consumer` connector
 
 ### Fixes
 
 - Fix race condition leading to quiescence timeout when shutting down Tremor
+- Fix `timeout` config unit mismatch in `qos::backpressure` and `qos::percentile` operators. Changed to nanoseconds precision. 
 
 
 ## [0.12.1]

--- a/tremor-pipeline/src/event.rs
+++ b/tremor-pipeline/src/event.rs
@@ -114,7 +114,7 @@ impl Event {
         Event::cb_ack(self.ingest_ns, self.id.clone(), self.op_meta.clone())
     }
 
-    /// produce a `CBAction::Ack` insight event with the given time (in ms) in the metadata
+    /// produce a `CBAction::Ack` insight event with the given time (in nanoseconds) in the metadata
     #[must_use]
     pub fn insight_ack_with_timing(&mut self, processing_time: u64) -> Event {
         let mut e = self.insight_ack();

--- a/tremor-pipeline/src/op/qos.rs
+++ b/tremor-pipeline/src/op/qos.rs
@@ -30,13 +30,10 @@ use tremor_script::prelude::*;
 /// * we have a event delivery failure OR
 /// * we have a message triggering a circuit breaker OR
 /// * the event metadata has a `time` field that exceeds the given `timeout`
-fn is_error_insight(insight: &Event, timeout: f64) -> bool {
+fn is_error_insight(insight: &Event, timeout: u64) -> bool {
     let meta = insight.data.suffix().meta();
     meta.get("error").is_some()
         || insight.cb == CbAction::Fail
         || insight.cb == CbAction::Trigger
-        || meta
-            .get("time")
-            .and_then(Value::cast_f64)
-            .map_or(false, |v| v > timeout)
+        || meta.get_u64("time").map_or(false, |v| v > timeout)
 }

--- a/tremor-pipeline/src/op/qos/backpressure.rs
+++ b/tremor-pipeline/src/op/qos/backpressure.rs
@@ -49,8 +49,8 @@ impl Default for Method {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    /// The maximum allowed timeout before backoff is applied in ms
-    pub timeout: f64,
+    /// The maximum allowed timeout before backoff is applied in nanoseconds
+    pub timeout: u64,
     /// A list of backoff steps in ms, wich are progressed through as long
     /// as the maximum timeout is exceeded
     ///
@@ -228,7 +228,7 @@ mod test {
     fn pass_wo_error() {
         let operator_id = OperatorId::new(0);
         let mut op: Backpressure = Config {
-            timeout: 100.0,
+            timeout: 100_000_000,
             steps: vec![1, 10, 100],
             method: Method::Discard,
         }
@@ -273,7 +273,7 @@ mod test {
     fn halt_on_error() {
         let operator_id = OperatorId::new(0);
         let mut op: Backpressure = Config {
-            timeout: 100.0,
+            timeout: 100_000_000,
             steps: vec![1, 10, 100],
             method: Method::Discard,
         }
@@ -301,7 +301,7 @@ mod test {
         // this is over our limit of `100` so we syould move
         // one up the backup steps
         let mut m = Object::new();
-        m.insert("time".into(), 200.0.into());
+        m.insert("time".into(), 200_000_000.into());
 
         let mut op_meta = OpMeta::default();
         op_meta.insert(operator_id, OwnedValue::null());
@@ -370,7 +370,7 @@ mod test {
     fn halt_on_error_cb() -> Result<()> {
         let operator_id = OperatorId::new(0);
         let mut op: Backpressure = Config {
-            timeout: 100.0,
+            timeout: 100_000_000,
             steps: vec![1, 10, 100],
             method: Method::Pause,
         }
@@ -395,7 +395,7 @@ mod test {
         // this is over our limit of `100` so we syould move
         // one up the backup steps
         let mut m = Object::new();
-        m.insert("time".into(), 200.0.into());
+        m.insert("time".into(), 200_000_000.into());
 
         let mut op_meta = OpMeta::default();
         op_meta.insert(operator_id, OwnedValue::null());
@@ -471,14 +471,14 @@ mod test {
     fn walk_backoff() {
         let operator_id = OperatorId::new(0);
         let mut op: Backpressure = Config {
-            timeout: 100.0,
+            timeout: 100_000_000,
             steps: vec![1, 10, 100],
             method: Method::Discard,
         }
         .into();
         // An contraflow that fails the timeout
         let mut m = Object::new();
-        m.insert("time".into(), 200.0.into());
+        m.insert("time".into(), 200_000_000.into());
         let mut op_meta = OpMeta::default();
         op_meta.insert(operator_id, OwnedValue::null());
 
@@ -492,7 +492,7 @@ mod test {
 
         // A contraflow that passes the timeout
         let m = literal!({
-            "time": 99.0
+            "time": 99_000_000
         });
         let mut op_meta = OpMeta::default();
         op_meta.insert(operator_id, OwnedValue::null());


### PR DESCRIPTION
They have been in millis, but the runtime returned nanos, so we got a unit mismatch and those operators were useless.

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/202)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


