### PR TITLE
Bind udp client to 0.0.0.0:0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Don't fail unrecoverably when the connection to the server is lost in Google PubSub consumer.
 - Update bert operators to work with tremor 0.12
 - Avoid hangs in `elastic` connector when not connected as source via its `out` or `err` port.
+- Default udp client bind ip to `0.0.0.0:0` instead of `127.0.0.1:0`
 
 ## [0.12.2]
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ integration-local = [
   "crononome-integration",
   "metronome-integration",
   "socket-integration",
-  "tcp-integration",
+  "net-integration",
   "wal-integration",
 ]
 gcp-integration = []
@@ -276,7 +276,7 @@ file-integration = []
 crononome-integration = []
 metronome-integration = []
 socket-integration = []
-tcp-integration = []
+net-integration = []
 wal-integration = []
 tarpaulin-exclude = []
 # those are falky tests

--- a/src/connectors/tests/mod.rs
+++ b/src/connectors/tests/mod.rs
@@ -37,8 +37,10 @@ mod metronome;
 mod pause_resume;
 #[cfg(feature = "s3-integration")]
 mod s3;
-#[cfg(feature = "tcp-integration")]
+#[cfg(feature = "net-integration")]
 mod tcp;
+#[cfg(feature = "net-integration")]
+mod udp;
 #[cfg(feature = "socket-integration")]
 mod unix_socket;
 #[cfg(feature = "wal-integration")]
@@ -284,7 +286,7 @@ impl ConnectorHarness {
         feature = "http-integration",
         feature = "es-integration",
         feature = "socket-integration",
-        feature = "tcp-integration",
+        feature = "net-integration",
         feature = "ws-integration"
     ))]
     pub(crate) async fn send_to_sink(&self, event: Event, port: Cow<'static, str>) -> Result<()> {
@@ -353,7 +355,7 @@ impl TestPipeline {
         feature = "kafka-integration",
         feature = "es-integration",
         feature = "s3-integration",
-        feature = "tcp-integration",
+        feature = "net-integration",
     ))]
     pub(crate) async fn get_contraflow(&self) -> Result<Event> {
         match self.rx_cf.recv().timeout(Duration::from_secs(20)).await?? {

--- a/src/connectors/tests/udp.rs
+++ b/src/connectors/tests/udp.rs
@@ -1,0 +1,118 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::ConnectorHarness;
+use crate::{connectors::impls::udp, errors::Result};
+use tremor_common::ports::IN;
+use tremor_pipeline::Event;
+use tremor_value::prelude::*;
+
+#[async_std::test]
+async fn udp_no_bind() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let server_defn = literal!({
+      "codec": "string",
+      "config": {
+          "url": "127.0.0.1:4242",
+      }
+    });
+
+    let server_harness =
+        ConnectorHarness::new("udp_server", &udp::server::Builder::default(), &server_defn).await?;
+    let server_out = server_harness
+        .out()
+        .expect("No pipeline connected to 'out' port of udp_server connector");
+    server_harness.start().await?;
+    server_harness.wait_for_connected().await?;
+
+    let client_defn = literal!({
+      "codec": "string",
+      "config": {
+          "url": "127.0.0.1:4242",
+      }
+    });
+
+    let client_harness =
+        ConnectorHarness::new("udp_client", &udp::client::Builder::default(), &client_defn).await?;
+    client_harness.start().await?;
+    client_harness.wait_for_connected().await?;
+
+    let event1 = Event {
+        data: (Value::String("badger".into()), literal!({})).into(),
+        ..Event::default()
+    };
+    client_harness.send_to_sink(event1, IN).await?;
+    // send something to socket 2
+    let server_event = server_out.get_event().await?;
+    // send an event and route it via eventid to socket 2
+
+    assert_eq!(server_event.data.parts().0.as_str(), Some("badger"));
+
+    let (_out, err) = server_harness.stop().await?;
+    assert!(err.is_empty());
+    let (_out, err) = client_harness.stop().await?;
+    assert!(err.is_empty());
+    Ok(())
+}
+
+#[async_std::test]
+async fn udp_bind() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let server_defn = literal!({
+      "codec": "string",
+      "config": {
+          "url": "127.0.0.1:4242",
+      }
+    });
+
+    let server_harness =
+        ConnectorHarness::new("udp_server", &udp::server::Builder::default(), &server_defn).await?;
+    let server_out = server_harness
+        .out()
+        .expect("No pipeline connected to 'out' port of udp_server connector");
+    server_harness.start().await?;
+    server_harness.wait_for_connected().await?;
+
+    let client_defn = literal!({
+      "codec": "string",
+      "config": {
+          "url": "127.0.0.1:4242",
+          "bind": "127.0.0.1:4243",
+      }
+    });
+
+    let client_harness =
+        ConnectorHarness::new("udp_client", &udp::client::Builder::default(), &client_defn).await?;
+    client_harness.start().await?;
+    client_harness.wait_for_connected().await?;
+
+    let event1 = Event {
+        data: (Value::String("badger".into()), literal!({})).into(),
+        ..Event::default()
+    };
+    client_harness.send_to_sink(event1, IN).await?;
+    // send something to socket 2
+    let server_event = server_out.get_event().await?;
+    // send an event and route it via eventid to socket 2
+
+    assert_eq!(server_event.data.parts().0.as_str(), Some("badger"));
+
+    let (_out, err) = server_harness.stop().await?;
+    assert!(err.is_empty());
+    let (_out, err) = client_harness.stop().await?;
+    assert!(err.is_empty());
+    Ok(())
+}

--- a/tremor-cli/tests/integration/udp-postprocessors/before/config.troy
+++ b/tremor-cli/tests/integration/udp-postprocessors/before/config.troy
@@ -9,7 +9,7 @@ flow
   with
     codec = "string",
     config = { 
-      "url": "localhost:4242",
+      "url": "localhost:4243",
     }
   end;
 

--- a/tremor-cli/tests/integration/udp-postprocessors/config.troy
+++ b/tremor-cli/tests/integration/udp-postprocessors/config.troy
@@ -20,7 +20,8 @@ flow
     codec = "yaml",
     postprocessors = ["base64"],
     config = {
-      "url": "localhost:4242",
+      "url": "localhost:4243",
+      "bind": "localhost:4244"
     }
   end;
   


### PR DESCRIPTION
# Pull request

## Description

Defaults udp binding address to `0.0.0.0:0`.

## Related

* Related Issues: fixes #1776
* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/213)

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

🤷 