### PR TITLE
Add initial GCP logging write connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### New features
+- Add `gcl_writer` Google Cloud Platform Cloud Logging connector for writing log entries
 - Add reverse functions and tests for arrays and strings, add sort test for arrays
 - Add a ClickHouse connector
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ aws-smithy-http = "0.45.0"
 googapis = { version = "0.6", default-features = false, features = [
   "google-pubsub-v1",
   "google-cloud-bigquery-storage-v1",
+  "google-logging-v2",
 ] }
 gouth = { version = "0.2" }
 http = "0.2.8"

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -1208,6 +1208,7 @@ pub(crate) fn builtin_connector_types() -> Vec<Box<dyn ConnectorBuilder + 'stati
         Box::new(impls::gpubsub::consumer::Builder::default()),
         Box::new(impls::gpubsub::producer::Builder::default()),
         Box::new(impls::clickhouse::Builder::default()),
+        Box::new(impls::gcl::writer::Builder::default()),
     ]
 }
 

--- a/src/connectors/impls.rs
+++ b/src/connectors/impls.rs
@@ -32,8 +32,8 @@ pub(crate) mod exit;
 pub(crate) mod file;
 /// Google Cloud Platform
 pub(crate) mod gbq;
-pub(crate) mod gpubsub;
 pub(crate) mod gcl;
+pub(crate) mod gpubsub;
 /// HTTP
 pub(crate) mod http;
 /// Kafka consumer and producer

--- a/src/connectors/impls.rs
+++ b/src/connectors/impls.rs
@@ -30,9 +30,10 @@ pub(crate) mod elastic;
 pub(crate) mod exit;
 /// file connector implementation
 pub(crate) mod file;
-/// Google Big Query
+/// Google Cloud Platform
 pub(crate) mod gbq;
 pub(crate) mod gpubsub;
+pub(crate) mod gcl;
 /// HTTP
 pub(crate) mod http;
 /// Kafka consumer and producer

--- a/src/connectors/impls/gcl.rs
+++ b/src/connectors/impls/gcl.rs
@@ -1,0 +1,77 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rand::Rng;
+use tremor_script::{tremor_fn, Registry, Value};
+
+pub(crate) mod writer;
+
+// The span ID within the trace associated with the log entry.
+//  For Trace spans, this is the same format that the Trace API v2
+//  uses: a 16-character hexadecimal encoding of an 8-byte array,
+// such as 000000000000004a
+fn random_span_id_value(ingest_ns_seed: u64) -> Value<'static> {
+    let mut rng = tremor_common::rand::make_prng(ingest_ns_seed);
+    let span_id: String = (0..8)
+        .map(|_| rng.gen::<u8>())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    Value::from(span_id)
+}
+
+fn random_trace_id_value(ingest_ns_seed: u64) -> Value<'static> {
+    let mut rng = tremor_common::rand::make_prng(ingest_ns_seed);
+    let span_id: String = (0..16)
+        .map(|_| rng.gen::<u8>())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    Value::from(span_id)
+}
+
+/// Extend function registry with `GCP Cloud Logging` support
+pub fn load(registry: &mut Registry) {
+    registry
+        .insert(tremor_fn! (google_logging|gen_span_id_string(ctx) {
+            Ok(random_span_id_value(ctx.ingest_ns()))
+        }))
+        .insert(tremor_fn! (google_logging|gen_trace_id_string(ctx) {
+            Ok(random_trace_id_value(ctx.ingest_ns()))
+        }));
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use test_case::test_case;
+    use tremor_script::{registry, EventContext};
+
+    #[test_case("gen_span_id_string" ; "google_logging::gen_span_id_string")]
+    #[test_case("gen_trace_id_string" ; "google_logging::gen_trace_id_string")]
+    fn test_tremor_fns(fun_name: &str) {
+        let mut ok_count = 0;
+        let mut reg = registry::registry();
+        load(&mut reg);
+
+        let f = reg.find("google_logging", fun_name);
+
+        if let Ok(f) = f {
+            let context = EventContext::default();
+            let r = f.invoke(&context, &[]);
+            assert!(r.is_ok());
+            ok_count += 1;
+        }
+
+        assert_eq!(1, ok_count);
+    }
+}

--- a/src/connectors/impls/gcl/writer.rs
+++ b/src/connectors/impls/gcl/writer.rs
@@ -97,7 +97,7 @@ pub(crate) struct Config {
     pub default_severity: i32,
 
     /// This setting sets a default set of labels that can be overriden on a per event
-    /// // basis through metadata
+    /// basis through metadata
     #[serde(default = "Default::default")]
     pub labels: HashMap<String, String>,
 }
