### PR TITLE
Ci package test

### DIFF
--- a/.github/workflows/validate-packages.yaml
+++ b/.github/workflows/validate-packages.yaml
@@ -1,0 +1,17 @@
+name: Validate package creation
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Build releases
+        run: make builds
+      - name: Creating release packages
+        run: make packages
+      - name: List files
+        run: ls packaging/out/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,11 +4975,29 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snmalloc-rs"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36acaace2719c972eab3ef6a6b3aee4495f0bf300f59715bb9cff6c5acf4ae20"
+dependencies = [
+ "snmalloc-sys 0.2.28",
+]
+
+[[package]]
+name = "snmalloc-rs"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad716cba37744e3db2c63486b77f1fbeeed268767ff47156b10b17677636e9c"
 dependencies = [
- "snmalloc-sys",
+ "snmalloc-sys 0.3.1",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a7e6e7d5fe756bee058ddedefc7e0a9f9c8dbaa9401b48ed3c17d6578e40b5"
+dependencies = [
+ "cmake",
 ]
 
 [[package]]
@@ -5841,7 +5859,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-async-std",
  "simd-json",
- "snmalloc-rs",
+ "snmalloc-rs 0.2.28",
  "surf",
  "tch",
  "temp-dir",
@@ -5875,7 +5893,7 @@ dependencies = [
  "lexical",
  "pretty_assertions",
  "simd-json",
- "snmalloc-rs",
+ "snmalloc-rs 0.3.1",
  "value-trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5842,7 +5842,6 @@ dependencies = [
  "signal-hook-async-std",
  "simd-json",
  "snmalloc-rs",
- "snmalloc-sys",
  "surf",
  "tch",
  "temp-dir",

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-APP=tremor-runtime
-DOCKER_VSN=$(shell grep 'ARG tag' docker/tremor-runtime.dockerfile | sed 's/.*=//')
-CARGO_VSN=$(shell grep '^version' Cargo.toml | sed -e 's/.*=[^"]*"//' -e 's/"$$//')
-VSN=$(DOCKER_VSN)
-YEAR=2018-2021
-
 RELEASE_TARGETS := \
 	x86_64-unknown-linux-gnu \
 	# x86_64-unknown-linux-musl \

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -39,10 +39,7 @@ serde_yaml = "0.8"
 signal-hook = "0.3"
 signal-hook-async-std = "0.2"
 simd-json = { version = "0.5", features = ["known-key"] }
-snmalloc-rs = { version = "=0.3.1", optional = false, feature = [
-    "qemu",
-    "usecxx17",
-] }
+snmalloc-rs = { version = "0.2" }
 surf = { version = "=2.3.2", default-features = false, features = [
     "encoding",
     "h1-client-rustls",

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -39,13 +39,10 @@ serde_yaml = "0.8"
 signal-hook = "0.3"
 signal-hook-async-std = "0.2"
 simd-json = { version = "0.5", features = ["known-key"] }
-# we need to stick with 0.2.26 as it includes its own libc
-# which allows us to build on older systems like centos 7
-# issues to track until we can loosen those restrictions:
-#   - https://github.com/microsoft/snmalloc/issues/328
-#   - https://github.com/SchrodingerZhu/snmalloc-rs/issues/145
-snmalloc-rs = { version = "=0.3.1", optional = false }
-snmalloc-sys = { version = "=0.3.1", optional = false }
+snmalloc-rs = { version = "=0.3.1", optional = false, feature = [
+    "qemu",
+    "usecxx17",
+] }
 surf = { version = "=2.3.2", default-features = false, features = [
     "encoding",
     "h1-client-rustls",

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -39,6 +39,8 @@ serde_yaml = "0.8"
 signal-hook = "0.3"
 signal-hook-async-std = "0.2"
 simd-json = { version = "0.5", features = ["known-key"] }
+# We need to stay with 0.2 for now as there are reasons that can be named for the need to be able to
+# compile and run on operating systems that are a decade old. (insert apropriate ammount rage)
 snmalloc-rs = { version = "0.2" }
 surf = { version = "=2.3.2", default-features = false, features = [
     "encoding",


### PR DESCRIPTION
# Pull request

## Description

This adds a package build test to CI so we can ensure that our ancient centos7 still builds stuff :sob: it also downgrades in malloc as it requires a kernel that is not older than 8 years. (I wish we could upgrade our kernel to something released in the past decade ...)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

🤷 