### PR TITLE
Redesign how connectors can stop the runtime.

### DIFF
--- a/src/connectors/impls/crononome.rs
+++ b/src/connectors/impls/crononome.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 mod handler;
 
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_conector_def, system::KillSwitch};
 use handler::{ChronomicQueue, CronEntryInt};
 use serde_yaml::Value as YamlValue;
 use tremor_common::time::nanotime;
@@ -41,6 +41,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         raw: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let raw = Config::new(raw)?;
         let payload = if let Some(yaml_entries) = raw.entries {

--- a/src/connectors/impls/discord.rs
+++ b/src/connectors/impls/discord.rs
@@ -17,7 +17,10 @@
 mod handler;
 mod utils;
 
-use crate::connectors::{prelude::*, spawn_task, Context};
+use crate::{
+    connectors::{prelude::*, spawn_task, Context},
+    system::KillSwitch,
+};
 use async_std::{
     channel::{bounded, Receiver, Sender},
     task::JoinHandle,
@@ -49,6 +52,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config: Config = Config::new(config)?;
 

--- a/src/connectors/impls/dns/client.rs
+++ b/src/connectors/impls/dns/client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::connectors::prelude::*;
+use crate::{connectors::prelude::*, system::KillSwitch};
 use async_std::channel::{bounded, Receiver, Sender};
 use async_std_resolver::{
     lookup::Lookup,
@@ -33,7 +33,12 @@ impl ConnectorBuilder for Builder {
         "dns_client".into()
     }
 
-    async fn build(&self, _id: &str, _raw_config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
+    async fn build(
+        &self,
+        _id: &str,
+        _raw_config: &ConnectorConfig,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
         let (tx, rx) = bounded(128);
         Ok(Box::new(Client { tx, rx }))
     }

--- a/src/connectors/impls/elastic.rs
+++ b/src/connectors/impls/elastic.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 use std::{fmt::Display, sync::atomic::AtomicBool};
 
+use crate::system::KillSwitch;
 use crate::{
     connectors::{
         impls::http::utils::Header, prelude::*, sink::concurrency_cap::ConcurrencyCap,
@@ -101,6 +102,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         raw_config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw_config)?;
         if config.nodes.is_empty() {
@@ -945,10 +947,11 @@ mod tests {
         let id = "my_elastic";
         let builder = super::Builder::default();
         let connector_config = ConnectorConfig::from_config(id, builder.connector_type(), &config)?;
+        let kill_switch = KillSwitch::dummy();
         assert_eq!(
             String::from("Invalid Definition for connector \"my_elastic\": empty nodes provided"),
             builder
-                .build("my_elastic", &connector_config)
+                .build("my_elastic", &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap()
@@ -970,12 +973,13 @@ mod tests {
         let id = "my_elastic";
         let builder = super::Builder::default();
         let connector_config = ConnectorConfig::from_config(id, builder.connector_type(), &config)?;
+        let kill_switch = KillSwitch::dummy();
         assert_eq!(
             String::from(
                 "Invalid Definition for connector \"my_elastic\": relative URL without a base"
             ),
             builder
-                .build("my_elastic", &connector_config)
+                .build("my_elastic", &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap()

--- a/src/connectors/impls/file.rs
+++ b/src/connectors/impls/file.rs
@@ -99,6 +99,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         Ok(Box::new(File { config }))

--- a/src/connectors/impls/gbq/writer.rs
+++ b/src/connectors/impls/gbq/writer.rs
@@ -63,6 +63,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         Ok(Box::new(Gbq { config }))

--- a/src/connectors/impls/gpubsub/consumer.rs
+++ b/src/connectors/impls/gpubsub/consumer.rs
@@ -73,6 +73,7 @@ impl ConnectorBuilder for Builder {
         alias: &str,
         _: &ConnectorConfig,
         raw: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw)?;
         let url = Url::<HttpsDefaults>::parse(config.endpoint.as_str())?;

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -14,7 +14,8 @@
 
 use crate::connectors::google::AuthInterceptor;
 use crate::connectors::prelude::{
-    Attempt, ErrorKind, EventSerializer, SinkAddr, SinkContext, SinkManagerBuilder, SinkReply, Url,
+    Attempt, ErrorKind, EventSerializer, KillSwitch, SinkAddr, SinkContext, SinkManagerBuilder,
+    SinkReply, Url,
 };
 use crate::connectors::sink::Sink;
 use crate::connectors::utils::url::HttpsDefaults;
@@ -62,6 +63,7 @@ impl ConnectorBuilder for Builder {
         _alias: &str,
         _config: &ConnectorConfig,
         raw_config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw_config)?;
 

--- a/src/connectors/impls/http/client.rs
+++ b/src/connectors/impls/http/client.rs
@@ -90,6 +90,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         connector_config: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
 

--- a/src/connectors/impls/http/server.rs
+++ b/src/connectors/impls/http/server.rs
@@ -73,6 +73,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         raw_config: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         let tls_server_config = config.tls.clone();

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -80,6 +80,7 @@ impl ConnectorBuilder for Builder {
         alias: &str,
         config: &ConnectorConfig,
         raw_config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let metrics_interval_s = config.metrics_interval_s;
         let config = Config::new(raw_config)?;

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -78,6 +78,7 @@ impl ConnectorBuilder for Builder {
         alias: &str,
         config: &ConnectorConfig,
         raw_config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let metrics_interval_s = config.metrics_interval_s;
         let config = Config::new(raw_config)?;

--- a/src/connectors/impls/kv.rs
+++ b/src/connectors/impls/kv.rs
@@ -184,6 +184,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config: Config = Config::new(config)?;
         if !PathBuf::from(&config.dir).is_dir().await {

--- a/src/connectors/impls/metrics.rs
+++ b/src/connectors/impls/metrics.rs
@@ -55,7 +55,12 @@ impl ConnectorBuilder for Builder {
     fn connector_type(&self) -> ConnectorType {
         "metrics".into()
     }
-    async fn build(&self, _id: &str, _config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
+    async fn build(
+        &self,
+        _id: &str,
+        _config: &ConnectorConfig,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
         Ok(Box::new(MetricsConnector::new()))
     }
 }

--- a/src/connectors/impls/metronome.rs
+++ b/src/connectors/impls/metronome.rs
@@ -40,6 +40,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         raw: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw)?;
         let origin_uri = EventOriginUri {
@@ -138,7 +139,7 @@ mod tests {
 
     use crate::{
         config::Reconnect,
-        connectors::ConnectorBuilder,
+        connectors::{prelude::KillSwitch, ConnectorBuilder},
         errors::{Error, Kind as ErrorKind, Result},
     };
     #[async_std::test]
@@ -153,9 +154,10 @@ mod tests {
             reconnect: Reconnect::None,
             metrics_interval_s: Some(5),
         };
+        let kill_switch = KillSwitch::dummy();
         assert!(matches!(
             builder
-                .build("snot", &connector_config)
+                .build("snot", &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap(),

--- a/src/connectors/impls/null.rs
+++ b/src/connectors/impls/null.rs
@@ -26,7 +26,12 @@ impl ConnectorBuilder for Builder {
         "null".into()
     }
 
-    async fn build(&self, _alias: &str, _config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
+    async fn build(
+        &self,
+        _alias: &str,
+        _config: &ConnectorConfig,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
         Ok(Box::new(Null {}))
     }
 }

--- a/src/connectors/impls/otel/client.rs
+++ b/src/connectors/impls/otel/client.rs
@@ -70,6 +70,7 @@ impl ConnectorBuilder for Builder {
         _id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         let origin_uri = EventOriginUri {
@@ -211,7 +212,8 @@ mod tests {
         )?;
 
         let builder = super::Builder::default();
-        let _connector = builder.build("foo", &config).await?;
+        let kill_switch = KillSwitch::dummy();
+        let _connector = builder.build("foo", &config, &kill_switch).await?;
 
         Ok(())
     }

--- a/src/connectors/impls/otel/server.rs
+++ b/src/connectors/impls/otel/server.rs
@@ -70,6 +70,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let origin_uri = EventOriginUri {
             scheme: "tremor-otel-server".to_string(),
@@ -210,7 +211,8 @@ mod tests {
         )?;
 
         let builder = super::Builder::default();
-        let _connector = builder.build("foo", &config).await?;
+        let kill_switch = KillSwitch::dummy();
+        let _connector = builder.build("foo", &config, &kill_switch).await?;
 
         Ok(())
     }

--- a/src/connectors/impls/s3/reader.rs
+++ b/src/connectors/impls/s3/reader.rs
@@ -87,6 +87,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = S3SourceConfig::new(config)?;
 

--- a/src/connectors/impls/s3/writer.rs
+++ b/src/connectors/impls/s3/writer.rs
@@ -62,6 +62,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = S3Config::new(config)?;
 

--- a/src/connectors/impls/stdio.rs
+++ b/src/connectors/impls/stdio.rs
@@ -59,7 +59,12 @@ impl ConnectorBuilder for Builder {
     fn connector_type(&self) -> ConnectorType {
         "stdio".into()
     }
-    async fn build(&self, _id: &str, _raw_config: &ConnectorConfig) -> Result<Box<dyn Connector>> {
+    async fn build(
+        &self,
+        _id: &str,
+        _raw_config: &ConnectorConfig,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
         Ok(Box::new(StdStreamConnector {}))
     }
 }

--- a/src/connectors/impls/tcp/client.rs
+++ b/src/connectors/impls/tcp/client.rs
@@ -71,6 +71,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         if config.url.port().is_none() {

--- a/src/connectors/impls/tcp/server.rs
+++ b/src/connectors/impls/tcp/server.rs
@@ -70,6 +70,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> crate::errors::Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         if config.url.port().is_none() {

--- a/src/connectors/impls/udp/client.rs
+++ b/src/connectors/impls/udp/client.rs
@@ -46,6 +46,7 @@ impl ConnectorBuilder for Builder {
         _id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config: Config = Config::new(config)?;
         if config.url.port().is_none() {

--- a/src/connectors/impls/udp/server.rs
+++ b/src/connectors/impls/udp/server.rs
@@ -45,6 +45,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         raw: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw)?;
         Ok(Box::new(UdpServer { config }))

--- a/src/connectors/impls/unix_socket/client.rs
+++ b/src/connectors/impls/unix_socket/client.rs
@@ -46,6 +46,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         conf: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(conf)?;
         let (source_tx, source_rx) = bounded(crate::QSIZE.load(Ordering::Relaxed));

--- a/src/connectors/impls/unix_socket/server.rs
+++ b/src/connectors/impls/unix_socket/server.rs
@@ -69,6 +69,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         let (sink_tx, sink_rx) = bounded(crate::QSIZE.load(Ordering::Relaxed));

--- a/src/connectors/impls/wal.rs
+++ b/src/connectors/impls/wal.rs
@@ -48,6 +48,7 @@ impl ConnectorBuilder for Builder {
         _: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config: Config = Config::new(config)?;
 

--- a/src/connectors/impls/ws/client.rs
+++ b/src/connectors/impls/ws/client.rs
@@ -67,6 +67,7 @@ impl ConnectorBuilder for Builder {
         id: &str,
         _: &ConnectorConfig,
         config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         let host = config

--- a/src/connectors/impls/ws/server.rs
+++ b/src/connectors/impls/ws/server.rs
@@ -59,6 +59,7 @@ impl ConnectorBuilder for Builder {
         _id: &str,
         _: &ConnectorConfig,
         raw_config: &Value,
+        _kill_switch: &KillSwitch,
     ) -> crate::errors::Result<Box<dyn Connector>> {
         let config = Config::new(raw_config)?;
 

--- a/src/connectors/prelude.rs
+++ b/src/connectors/prelude.rs
@@ -31,6 +31,7 @@ pub(crate) use crate::connectors::{
     StreamDone, StreamIdGen, ACCEPT_TIMEOUT,
 };
 pub(crate) use crate::errors::{Error, Kind as ErrorKind, Result};
+pub(crate) use crate::system::KillSwitch;
 pub(crate) use crate::utils::hostname;
 pub(crate) use crate::{Event, QSIZE};
 pub(crate) use std::sync::atomic::Ordering;

--- a/src/connectors/tests/bench.rs
+++ b/src/connectors/tests/bench.rs
@@ -43,8 +43,13 @@ async fn stop_after_events() -> Result<()> {
       }
     });
     let (world, world_handle) = World::start(WorldConfig::default()).await?;
-    let harness =
-        ConnectorHarness::new(function_name!(), &bench::Builder::new(world.clone()), &defn).await?;
+    let harness = ConnectorHarness::new_with_kill_switch(
+        function_name!(),
+        &bench::Builder::default(),
+        &defn,
+        world.kill_switch,
+    )
+    .await?;
     let out = harness.out().expect("No out pipeline connected");
     harness.start().await?;
     harness.wait_for_connected().await?;
@@ -88,8 +93,13 @@ async fn stop_after_secs() -> Result<()> {
     });
 
     let (world, world_handle) = World::start(WorldConfig::default()).await?;
-    let harness =
-        ConnectorHarness::new(function_name!(), &bench::Builder::new(world.clone()), &defn).await?;
+    let harness = ConnectorHarness::new_with_kill_switch(
+        function_name!(),
+        &bench::Builder::default(),
+        &defn,
+        world.kill_switch,
+    )
+    .await?;
     let out = harness.out().expect("No out pipeline connected");
     harness.start().await?;
     harness.wait_for_connected().await?;


### PR DESCRIPTION
# Pull request

## Description

This introduces a new struct KillSwitch, that is passed into the ConnectorBuilder. It only allows to stop the runtime, nothing else.
The reason for this refactoring is that this is easier to use for the PDK across the ABI boundary.


## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: #1597

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