@@ -180,6 +180,7 @@ fn value_to_monitored_resource(
         Some(from) => {
             let vt = from.value_type();
             match from {
+                // Consider refactoring for unwrap_or_default when #1819 is resolved
                 OwnedValue::Object(from) => {
                     let kind = from.get("type");
                     let kind = kind.as_str();

--- a/src/connectors/impls/gcl/writer.rs
+++ b/src/connectors/impls/gcl/writer.rs
@@ -1,0 +1,318 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod meta;
+mod sink;
+
+use crate::connectors::impls::gcl::writer::sink::GclSink;
+use crate::connectors::prelude::*;
+use crate::connectors::{Connector, ConnectorBuilder, ConnectorConfig, ConnectorType};
+use crate::errors::Error;
+use googapis::google::api::MonitoredResource;
+use googapis::google::logging::r#type::LogSeverity;
+use serde::Deserialize;
+use simd_json::OwnedValue;
+use std::collections::HashMap;
+use tremor_pipeline::ConfigImpl;
+
+#[derive(Deserialize, Clone)]
+pub(crate) struct Config {
+    /// The default `log_name` for this configuration or `default` if not provided.
+    /// The `log_name` field can be overridden in metadata.
+    ///
+    /// From the protocol buffers specification:
+    ///
+    /// Optional. A default log resource name that is assigned to all log entries in entries that do not specify a value for log_name:
+    ///
+    /// "projects/\[PROJECT_ID]/logs/[LOG_ID\]"
+    /// "organizations/\[ORGANIZATION_ID]/logs/[LOG_ID\]"
+    /// "billingAccounts/\[BILLING_ACCOUNT_ID]/logs/[LOG_ID\]"
+    /// "folders/\[FOLDER_ID]/logs/[LOG_ID\]"
+    /// \[LOG_ID\] must be URL-encoded. For example:
+    ///
+    /// "projects/my-project-id/logs/syslog"
+    /// "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"
+    /// The permission logging.logEntries.create is needed on each project, organization, billing account, or folder that is receiving new log entries, whether the resource is specified in logName or in an individual log entry.
+    pub log_name: Option<String>,
+
+    /// The default monitored resource for the log entries being written.
+    ///
+    /// From the protocol buffers specification:
+    ///
+    /// Optional. A default monitored resource object that is assigned to all log entries in entries that do not specify a value for resource. Example:
+    ///
+    /// ```json
+    /// { "type": "gce_instance",
+    /// "labels": {
+    ///   "zone": "us-central1-a", "instance_id": "00000000000000000000" }}
+    /// ```    
+    #[serde(default = "Default::default")]
+    pub resource: Option<simd_json::OwnedValue>,
+
+    /// This setting sets the behaviour of the connector with respect to whether valid entries should
+    /// be written even if some entries in a batch set to Google Cloud Logging are invalid. Defaults to
+    /// false
+    ///
+    /// From the protocol buffers specification:
+    ///
+    /// Optional. Whether valid entries should be written even if some other entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any entry is not written, then the response status is the error associated with one of the failed entries and the response includes error details keyed by the entries' zero-based index in the entries.write method.
+    #[serde(default = "default_partial_success")]
+    pub partial_success: bool,
+
+    /// This setting enables a sanity check for validating that log entries are well formed and
+    /// and valid by exercising the connector to write entries where resulting entries are not
+    /// persisted. Useful primarily during initial exploration and configuration or after
+    /// large configuration changes as a sanity check.
+    ///
+    /// From the protocol buffers specification:
+    ///
+    /// Optional. If true, the request should expect normal response, but the entries won't be persisted nor exported. Useful for checking whether the logging API endpoints are working properly before sending valuable data.
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+
+    /// Sets a connection timeout for connections to the GCP logging endpoint
+    /// that applies during connection
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout: u64,
+
+    /// Sets a request timeout for requests to the GCP logging endpoint
+    /// that applies for each request sent to the endpoint
+    #[serde(default = "default_request_timeout")]
+    pub request_timeout: u64,
+
+    /// This setting sets a default log severity that can be overriden on a per event
+    /// basis through metadata
+    #[serde(default = "default_log_severity")]
+    pub default_severity: i32,
+
+    /// This setting sets a default set of labels that can be overriden on a per event
+    /// // basis through metadata
+    #[serde(default = "Default::default")]
+    pub labels: HashMap<String, String>,
+}
+
+fn default_partial_success() -> bool {
+    false
+}
+
+fn default_dry_run() -> bool {
+    false
+}
+
+fn default_connect_timeout() -> u64 {
+    1_000_000_000 // 1 second
+}
+
+fn default_request_timeout() -> u64 {
+    10_000_000_000 // 10 seconds
+}
+
+fn default_log_severity() -> i32 {
+    LogSeverity::Default as i32
+}
+
+impl Config {
+    fn default_log_name(&self) -> String {
+        // Use user supplied default, if provided
+        if let Some(has_usersupplied_default) = &self.log_name {
+            return has_usersupplied_default.clone();
+        }
+
+        // Use hardwired `default`, if no user supplied default provided
+        "default".to_string()
+    }
+
+    pub(crate) fn log_name(&self, meta: Option<&Value>) -> String {
+        // Override for a specific per event log_name
+        if let Some(has_meta) = meta {
+            if let Some(log_name) = has_meta.get("log_name") {
+                return log_name.to_string();
+            }
+        }
+
+        self.default_log_name()
+    }
+
+    pub(crate) fn log_severity(&self, meta: Option<&Value>) -> Result<i32> {
+        // Override for a specific per event severity
+        if let Some(has_meta) = meta {
+            if let Some(log_severity) = has_meta.get("log_severity") {
+                return log_severity
+                    .as_i32()
+                    .ok_or_else(|| "log_severity is not an integer".into());
+            };
+        }
+
+        Ok(self.default_severity)
+    }
+
+    pub(crate) fn labels(meta: Option<&Value>) -> HashMap<String, String> {
+        let mut labels = HashMap::new();
+
+        if let Some(has_meta) = meta.get_object("labels") {
+            for (k, v) in has_meta.iter() {
+                labels.insert(k.to_string(), v.to_string());
+            }
+        }
+
+        labels
+    }
+}
+
+impl ConfigImpl for Config {}
+
+fn value_to_monitored_resource(
+    from: Option<&simd_json::OwnedValue>,
+) -> Result<Option<MonitoredResource>> {
+    match from {
+        None => Ok(None),
+        Some(from) => {
+            let vt = from.value_type();
+            match from {
+                OwnedValue::Object(from) => {
+                    let kind = from.get("type");
+                    let kind = kind.as_str();
+                    let maybe_labels = from.get("labels");
+                    let labels: HashMap<String, String> = match maybe_labels {
+                        None => HashMap::new(),
+                        Some(labels) => labels
+                            .as_object()
+                            .ok_or_else(|| {
+                                Error::from(ErrorKind::GclTypeMismatch("Value::Object", vt))
+                            })?
+                            .iter()
+                            .map(|(key, value)| {
+                                let key = key.to_string();
+                                let value = value.to_string();
+                                (key, value)
+                            })
+                            .collect(),
+                    };
+                    Ok(Some(MonitoredResource {
+                        r#type: match kind {
+                            None => "".to_string(),
+                            Some(kind) => kind.to_string(),
+                        },
+                        labels,
+                    }))
+                }
+                _otherwise => Err(Error::from(ErrorKind::GclTypeMismatch(
+                    "Value::Object",
+                    from.value_type(),
+                ))),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Builder {}
+
+struct Gcl {
+    config: Config,
+}
+
+#[async_trait::async_trait]
+impl Connector for Gcl {
+    async fn create_sink(
+        &mut self,
+        sink_context: SinkContext,
+        builder: SinkManagerBuilder,
+    ) -> Result<Option<SinkAddr>> {
+        let sink = GclSink::new(self.config.clone());
+
+        builder.spawn(sink, sink_context).map(Some)
+    }
+
+    fn codec_requirements(&self) -> CodecReq {
+        CodecReq::Structured
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectorBuilder for Builder {
+    fn connector_type(&self) -> ConnectorType {
+        "gcl_writer".into()
+    }
+
+    async fn build_cfg(
+        &self,
+        _id: &str,
+        _: &ConnectorConfig,
+        raw: &Value,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
+        Ok(Box::new(Gcl {
+            config: Config::new(raw)?,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_to_monitored_resource_conversion() -> Result<()> {
+        let mut ok_count = 0;
+        let from: OwnedValue = literal!({
+            "type": "gce_instance".to_string(),
+            "labels": {
+              "zone": "us-central1-a",
+              "instance_id": "00000000000000000000",
+            }
+        })
+        .into();
+        let value = value_to_monitored_resource(Some(&from))?;
+        if let Some(value) = value {
+            assert_eq!("gce_instance", &value.r#type);
+            assert_eq!("us-central1-a".to_string(), value.labels["zone"]);
+            assert_eq!(
+                "00000000000000000000".to_string(),
+                value.labels["instance_id"]
+            );
+            ok_count += 1;
+        } else {
+            return Err("Skipped test asserts due to serialization error".into());
+        }
+
+        let from: OwnedValue = literal!({
+            "type": "gce_instance".to_string(),
+        })
+        .into();
+        let value = value_to_monitored_resource(Some(&from))?;
+        if let Some(value) = value {
+            assert_eq!(0, value.labels.len());
+            ok_count += 1;
+        } else {
+            return Err("Skipped test asserts due to serialization error".into());
+        }
+
+        let from: OwnedValue = literal!({
+            "type": "gce_instance".to_string(),
+            "labels": [ "snot" ]
+        })
+        .into();
+        let bad_labels = value_to_monitored_resource(Some(&from));
+        assert!(bad_labels.is_err());
+
+        let from = literal!(["snot"]);
+        let from: OwnedValue = from.into();
+        let bad_value = value_to_monitored_resource(Some(&from));
+        assert!(bad_value.is_err());
+
+        assert_eq!(2, ok_count);
+        Ok(())
+    }
+}

--- a/src/connectors/impls/gcl/writer.rs
+++ b/src/connectors/impls/gcl/writer.rs
@@ -17,7 +17,7 @@ mod sink;
 
 use crate::connectors::impls::gcl::writer::sink::GclSink;
 use crate::connectors::prelude::*;
-use crate::connectors::{Connector, ConnectorBuilder, ConnectorConfig, ConnectorType};
+use crate::connectors::{Alias, Connector, ConnectorBuilder, ConnectorConfig, ConnectorType};
 use crate::errors::Error;
 use googapis::google::api::MonitoredResource;
 use googapis::google::logging::r#type::LogSeverity;
@@ -249,7 +249,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _id: &str,
+        _id: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gcl/writer/meta.rs
+++ b/src/connectors/impls/gcl/writer/meta.rs
@@ -1,0 +1,425 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::Result;
+use googapis::google::logging::{
+    r#type::HttpRequest,
+    v2::{LogEntryOperation, LogEntrySourceLocation},
+};
+use tremor_value::Value;
+use value_trait::ValueAccess;
+
+pub(crate) fn get_or_default(meta: Option<&Value>, key: &str) -> String {
+    meta.get_str(key).unwrap_or_default().to_string()
+}
+
+pub(crate) fn insert_id(meta: Option<&Value>) -> String {
+    get_or_default(meta, "insert_id")
+}
+
+pub(crate) fn http_request(meta: Option<&Value>) -> Option<HttpRequest> {
+    // Override for a specific per event trace
+    let meta = meta?;
+    let http_request = meta.get("http_request")?;
+
+    Some(HttpRequest {
+        request_method: http_request
+            .get("request_method")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        request_url: http_request
+            .get("request_url")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        request_size: http_request.get("request_size").as_i64().unwrap_or(0),
+        status: http_request.get("status").as_i32().unwrap_or(0),
+        response_size: http_request.get("response_size").as_i64().unwrap_or(0),
+        user_agent: http_request
+            .get("user_agent")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        remote_ip: http_request
+            .get("remote_ip")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        server_ip: http_request
+            .get("server_ip")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        referer: http_request
+            .get("referer")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        latency: match http_request.get("latency").as_u64().unwrap_or(0) {
+            0 => None,
+            otherwise => Some(std::time::Duration::from_nanos(otherwise).into()),
+        },
+        cache_lookup: http_request.get("cache_lookup").as_bool().unwrap_or(false),
+        cache_hit: http_request.get("cache_hit").as_bool().unwrap_or(false),
+        cache_validated_with_origin_server: http_request
+            .get("cache_validated_with_origin_server")
+            .as_bool()
+            .unwrap_or(false),
+        cache_fill_bytes: http_request.get("cache_fill_bytes").as_i64().unwrap_or(0),
+        protocol: http_request
+            .get("protocol")
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+    })
+}
+
+pub(crate) fn operation(meta: Option<&Value>) -> Option<LogEntryOperation> {
+    let meta = meta?;
+    // Override for a specific per event trace
+    if let Some(operation @ Value::Object(_)) = meta.get("operation") {
+        return Some(LogEntryOperation {
+            id: operation.get_str("id").unwrap_or("").to_string(),
+            producer: operation.get_str("producer").unwrap_or("").to_string(),
+            first: operation.get_bool("first").unwrap_or(false),
+            last: operation.get_bool("last").unwrap_or(false),
+        });
+    }
+
+    // Otherwise, None as mapping is optional
+    None
+}
+
+pub(crate) fn trace(meta: Option<&Value>) -> String {
+    get_or_default(meta, "trace")
+}
+
+pub(crate) fn span_id(meta: Option<&Value>) -> String {
+    get_or_default(meta, "span_id")
+}
+
+pub(crate) fn trace_sampled(meta: Option<&Value>) -> Result<bool> {
+    // Override for a specific per event severity
+    if let Some(has_meta) = meta {
+        if let Some(trace_sampled) = has_meta.get("trace_sampled") {
+            return trace_sampled
+                .as_bool()
+                .ok_or_else(|| "trace_sampled is not a boolean".into());
+        };
+    }
+
+    Ok(false)
+}
+
+pub(crate) fn source_location(meta: Option<&Value>) -> Option<LogEntrySourceLocation> {
+    let has_meta = meta?;
+    // Override for a specific per event trace
+    if let Some(loc @ Value::Object(_)) = has_meta.get("source_location") {
+        return Some(LogEntrySourceLocation {
+            file: loc.get("file").as_str().unwrap_or("").to_string(),
+            line: loc.get("line").as_i64().unwrap_or(0),
+            function: loc.get("function").as_str().unwrap_or("").to_string(),
+        });
+    }
+
+    // Otherwise, None as mapping is optional
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::Config;
+    use super::*;
+
+    use crate::connectors::impls::gcl::writer::default_log_severity;
+    use googapis::google::logging::r#type::LogSeverity;
+    use std::collections::HashMap as StdHashMap;
+    use tremor_pipeline::ConfigImpl;
+    use tremor_value::literal;
+    use tremor_value::structurize;
+
+    #[test]
+    fn config_with_defaults_no_overrides() -> Result<()> {
+        let config: Config = Config::new(&literal!({}))?;
+
+        assert_eq!(None, config.log_name);
+        assert_eq!(None, config.resource);
+        assert_eq!(false, config.partial_success);
+        assert_eq!(false, config.dry_run);
+        assert_eq!(1_000_000_000, config.connect_timeout);
+        assert_eq!(10_000_000_000, config.request_timeout);
+        assert_eq!(LogSeverity::Default as i32, config.default_severity);
+        assert_eq!(std::collections::HashMap::new(), config.labels);
+
+        Ok(())
+    }
+
+    #[test]
+    fn config_with_defaults_and_overrides() -> Result<()> {
+        let config: Config = Config::new(&literal!({}))?;
+        let meta = literal!({}); // no overrides
+        assert_eq!("default".to_string(), config.log_name(Some(&meta)));
+        assert_eq!(
+            LogSeverity::Default as i32,
+            config.log_severity(Some(&meta))?
+        );
+        assert_eq!("".to_string(), insert_id(Some(&meta)));
+        assert_eq!(None, http_request(Some(&meta)));
+        assert_eq!(StdHashMap::new(), Config::labels(Some(&meta)));
+        assert_eq!(None, operation(Some(&meta)));
+        assert_eq!("".to_string(), trace(Some(&meta)));
+        assert_eq!("".to_string(), span_id(Some(&meta)));
+        assert_eq!(false, trace_sampled(Some(&meta))?);
+        assert_eq!(None, source_location(Some(&meta)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn default_log_name_test() -> Result<()> {
+        let empty_config: Config = Config::new(&literal!({}))?;
+        assert_eq!("default", &empty_config.log_name(None));
+
+        let ok_config: Config = Config::new(&literal!({"log_name": "snot"}))?;
+        assert_eq!("snot", &ok_config.log_name(None));
+
+        let ko_config: std::result::Result<Config, tremor_value::Error> =
+            structurize(literal!({ "log_name": 42 }));
+        assert!(ko_config.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn log_name_overrides() -> Result<()> {
+        let empty_config: Config = Config::new(&literal!({}))?;
+        let meta = literal!({
+            "log_name": "snot",
+        });
+        assert_eq!("snot".to_string(), empty_config.log_name(Some(&meta)));
+        Ok(())
+    }
+
+    #[test]
+    fn log_severity_overrides() -> Result<()> {
+        let mut empty_config: Config = Config::new(&literal!({}))?;
+        let meta = literal!({
+            "log_severity": LogSeverity::Debug as i32,
+        });
+        assert_eq!(
+            LogSeverity::Debug as i32,
+            empty_config.log_severity(Some(&meta))?
+        );
+
+        let err_meta = literal!({
+            "log_severity": ["snot"],
+        });
+        let result = empty_config.log_severity(Some(&err_meta));
+        assert!(result.is_err());
+
+        let no_meta = literal!({});
+        empty_config.default_severity = default_log_severity();
+        let result = empty_config.log_severity(Some(&no_meta));
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn insert_id_overrides() {
+        let meta = literal!({
+            "insert_id": "1234",
+        });
+        assert_eq!("1234".to_string(), insert_id(Some(&meta)));
+    }
+
+    #[test]
+    fn http_request_overrides() {
+        let mut ok_count = 0;
+
+        let meta = literal!({
+            "http_request": {
+                "request_method": "GET",
+                "request_url": "https://www.tremor.rs/",
+                "request_size": 0,
+                "status": 200,
+                "response_size": 1024,
+                "user_agent": "Tremor/v12",
+                "remote_ip": "3.125.16.34",
+                "server_ip": "127.0.0.1",
+                "referer": "",
+                "latency": 100_000_000u64,
+                "cache_lookup": false,
+                "cache_hit": false,
+                "cache_validated_with_origin_server": false,
+                "cache_fill_bytes": 0,
+                "protocol": "websocket"
+            }
+        });
+        if let Some(_http_request) = http_request(Some(&meta)) {
+            assert_eq!("GET", _http_request.request_method);
+            assert_eq!("https://www.tremor.rs/", _http_request.request_url);
+            assert_eq!(0, _http_request.request_size);
+            assert_eq!(200, _http_request.status);
+            assert_eq!(1024, _http_request.response_size);
+            assert_eq!("Tremor/v12", _http_request.user_agent);
+            assert_eq!("3.125.16.34", _http_request.remote_ip);
+            assert_eq!("127.0.0.1", _http_request.server_ip);
+            assert_eq!("", _http_request.referer);
+            //                assert_eq!(100_000_000u64, _http_request.latency.into());
+            assert_eq!(false, _http_request.cache_lookup);
+            assert_eq!(false, _http_request.cache_hit);
+            assert_eq!(false, _http_request.cache_validated_with_origin_server);
+            assert_eq!(0, _http_request.cache_fill_bytes);
+            assert_eq!("websocket", _http_request.protocol);
+            ok_count += 1;
+        };
+
+        let meta = literal!({
+            "http_request": {
+                "request_method": "GET",
+                "request_url": "https://www.tremor.rs/",
+                "request_size": 0,
+                "status": 200,
+                "response_size": 1024,
+                "user_agent": "Tremor/v12",
+                "remote_ip": "3.125.16.34",
+                "server_ip": "127.0.0.1",
+                "referer": "",
+                "cache_lookup": false,
+                "cache_hit": false,
+                "cache_validated_with_origin_server": false,
+                "cache_fill_bytes": 0,
+                "protocol": "websocket"
+            }
+        });
+        if let Some(_http_request) = http_request(Some(&meta)) {
+            assert_eq!(None, _http_request.latency);
+            ok_count += 1;
+        }
+
+        assert_eq!(2, ok_count);
+    }
+
+    #[test]
+    fn default_labels_test() -> Result<()> {
+        // NOTE labels are disjoin in GCL
+        //      Common labels are sent once per batch of events
+        //      Metadata override ( per event ) labels are per event
+        //      So, although odd, this test is as intended
+        assert_eq!(StdHashMap::new(), Config::labels(None));
+
+        let ok_config = Config::new(&literal!({ "labels": { "snot": "badger" } }))?;
+        assert_eq!(1, ok_config.labels.len());
+
+        let ko_config: std::result::Result<Config, tremor_pipeline::errors::Error> =
+            Config::new(&literal!({ "labels": "snot" }));
+        assert!(ko_config.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn label_overrides() {
+        let meta = literal!({
+            "labels": {
+                "badger": "snake"
+            }
+        });
+        let labels = Config::labels(Some(&meta));
+        let badger = labels.get("badger");
+        assert_eq!(None, labels.get("snot"));
+        assert_eq!(
+            "snake".to_string(),
+            badger.unwrap_or(&"fail".to_string()).to_string()
+        );
+    }
+
+    #[test]
+    fn operation_overrides() {
+        let meta = literal!({
+            "operation": {
+                "id": "snot",
+                "producer": "badger",
+                "first": true,
+                "last": true,
+            },
+        });
+        assert_eq!(
+            Some(LogEntryOperation {
+                id: "snot".to_string(),
+                producer: "badger".to_string(),
+                first: true,
+                last: true
+            }),
+            operation(Some(&meta))
+        );
+    }
+
+    #[test]
+    fn trace_overrides() {
+        let meta = literal!({
+            "trace": "snot"
+        });
+        let meta = trace(Some(&meta));
+        assert_eq!("snot", meta);
+    }
+
+    #[test]
+    fn span_id_overrides() {
+        let meta = literal!({
+            "span_id": "snot"
+        });
+        let meta = span_id(Some(&meta));
+        assert_eq!("snot", meta);
+    }
+
+    #[test]
+    fn trace_sampled_overrides() -> Result<()> {
+        let meta = literal!({
+            "trace_sampled": true
+        });
+        let meta_trace_ok = trace_sampled(Some(&meta))?;
+        assert!(meta_trace_ok);
+
+        let meta = literal!({
+            "trace_sampled": [ "snot" ]
+        });
+        let trace_err = trace_sampled(Some(&meta));
+        assert!(trace_err.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn source_location_overrides() {
+        let meta = literal!({
+            "source_location": {
+                "file": "snot",
+                "line": 42,
+                "function": "badger"
+            }
+        });
+        let sl = source_location(Some(&meta));
+        assert_eq!(
+            Some(LogEntrySourceLocation {
+                file: "snot".to_string(),
+                line: 42i64,
+                function: "badger".to_string()
+            }),
+            sl
+        );
+    }
+}

--- a/src/connectors/impls/gcl/writer/sink.rs
+++ b/src/connectors/impls/gcl/writer/sink.rs
@@ -20,10 +20,7 @@ use crate::connectors::utils::pb;
 use async_std::prelude::FutureExt;
 use googapis::google::logging::v2::log_entry::Payload;
 use googapis::google::logging::v2::logging_service_v2_client::LoggingServiceV2Client;
-use googapis::google::logging::v2::{
-    LogEntry,
-    WriteLogEntriesRequest,
-};
+use googapis::google::logging::v2::{LogEntry, WriteLogEntriesRequest};
 use gouth::Token;
 use prost_types::Timestamp;
 use std::time::Duration;
@@ -98,7 +95,7 @@ impl Sink for GclSink {
             #[allow(clippy::cast_precision_loss)]
             #[allow(clippy::cast_possible_wrap)]
             let mut timestamp = Timestamp {
-                seconds: event.ingest_ns as i64 / 1_000_000_000i64,
+                seconds: (event.ingest_ns / 1_000_000_000) as i64,
                 nanos: (event.ingest_ns % 1_000_000_000) as i32,
             };
             timestamp.normalize();

--- a/src/connectors/impls/gcl/writer/sink.rs
+++ b/src/connectors/impls/gcl/writer/sink.rs
@@ -243,7 +243,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: "".to_string(),
+                    alias: Alias::new("", ""),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -253,7 +253,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    "",
+                    &Alias::new("", ""),
                 )
                 .unwrap(),
                 0,
@@ -289,7 +289,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: "".to_string(),
+                    alias: Alias::new("", ""),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -299,7 +299,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    "",
+                    &Alias::new("", ""),
                 )
                 .unwrap(),
                 0,

--- a/src/connectors/impls/gcl/writer/sink.rs
+++ b/src/connectors/impls/gcl/writer/sink.rs
@@ -21,7 +21,6 @@ use async_std::prelude::FutureExt;
 use googapis::google::logging::v2::log_entry::Payload;
 use googapis::google::logging::v2::logging_service_v2_client::LoggingServiceV2Client;
 use googapis::google::logging::v2::{
-    //    ListMonitoredResourceDescriptorsRequest, /* LogEntryOperation */
     LogEntry,
     WriteLogEntriesRequest,
 };
@@ -173,16 +172,6 @@ impl Sink for GclSink {
                 }),
             },
         );
-
-        // NOTE lists available monitored resources in the project / service account
-        //      Included for illustration in case validating the descriptors becomes a requirement
-        // let list = client
-        //     .list_monitored_resource_descriptors(ListMonitoredResourceDescriptorsRequest {
-        //         page_size: 0,
-        //         page_token: "".to_string(),
-        //     })
-        //     .await?;
-        // dbg!(list);
 
         self.client = Some(client);
 

--- a/src/connectors/impls/gcl/writer/sink.rs
+++ b/src/connectors/impls/gcl/writer/sink.rs
@@ -1,0 +1,360 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::meta;
+use crate::connectors::google::AuthInterceptor;
+use crate::connectors::impls::gcl::writer::Config;
+use crate::connectors::prelude::*;
+use crate::connectors::utils::pb;
+use async_std::prelude::FutureExt;
+use googapis::google::logging::v2::log_entry::Payload;
+use googapis::google::logging::v2::logging_service_v2_client::LoggingServiceV2Client;
+use googapis::google::logging::v2::{
+    //    ListMonitoredResourceDescriptorsRequest, /* LogEntryOperation */
+    LogEntry,
+    WriteLogEntriesRequest,
+};
+use gouth::Token;
+use prost_types::Timestamp;
+use std::time::Duration;
+use tonic::codegen::InterceptedService;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig};
+use tonic::{Code, Status};
+
+pub(crate) struct GclSink {
+    client: Option<LoggingServiceV2Client<InterceptedService<Channel, AuthInterceptor>>>,
+    config: Config,
+}
+
+fn value_to_log_entry(
+    timestamp: Timestamp,
+    config: &Config,
+    data: &Value,
+    meta: Option<&Value>,
+) -> Result<LogEntry> {
+    Ok(LogEntry {
+        log_name: config.log_name(meta),
+        resource: super::value_to_monitored_resource(config.resource.as_ref())?,
+        timestamp: Some(timestamp),
+        receive_timestamp: None,
+        severity: config.log_severity(meta)?,
+        insert_id: meta::insert_id(meta),
+        http_request: meta::http_request(meta),
+        labels: Config::labels(meta),
+        operation: meta::operation(meta),
+        trace: meta::trace(meta),
+        span_id: meta::span_id(meta),
+        trace_sampled: meta::trace_sampled(meta)?,
+        source_location: meta::source_location(meta),
+        payload: Some(Payload::JsonPayload(pb::value_to_prost_struct(data)?)),
+    })
+}
+
+impl GclSink {
+    pub fn new(config: Config) -> Self {
+        Self {
+            client: None,
+            config,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_client(
+        &mut self,
+        client: LoggingServiceV2Client<InterceptedService<Channel, AuthInterceptor>>,
+    ) {
+        self.client = Some(client);
+    }
+}
+
+#[async_trait::async_trait]
+impl Sink for GclSink {
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        event: Event,
+        ctx: &SinkContext,
+        _serializer: &mut EventSerializer,
+        _start: u64,
+    ) -> Result<SinkReply> {
+        let client = self.client.as_mut().ok_or(ErrorKind::ClientNotAvailable(
+            "Google Cloud Logging",
+            "The client is not connected",
+        ))?;
+
+        let mut entries = Vec::with_capacity(event.len());
+        for (data, meta) in event.value_meta_iter() {
+            let meta = meta.get("gcl_writer").or(None);
+            #[allow(clippy::cast_precision_loss)]
+            #[allow(clippy::cast_possible_wrap)]
+            let mut timestamp = Timestamp {
+                seconds: event.ingest_ns as i64 / 1_000_000_000i64,
+                nanos: (event.ingest_ns % 1_000_000_000) as i32,
+            };
+            timestamp.normalize();
+            entries.push(value_to_log_entry(timestamp, &self.config, data, meta)?);
+        }
+
+        let log_entries_response = client
+            .write_log_entries(WriteLogEntriesRequest {
+                log_name: self.config.log_name(None),
+                resource: super::value_to_monitored_resource(self.config.resource.as_ref())?,
+                labels: self.config.labels.clone(),
+                entries,
+                partial_success: self.config.partial_success,
+                dry_run: self.config.dry_run,
+            })
+            .timeout(Duration::from_nanos(self.config.request_timeout))
+            .await?;
+
+        if let Err(error) = log_entries_response {
+            error!("Failed to write a log entries: {}", error);
+
+            if matches!(
+                error.code(),
+                Code::Aborted
+                    | Code::Cancelled
+                    | Code::DataLoss
+                    | Code::DeadlineExceeded
+                    | Code::Internal
+                    | Code::ResourceExhausted
+                    | Code::Unavailable
+                    | Code::Unknown
+            ) {
+                ctx.swallow_err(
+                    ctx.notifier.connection_lost().await,
+                    "Failed to notify about Google Cloud Logging connection loss",
+                );
+            }
+
+            Ok(SinkReply::FAIL)
+        } else {
+            Ok(SinkReply::ACK)
+        }
+    }
+
+    async fn connect(&mut self, ctx: &SinkContext, _attempt: &Attempt) -> Result<bool> {
+        info!("{} Connecting to Google Cloud Logging", ctx);
+        let token = Token::new()?;
+
+        let tls_config = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(googapis::CERTIFICATES))
+            .domain_name("logging.googleapis.com");
+
+        let channel = Channel::from_static("https://logging.googleapis.com")
+            .connect_timeout(Duration::from_nanos(self.config.connect_timeout))
+            .tls_config(tls_config)?
+            .connect()
+            .await?;
+
+        let client = LoggingServiceV2Client::with_interceptor(
+            channel,
+            AuthInterceptor {
+                token: Box::new(move || match token.header_value() {
+                    Ok(val) => Ok(val),
+                    Err(e) => {
+                        error!("Failed to get token for Google Logging Client: {}", e);
+
+                        Err(Status::unavailable(
+                            "Failed to retrieve authentication token.",
+                        ))
+                    }
+                }),
+            },
+        );
+
+        // NOTE lists available monitored resources in the project / service account
+        //      Included for illustration in case validating the descriptors becomes a requirement
+        // let list = client
+        //     .list_monitored_resource_descriptors(ListMonitoredResourceDescriptorsRequest {
+        //         page_size: 0,
+        //         page_token: "".to_string(),
+        //     })
+        //     .await?;
+        // dbg!(list);
+
+        self.client = Some(client);
+
+        Ok(true)
+    }
+
+    fn auto_ack(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::connectors::impls::gcl;
+    use crate::connectors::tests::ConnectorHarness;
+    use crate::connectors::ConnectionLostNotifier;
+    use googapis::google::logging::r#type::LogSeverity;
+    use std::sync::Arc;
+    use tremor_value::{literal, structurize};
+
+    #[test]
+    fn fails_if_the_event_is_not_an_object() -> Result<()> {
+        let now = tremor_common::time::nanotime();
+        let mut timestamp = Timestamp {
+            seconds: now as i64 / 1_000_000_000i64,
+            nanos: (now % 1_000_000_000) as i32,
+        };
+        timestamp.normalize();
+        let data = &literal!("snot");
+        let config = Config::new(&literal!({}))?;
+        let meta = literal!({});
+        let meta = meta.get("gcl_writer").or(None);
+
+        let result = value_to_log_entry(timestamp, &config, data, meta);
+        if let Err(Error(ErrorKind::GclTypeMismatch("Value::Object", x), _)) = result {
+            assert_eq!(x, ValueType::String);
+            Ok(())
+        } else {
+            Err("Mapping did not fail on non-object event".into())
+        }
+    }
+
+    #[async_std::test]
+    async fn sink_succeeds_if_config_is_empty() -> Result<()> {
+        let config = literal!({
+            "config": {}
+        });
+
+        let result =
+            ConnectorHarness::new(function_name!(), &gcl::writer::Builder::default(), &config)
+                .await;
+
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn on_event_fails_if_client_is_not_conected() -> Result<()> {
+        let (rx, _tx) = async_std::channel::unbounded();
+        let config = Config::new(&literal!({
+            "connect_timeout": 1_000_000
+        }))
+        .unwrap();
+
+        let mut sink = GclSink::new(config);
+
+        let result = sink
+            .on_event(
+                "",
+                Event::signal_tick(),
+                &SinkContext {
+                    uid: Default::default(),
+                    alias: "".to_string(),
+                    connector_type: Default::default(),
+                    quiescence_beacon: Default::default(),
+                    notifier: ConnectionLostNotifier::new(rx),
+                },
+                &mut EventSerializer::new(
+                    None,
+                    CodecReq::Structured,
+                    vec![],
+                    &ConnectorType::from(""),
+                    "",
+                )
+                .unwrap(),
+                0,
+            )
+            .await;
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn on_event_fails_if_write_stream_is_not_connected() -> Result<()> {
+        let (rx, _tx) = async_std::channel::unbounded();
+        let config = Config::new(&literal!({
+            "connect_timeout": 1_000_000,
+            "request_timeout": 1_000_000
+        }))
+        .unwrap();
+
+        let mut sink = GclSink::new(config);
+        sink.set_client(LoggingServiceV2Client::with_interceptor(
+            Channel::from_static("http://example.com").connect_lazy(),
+            AuthInterceptor {
+                token: Box::new(|| Ok(Arc::new(String::new()))),
+            },
+        ));
+
+        assert!(!sink.auto_ack());
+
+        let result = sink
+            .on_event(
+                "",
+                Event::signal_tick(),
+                &SinkContext {
+                    uid: Default::default(),
+                    alias: "".to_string(),
+                    connector_type: Default::default(),
+                    quiescence_beacon: Default::default(),
+                    notifier: ConnectionLostNotifier::new(rx),
+                },
+                &mut EventSerializer::new(
+                    None,
+                    CodecReq::Structured,
+                    vec![],
+                    &ConnectorType::from(""),
+                    "",
+                )
+                .unwrap(),
+                0,
+            )
+            .await;
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn log_name_override() -> Result<()> {
+        let now = tremor_common::time::nanotime();
+        let mut timestamp = Timestamp {
+            seconds: now as i64 / 1_000_000_000i64,
+            nanos: (now % 1_000_000_000) as i32,
+        };
+        timestamp.normalize();
+        let config: Config = structurize(literal!({ "log_name": "snot" }))?;
+        let data = literal!({"snot": "badger"});
+        let meta = literal!({"log_name": "override"});
+        let le = value_to_log_entry(timestamp, &config, &data, Some(&meta))?;
+        assert_eq!("override", &le.log_name);
+
+        Ok(())
+    }
+
+    #[test]
+    fn log_severity_override() -> Result<()> {
+        let now = tremor_common::time::nanotime();
+        let mut timestamp = Timestamp {
+            seconds: now as i64 / 1_000_000_000i64,
+            nanos: (now % 1_000_000_000) as i32,
+        };
+        timestamp.normalize();
+        let config: Config = structurize(literal!({}))?;
+        let data = literal!({"snot": "badger"});
+        let meta = literal!({"log_name": "override", "log_severity": LogSeverity::Debug as i32});
+        let le = value_to_log_entry(timestamp, &config, &data, Some(&meta))?;
+        assert_eq!("override", &le.log_name);
+        assert_eq!(LogSeverity::Debug as i32, le.severity);
+
+        Ok(())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -367,6 +367,16 @@ error_chain! {
             description("Malformed UUID")
                 display("Malformed UUID")
         }
+
+        GclSinkFailed(msg: &'static str) {
+            description("Google Cloud Logging Sink failed")
+                display("Google Cloud Logging Sink failed: {}", msg)
+        }
+
+        GclTypeMismatch(expected: &'static str, actual:value_trait::ValueType) {
+            description("Type in the message does not match Google Cloud Logging API type")
+            display("Type in the message does not match Google Cloud Logging API type. Expected: {}, actual: {:?}", expected, actual)
+        }
     }
 }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::connectors::impls::otel;
 use crate::connectors::impls::gcl;
+use crate::connectors::impls::otel;
 use crate::errors::Result;
 use crate::version::VERSION;
 use tremor_script::registry::Registry;
-use tremor_script::{tremor_const_fn, tremor_fn};
 use tremor_script::FN_REGISTRY;
+use tremor_script::{tremor_const_fn, tremor_fn};
 
 /// Loads the function library
 ///

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use crate::connectors::impls::otel;
+use crate::connectors::impls::gcl;
 use crate::errors::Result;
 use crate::version::VERSION;
 use tremor_script::registry::Registry;
-use tremor_script::tremor_fn;
+use tremor_script::{tremor_const_fn, tremor_fn};
 use tremor_script::FN_REGISTRY;
 
 /// Loads the function library
@@ -34,10 +35,11 @@ pub fn load() -> Result<()> {
 ///  * if we can't install extensions
 pub fn install(reg: &mut Registry) -> Result<()> {
     otel::load(reg);
+    gcl::load(reg);
     reg.insert(tremor_fn!(system|instance(_context) {
         Ok(Value::from(instance!()))
     }))
-    .insert(tremor_fn!(system|version(_context) {
+    .insert(tremor_const_fn!(system|version(_context) {
         Ok(Value::from(VERSION).into_static())
     }));
 

--- a/tremor-script/lib/google.tremor
+++ b/tremor-script/lib/google.tremor
@@ -1,0 +1,14 @@
+### <p align="center">
+###   <img src="https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.png" width='35%'/>
+### </p>
+###
+### <hr/>
+###
+### # The Tremor language GCP library.
+###
+### It provides the following modules for the Google Cloud Platform
+###
+### * [cloud::logging](cloud/logging.md) - functionality related to `Cloud Logging v2`
+###
+
+use google::cloud;

--- a/tremor-script/lib/google/cloud.tremor
+++ b/tremor-script/lib/google/cloud.tremor
@@ -1,0 +1,1 @@
+use google::cloud::logging;

--- a/tremor-script/lib/google/cloud/logging.tremor
+++ b/tremor-script/lib/google/cloud/logging.tremor
@@ -1,0 +1,13 @@
+use google::cloud::logging::severity;
+
+## Generate a random span id using the hex string representation
+##
+## Returns a `string`
+intrinsic fn gen_span_id_string() as google_logging::gen_span_id_string;
+
+## Generate a random trace id using the hex string representation
+##
+## Returns a `string`
+intrinsic fn gen_trace_id_string() as google_logging::gen_trace_id_string;
+
+

--- a/tremor-script/lib/google/cloud/logging/severity.tremor
+++ b/tremor-script/lib/google/cloud/logging/severity.tremor
@@ -1,0 +1,27 @@
+
+## The log entry has no assigned severity level.
+const DEFAULT	=	0;
+
+## Debug or trace information.
+const DEBUG	=	100;
+
+## Routine information, such as ongoing status or performance.
+const INFO	=	200;
+
+## Normal but significant events, such as start up, shut down, or a configuration change.
+const NOTICE	=	300;
+
+## Warning events might cause problems.
+const WARNING	=	400;
+
+## Error events are likely to cause problems.
+const ERROR	=	500;
+
+## Critical events cause more severe problems or outages.
+const CRITICAL	=	600;
+
+## A person must take an action immediately.
+const ALERT	=	700;
+
+## One or more systems are unusable.
+const EMERGENCY	=	800;


### PR DESCRIPTION
Signed-off-by: Darach Ennis <darach@gmail.com>

# Pull request

Adds GCP cloud logging support for writing log entries using json payloads.
Initial experimental revision for soliciting feedback.

## Description

Adds basic support for GCP cloud logging

## Related

None.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

This is net new functionality with no performance testing conducted to date.

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


