### PR TITLE
Downgrade serial test again and ignore all versions of this lib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     rebase-strategy: auto
     ignore:
       - dependency-name: "serial_test"
+        # ignore those versions, as they still make our test suite fail
+        # check this issue for progress on this: https://github.com/palfrey/serial_test/issues/68
+        versions: ["0.7.x", "0.8.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
     rebase-strategy: auto
     ignore:
       - dependency-name: "serial_test"
-        versions: ["0.7.x"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,22 +4504,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.8.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
- "futures",
  "lazy_static",
- "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "0.8.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ proptest = "1.0"
 regex = "1"
 # We downgraded to 0.6 because:
 # in the face of high concurrency serial_test 0.7.0 panics after 60 seconds
-serial_test = "=0.8"
+serial_test = "=0.6"
 signal-hook = "0.3"
 signal-hook-async-std = "0.2"
 tempfile = { version = "3.2" }


### PR DESCRIPTION
# Pull request

## Description

Now with infinite ignoring power for `serial_test`

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
snot
