### PR TITLE
added reverse function for arrays and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### New features
+- Add reverse functions and tests for arrays and strings, add sort test for arrays
+
 ## [0.12.4]
 
 ### Fixes

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -34,6 +34,22 @@ test::suite({
   "tags": [ "array" ],
   "tests": [
     test::test({
+      "name": "array sort 1",
+      "test": test::assert("array sort 1", array::sort([1,4,3]),[1,3,4])
+    }),
+    test::test({
+      "name": "array sort 2",
+      "test": test::assert("array sort 2", array::sort(["b","a","parrot"]),["a","b","parrot"])
+    }),
+    test::test({
+      "name": "array reverse 1",
+      "test": test::assert("array reverse 1", array::reverse([1,2,3]),[3,2,1])
+    }),
+    test::test({
+      "name": "array reverse 2",
+      "test": test::assert("array reverse 2", array::reverse(["fudge","brownies"]),["brownies","fudge"])
+    }),
+    test::test({
       "name": "array len 1",
       "test": test::assert("array len 1", array::len([]),0)
     }),
@@ -366,6 +382,10 @@ test::suite({
   "name": "String library tests",
   "tags": [ "string" ],
   "tests": [
+    test::test({
+      "name": "reverse",
+      "test": test::assert("reverse", string::reverse("cats"), "stac")
+    }),
     test::test({
       "name": "from_butf8_lossy",
       "test": test::assert("from_butf8_lossy", string::from_utf8_lossy(<< 115, 110, 111, 116 >>), "snot")

--- a/tremor-script/lib/std/array.tremor
+++ b/tremor-script/lib/std/array.tremor
@@ -87,8 +87,17 @@ intrinsic fn concatenate(left, right) as array::concatenate;
 ## Sorts an array
 ##
 ## > ```tremor
-## > array::concatenate([3, 2, 3, 1, 4]) == [1, 2, 3, 3, 4]
+## > array::sort([3, 2, 3, 1, 4]) == [1, 2, 3, 3, 4]
 ## > ```
 ##
 ## Returns an `array`
-intrinsic fn sort(left, right) as array::sort;
+intrinsic fn sort(array) as array::sort;
+
+## Reverses an array
+##
+## > ```tremor
+## > array::reverse([3, 2, 3, 1, 4]) == [4, 1, 3, 2, 3]
+## > ```
+##
+## Returns an `array`
+intrinsic fn reverse(array) as array::reverse;

--- a/tremor-script/lib/std/string.tremor
+++ b/tremor-script/lib/std/string.tremor
@@ -106,3 +106,8 @@ intrinsic fn from_utf8_lossy(bytes) as string::from_utf8_lossy;
 ##
 ## Returns a `binary`
 intrinsic fn into_binary(bytes) as string::into_binary;
+
+## Reverses a `string` 
+##
+## Returns a `string`
+intrinsic fn reverse(input) as string::reverse;

--- a/tremor-script/src/std_lib/array.rs
+++ b/tremor-script/src/std_lib/array.rs
@@ -117,6 +117,24 @@ mod test {
     use crate::registry::fun;
 
     #[test]
+    fn sort() {
+        let f = fun("array", "sort");
+        let v = Value::from(vec!["this", "is", "a", "test"]);
+        assert_val!(f(&[&v]), Value::from(vec!["a", "is", "test", "this"]));
+        let v = Value::from(vec![3, 2, 3, 1, 4]);
+        assert_val!(f(&[&v]), Value::from(vec![1, 2, 3, 3, 4]));
+    }
+
+    #[test]
+    fn reverse() {
+        let f = fun("array", "reverse");
+        let v = Value::from(vec!["this", "is", "a", "test"]);
+        assert_val!(f(&[&v]), Value::from(vec!["test", "a", "is", "this"]));
+        let v = Value::from(vec![1, 2, 3, 3, 4]);
+        assert_val!(f(&[&v]), Value::from(vec![4, 3, 3, 2, 1]));
+    }
+
+    #[test]
     fn len() {
         let f = fun("array", "len");
         let v = Value::from(vec!["this", "is", "a", "test"]);

--- a/tremor-script/src/std_lib/array.rs
+++ b/tremor-script/src/std_lib/array.rs
@@ -24,6 +24,11 @@ pub fn load(registry: &mut Registry) {
             output.sort();
             Ok(Value::from(output))
         }))
+        .insert(tremor_const_fn! (array|reverse(_context, _input: Array) {
+            let mut output = _input.clone();
+            output.reverse();
+            Ok(Value::from(output))
+        }))
         .insert(tremor_const_fn! (array|len(_context, _input: Array) {
             Ok(Value::from(_input.len() as i64))
         }))

--- a/tremor-script/src/std_lib/string.rs
+++ b/tremor-script/src/std_lib/string.rs
@@ -182,7 +182,7 @@ pub fn load(registry: &mut Registry) {
             "string".to_string(),
             "format".to_string(),
             Box::new(StringFormat::default()),
-        ));     
+        ));
 }
 
 #[cfg(test)]

--- a/tremor-script/src/std_lib/string.rs
+++ b/tremor-script/src/std_lib/string.rs
@@ -173,11 +173,16 @@ pub fn load(registry: &mut Registry) {
         ).insert(tremor_const_fn! (string|into_binary(_context, _input: String) {
                 Ok(Value::Bytes(_input.as_bytes().to_vec().into()))
             }),
+        ).insert(tremor_const_fn! (string|reverse(_context, _input: String) {
+                let input = _input.clone();
+                let output = input.chars().rev().collect::<String>();
+                Ok(Value::from(output))
+            }),
         ).insert(TremorFnWrapper::new(
             "string".to_string(),
             "format".to_string(),
             Box::new(StringFormat::default()),
-        ));
+        ));     
 }
 
 #[cfg(test)]

--- a/tremor-script/src/std_lib/string.rs
+++ b/tremor-script/src/std_lib/string.rs
@@ -198,6 +198,12 @@ mod test {
         assert_val!(f(&[&v]), "badger\u{fffd}");
     }
     #[test]
+    fn reverse() {
+        let f = fun("string", "reverse");
+        let v = Value::from("badger");
+        assert_val!(f(&[&v]), Value::from("regdab"));
+    }
+    #[test]
     fn into_binary() {
         let f = fun("string", "into_binary");
         let v = Value::from("badger");


### PR DESCRIPTION

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->
Added a reverse function for arrays and for strings

## Related


* Related Issues: fixes #1790


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


