### PR TITLE
Add several new ES metadata options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### New features
 
 - Added the `gpubsub_consumer` connector
+- Added new metadata options to `elastic` connector: `version`, `version_type`, `retry_on_conflict`, `if_primary_term`, `if_seq_no`
 
 ### Fixes
 

--- a/src/connectors/tests/elastic.rs
+++ b/src/connectors/tests/elastic.rs
@@ -388,34 +388,39 @@ async fn connector_elastic() -> Result<()> {
     harness.send_to_sink(update_event, IN).await?;
     let out_event = out.get_event().await?;
     let meta = out_event.data.suffix().meta();
-    assert_eq!(literal!({
-        "elastic": {
-            "_id": "1234",
-            "_index": "my_index",
-            "_type": "_doc",
-            "version": 2,
-            "action": "update",
-            "success": true
-        }
-    }), meta);
-    assert_eq!(literal!({
-        "update": {
-            "_primary_term": 1,
-            "_shards": {
-                "total": 2,
-                "successful": 1,
-                "failed": 0
-            },
-            "_type": "_doc",
-            "_index": "my_index",
-            "result": "updated",
-            "_id": "1234",
-            "_seq_no": 4,
-            "status": 200,
-            "_version": 2
-        }
-    }), out_event.data.suffix().value());
-
+    assert_eq!(
+        literal!({
+            "elastic": {
+                "_id": "1234",
+                "_index": "my_index",
+                "_type": "_doc",
+                "version": 2,
+                "action": "update",
+                "success": true
+            }
+        }),
+        meta
+    );
+    assert_eq!(
+        literal!({
+            "update": {
+                "_primary_term": 1,
+                "_shards": {
+                    "total": 2,
+                    "successful": 1,
+                    "failed": 0
+                },
+                "_type": "_doc",
+                "_index": "my_index",
+                "result": "updated",
+                "_id": "1234",
+                "_seq_no": 4,
+                "status": 200,
+                "_version": 2
+            }
+        }),
+        out_event.data.suffix().value()
+    );
 
     // check what happens when ES isnt reachable
     container.stop();


### PR DESCRIPTION
* version
* version_type
* retry_on_conflict
* if_primary_term
* if_seq_no

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/203)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


