### PR TITLE
Try to split out tests to speed up ci

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,26 @@ on:
 
 jobs:
   tests-linux:
+    strategy:
+      matrix:
+        include:
+          - project: "tremor-runtime"
+            covname: runtime
+            features: "--features integration"
+          - project: "tremor-api"
+            covname: api
+          - project: "tremor-cli"
+            covname: cli
+          - project: "tremor-common"
+            covname: common
+          - project: "tremor-influx"
+            covname: influx
+          - project: "tremor-pipeline"
+            covname: pipeline
+          - project: "tremor-script"
+            covname: script
+          - project: "tremor-value"
+            covname: value
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,11 +45,10 @@ jobs:
           PROPTEST_CASES: 2500
           RUSTFLAGS: -D warnings -C target-feature=+avx,+avx2,+sse4.2
           RUST_BACKTRACE: 1
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.txt --features integration
+        run: cargo llvm-cov --lcov --output-path lcov.txt -p ${{ matrix.project }} --all-targets ${{ matrix.features }}
       - uses: codecov/codecov-action@v3
         with:
-          #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./lcov.txt # optional
-          flags: unittests # optional
+          flags: ${{ matrix.covname }} # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)      

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 4
+    after_n_builds: 11
 
 coverage:
   precision: 2


### PR DESCRIPTION
# Pull request

## Description

This tires to separate testing for different workspace components to parallelize and spend less total time


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

perhaps