### PR TITLE
Update snmalloc to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,36 +4752,18 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snmalloc-rs"
-version = "0.2.28"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36acaace2719c972eab3ef6a6b3aee4495f0bf300f59715bb9cff6c5acf4ae20"
+checksum = "90bbab242a22c735dcd4c1441fffbe7004ea91f7d8fe7902cf283d72405ef978"
 dependencies = [
- "snmalloc-sys 0.2.28",
-]
-
-[[package]]
-name = "snmalloc-rs"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad716cba37744e3db2c63486b77f1fbeeed268767ff47156b10b17677636e9c"
-dependencies = [
- "snmalloc-sys 0.3.1",
+ "snmalloc-sys",
 ]
 
 [[package]]
 name = "snmalloc-sys"
-version = "0.2.28"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a7e6e7d5fe756bee058ddedefc7e0a9f9c8dbaa9401b48ed3c17d6578e40b5"
-dependencies = [
- "cmake",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d99830c399002567038c5566f70ecee0e335aeff3fd20f89901ac6170d6917"
+checksum = "80756c9f5dacaa9ff49afddb77ea18e80013228128ced3c2162f13306a225dd7"
 dependencies = [
  "cmake",
 ]
@@ -5580,7 +5562,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-async-std",
  "simd-json",
- "snmalloc-rs 0.2.28",
+ "snmalloc-rs",
  "surf",
  "tch",
  "temp-dir",
@@ -5614,7 +5596,7 @@ dependencies = [
  "lexical",
  "pretty_assertions",
  "simd-json",
- "snmalloc-rs 0.3.1",
+ "snmalloc-rs",
  "value-trait",
 ]
 

--- a/tremor-cli/Cargo.toml
+++ b/tremor-cli/Cargo.toml
@@ -41,11 +41,11 @@ signal-hook-async-std = "0.2"
 simd-json = { version = "0.5", features = ["known-key"] }
 # We need to stay with 0.2 for now as there are reasons that can be named for the need to be able to
 # compile and run on operating systems that are a decade old. (insert apropriate ammount rage)
-snmalloc-rs = { version = "0.2" }
+snmalloc-rs = { version = "0.3.3" }
 surf = { version = "=2.3.2", default-features = false, features = [
-    "encoding",
-    "h1-client-rustls",
-    "middleware-logger",
+  "encoding",
+  "h1-client-rustls",
+  "middleware-logger",
 ] }
 tremor-api = { version = "0.12.3", path = "../tremor-api" }
 tremor-common = { version = "0.12.3", path = "../tremor-common" }


### PR DESCRIPTION
# Pull request

## Description

snmalloc 0.3.1 did not work on centos 7, now all is good!

## Related

* Related Issues: https://github.com/microsoft/snmalloc/issues/544

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


