### PR TITLE
Gpubsub unavailable retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,18 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "async-std",
- "native-tls",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "async-net"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,7 +2392,6 @@ version = "6.5.1"
 source = "git+https://github.com/tremor-rs/http-client?rev=059b23e#059b23e5d615debe41a6a1cd1f4228579179a88c"
 dependencies = [
  "async-h1",
- "async-native-tls",
  "async-std",
  "async-tls 0.11.0",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ surf = { version = "=2.3.2", default-features = false, features = [
   "middleware-logger", # default feature, so we keep it
 ] }
 # We use our fork until: https://github.com/http-rs/http-client/pull/100 is merged
-http-client = { git = "https://github.com/tremor-rs/http-client", rev = "059b23e", features = [
+http-client = { git = "https://github.com/tremor-rs/http-client", rev = "059b23e", default-features = false, features = [
   "h1_client",
   "rustls",
 ] }

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,9 @@ coverage:
   round: down
   range: "70...100"
   status: # see https://docs.codecov.com/docs/commit-status
+    patch:
+      default:
+        target: 80%
     project:
       default:
         # basic

--- a/src/codec/json.rs
+++ b/src/codec/json.rs
@@ -162,4 +162,19 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn encode_into() -> Result<()> {
+        let value = literal!({"snot": ["badger", null, false, 1.5, 42]});
+        let codec: Box<dyn Codec> = Box::new(Json::<Unsorted>::default());
+        println!("{codec} {codec:?}"); // for coverage
+
+        let mut buf = vec![];
+        codec.encode_into(&value, &mut buf)?;
+        assert_eq!(
+            "{\"snot\":[\"badger\",null,false,1.5,42]}".to_string(),
+            String::from_utf8_lossy(&buf)
+        );
+        Ok(())
+    }
 }

--- a/src/connectors/sink.rs
+++ b/src/connectors/sink.rs
@@ -119,16 +119,6 @@ impl Default for SinkAck {
     }
 }
 
-impl From<bool> for SinkAck {
-    fn from(ok: bool) -> Self {
-        if ok {
-            Self::Ack
-        } else {
-            Self::Fail
-        }
-    }
-}
-
 /// Possible replies from asynchronous sinks via `reply_channel` from event or signal handling
 #[derive(Debug)]
 pub(crate) enum AsyncSinkReply {

--- a/src/connectors/tests/gpubsub/gsub.rs
+++ b/src/connectors/tests/gpubsub/gsub.rs
@@ -94,6 +94,7 @@ async fn simple_subscribe() -> Result<()> {
     let endpoint_clone = endpoint.clone();
 
     let connector_yaml: Value = literal!({
+        "metrics_interval_s": 1,
         "codec": "binary",
         "config":{
             "endpoint": endpoint,

--- a/tremor-script/src/ast/deploy.rs
+++ b/tremor-script/src/ast/deploy.rs
@@ -203,8 +203,8 @@ impl DeployEndpoint {
     /// Creates a new endpoint
     pub fn new<A, P>(alias: &A, port: &P, mid: &NodeMeta) -> Self
     where
-        A: ToString,
-        P: ToString,
+        A: ToString + ?Sized,
+        P: ToString + ?Sized,
     {
         Self {
             alias: alias.to_string(),


### PR DESCRIPTION
# Pull request

## Description

Retry the `streaming_pull` call if we get an `Unavailable` from google, which is not too uncommon. Before we were forcing the connector to reconnect, which had a big impact.
I do a retry after 1s with exponential backoff if it starts returning `Unavailable` immediately.
There is a maximum of 5 retries to not retry infinitely. This is all not exposed via config on purpose. Should it be exposed?

It feels hacky, so all feedback is welcome.

## Related

## Checklist



* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


