### PR TITLE
Improve error handling in the PubSub consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixes
+- Don't fail unrecoverably when the connecition to the server is lost in Google PubSub consumer.
+
 ## [0.12.2]
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Fixes
-- Don't fail unrecoverably when the connecition to the server is lost in Google PubSub consumer.
+- Don't fail unrecoverably when the connection to the server is lost in Google PubSub consumer.
 
 ## [0.12.2]
 ### New features


### PR DESCRIPTION
Signed-off-by: Ramona Luczkiewicz <rluczkiewicz@wayfair.com>

# Pull request

## Description

With these changes, the consumer will no longer unrecoverably fail when the connection to the server is lost.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ x The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

