### PR TITLE
Allow kafka connectors to detect some more errors and reconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Add reverse functions and tests for arrays and strings, add sort test for arrays
 - Add a ClickHouse connector
 
+### Fixes
+
+- Allow `kafka_consumer` connector to reconnect upon more error conditions and avoid stalls.
+
 ## [0.12.4]
 
 ### Fixes

--- a/src/connectors.rs
+++ b/src/connectors.rs
@@ -169,6 +169,7 @@ impl Addr {
 }
 
 /// Messages a Connector instance receives and acts upon
+#[derive(Debug)]
 pub(crate) enum Msg {
     /// connect 1 or more pipelines to a port
     LinkInput {
@@ -1263,18 +1264,18 @@ where
 }
 
 #[cfg(test)]
-mod unit_tests {
+pub(crate) mod unit_tests {
     use super::*;
 
     #[derive(Clone)]
-    struct FakeContext {
+    pub(crate) struct FakeContext {
         t: ConnectorType,
         notifier: reconnect::ConnectionLostNotifier,
         beacon: QuiescenceBeacon,
     }
 
     impl FakeContext {
-        fn new(tx: Sender<Msg>) -> Self {
+        pub(crate) fn new(tx: Sender<Msg>) -> Self {
             Self {
                 t: ConnectorType::from("snot"),
                 notifier: reconnect::ConnectionLostNotifier::new(tx),

--- a/src/connectors/impls/kafka.rs
+++ b/src/connectors/impls/kafka.rs
@@ -14,12 +14,24 @@
 pub(crate) mod consumer;
 pub(crate) mod producer;
 
-use crate::errors::{err_conector_def, Result};
+use crate::{
+    connectors::{metrics::make_metrics_payload, Context},
+    errors::{err_conector_def, Result},
+};
+use async_broadcast::Sender as BroadcastSender;
+use async_std::channel::Sender;
+use beef::Cow;
 use core::future::Future;
 use futures::future;
-use rdkafka::{error::KafkaError, util::AsyncRuntime};
+use halfbrown::HashMap;
+use rdkafka::{error::KafkaError, util::AsyncRuntime, ClientContext};
 use rdkafka_sys::RDKafkaErrorCode;
-use std::time::{Duration, Instant};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
+};
+use tremor_script::EventPayload;
+use tremor_value::Value;
 
 const KAFKA_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -75,4 +87,192 @@ fn is_failed_connect_error(err: &KafkaError) -> bool {
             // TODO: what else?
             | KafkaError::Global(RDKafkaErrorCode::UnknownTopicOrPartition | RDKafkaErrorCode::UnknownTopic | RDKafkaErrorCode::AllBrokersDown)
     )
+}
+
+struct TremorRDKafkaContext<Ctx>
+where
+    Ctx: Context + Send + Sync + 'static,
+{
+    ctx: Ctx,
+    connect_tx: Sender<KafkaError>,
+    metrics_tx: BroadcastSender<EventPayload>,
+    active: AtomicBool,
+}
+
+impl<Ctx> TremorRDKafkaContext<Ctx>
+where
+    Ctx: Context + Send + Sync + 'static,
+{
+    const PRODUCER: &'static str = "producer";
+    const CONSUMER: &'static str = "consumer";
+
+    fn new(
+        ctx: Ctx,
+        connect_tx: Sender<KafkaError>,
+        metrics_tx: BroadcastSender<EventPayload>,
+    ) -> Self {
+        Self {
+            ctx,
+            connect_tx,
+            metrics_tx,
+            active: AtomicBool::new(true),
+        }
+    }
+
+    fn on_connection_lost(&self) {
+        let ctx = self.ctx.clone();
+
+        // only actually notify the notifier if we didn't do so before
+        // otherwise we would flood the connector and reconnect multiple times
+        if self.active.fetch_and(false, Ordering::AcqRel) {
+            async_std::task::spawn(async move {
+                if let Err(e) = ctx.notifier().connection_lost().await {
+                    error!("{ctx} Error notifying the connector of a lost connection: {e}");
+                }
+            });
+        }
+    }
+}
+
+impl<Ctx> ClientContext for TremorRDKafkaContext<Ctx>
+where
+    Ctx: Context + Send + Sync + 'static,
+{
+    /// log messages from librdkafka with connector alias prefixed
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        match level {
+            rdkafka::config::RDKafkaLogLevel::Emerg
+            | rdkafka::config::RDKafkaLogLevel::Alert
+            | rdkafka::config::RDKafkaLogLevel::Critical
+            | rdkafka::config::RDKafkaLogLevel::Error => {
+                error!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+            }
+            rdkafka::config::RDKafkaLogLevel::Warning => {
+                warn!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+            }
+            rdkafka::config::RDKafkaLogLevel::Notice => {
+                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+            }
+            rdkafka::config::RDKafkaLogLevel::Info => {
+                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+            }
+            rdkafka::config::RDKafkaLogLevel::Debug => {
+                debug!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+            }
+        }
+    }
+
+    // TODO: add full connector id to tags
+    fn stats(&self, stats: rdkafka::Statistics) {
+        let metrics_payload = if stats.client_type.eq(Self::PRODUCER) {
+            let timestamp = stats.time as u64 * 1_000_000_000;
+            let mut fields = HashMap::with_capacity(3);
+            fields.insert(Cow::const_str("tx_msgs"), Value::from(stats.txmsgs));
+            fields.insert(
+                Cow::const_str("tx_msg_bytes"),
+                Value::from(stats.txmsg_bytes),
+            );
+            fields.insert(Cow::const_str("queued_msgs"), Value::from(stats.msg_cnt));
+
+            let mut tags = HashMap::with_capacity(1);
+            tags.insert(
+                Cow::const_str("connector"),
+                Value::from(self.ctx.alias().to_string()),
+            );
+
+            make_metrics_payload("kafka_producer_stats", fields, tags, timestamp)
+        } else if stats.client_type.eq(Self::CONSUMER) {
+            let timestamp = stats.time as u64 * 1_000_000_000;
+
+            // consumer stats
+            let mut fields = HashMap::with_capacity(4);
+            fields.insert(Cow::const_str("rx_msgs"), Value::from(stats.rxmsgs));
+            fields.insert(
+                Cow::const_str("rx_msg_bytes"),
+                Value::from(stats.rxmsg_bytes),
+            );
+            if let Some(cg) = stats.cgrp {
+                fields.insert(
+                    Cow::const_str("partitions_assigned"),
+                    Value::from(cg.assignment_size),
+                );
+            }
+            let mut consumer_lag = 0_i64;
+            for topic in stats.topics.values() {
+                for partition in topic.partitions.values() {
+                    if partition.desired && !partition.unknown && partition.consumer_lag >= 0 {
+                        consumer_lag += partition.consumer_lag;
+                    }
+                }
+            }
+            fields.insert(Cow::const_str("consumer_lag"), Value::from(consumer_lag));
+            let mut tags = HashMap::with_capacity(1);
+            tags.insert(
+                Cow::const_str("connector"),
+                Value::from(self.ctx.alias().to_string()),
+            );
+            make_metrics_payload("kafka_consumer_stats", fields, tags, timestamp)
+        } else {
+            warn!(
+                "{} Unknown stats client_type: \"{}\"",
+                &self.ctx, stats.client_type
+            );
+            return;
+        };
+
+        if let Err(e) = self.metrics_tx.try_broadcast(metrics_payload) {
+            warn!("{} Error sending kafka stats: {e}", self.ctx);
+        }
+    }
+
+    fn error(&self, error: KafkaError, reason: &str) {
+        error!("{} Kafka Error {}: {}", &self.ctx, &error, reason);
+        if !self.connect_tx.is_closed() {
+            // still in connect phase
+            if is_fatal_error(&error) || is_failed_connect_error(&error) {
+                if let Err(e) = self.connect_tx.try_send(error) {
+                    // if we error here, the queue is full, so we already notified the connector, ignore
+                    warn!("{} Error sending connect message: {e}", self.ctx);
+                }
+                self.connect_tx.close();
+            }
+        } else if is_fatal_error(&error) {
+            // we are out of connect phase
+            // issue a reconnect upon fatal errors
+            self.on_connection_lost();
+        }
+    }
+}
+
+/// Kafka error indicating success
+pub(crate) const NO_ERROR: KafkaError = KafkaError::Global(RDKafkaErrorCode::NoError);
+
+/// check if a kafka error is fatal for producer and consumer
+fn is_fatal_error(e: &KafkaError) -> bool {
+    match e {
+        // Generic fatal errors
+        KafkaError::AdminOp(code)
+        | KafkaError::ConsumerCommit(code)
+        | KafkaError::Global(code)
+        | KafkaError::GroupListFetch(code)
+        | KafkaError::MessageConsumption(code)
+        | KafkaError::MessageProduction(code)
+        | KafkaError::MetadataFetch(code)
+        | KafkaError::OffsetFetch(code)
+        | KafkaError::SetPartitionOffset(code)
+        | KafkaError::StoreOffset(code) => matches!(
+            code,
+            RDKafkaErrorCode::Fatal
+                | RDKafkaErrorCode::AllBrokersDown
+                | RDKafkaErrorCode::InvalidProducerEpoch
+                | RDKafkaErrorCode::UnknownMemberId
+        ),
+        // Check if it is a fatal transaction error
+        KafkaError::Transaction(e) => e.is_fatal(),
+        // subscription failed for the consumer
+        KafkaError::Subscription(_) => true,
+
+        // This is required due to `KafkaError` being mared as `#[non_exhaustive]`
+        _ => false,
+    }
 }

--- a/src/connectors/impls/kafka.rs
+++ b/src/connectors/impls/kafka.rs
@@ -145,24 +145,25 @@ where
             | rdkafka::config::RDKafkaLogLevel::Alert
             | rdkafka::config::RDKafkaLogLevel::Critical
             | rdkafka::config::RDKafkaLogLevel::Error => {
-                error!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+                error!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
             rdkafka::config::RDKafkaLogLevel::Warning => {
-                warn!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+                warn!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
             rdkafka::config::RDKafkaLogLevel::Notice => {
-                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
             rdkafka::config::RDKafkaLogLevel::Info => {
-                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
             rdkafka::config::RDKafkaLogLevel::Debug => {
-                debug!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message)
+                debug!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
         }
     }
 
     // TODO: add full connector id to tags
+    #[allow(clippy::cast_sign_loss)]
     fn stats(&self, stats: rdkafka::Statistics) {
         let metrics_payload = if stats.client_type.eq(Self::PRODUCER) {
             let timestamp = stats.time as u64 * 1_000_000_000;

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -13,14 +13,12 @@
 // limitations under the License.
 
 use async_std::sync::Arc;
-use beef::Cow;
 use std::time::Duration;
 
 use crate::connectors::impls::kafka::{
-    is_failed_connect_error, SmolRuntime, TremorRDKafkaContext, KAFKA_CONNECT_TIMEOUT, NO_ERROR,
+    SmolRuntime, TremorRDKafkaContext, KAFKA_CONNECT_TIMEOUT, NO_ERROR,
 };
 use crate::connectors::prelude::*;
-use crate::connectors::utils::metrics::make_metrics_payload;
 use async_broadcast::{broadcast, Receiver as BroadcastReceiver};
 use async_std::channel::{bounded, Receiver, Sender};
 use async_std::prelude::{FutureExt, StreamExt};
@@ -32,7 +30,7 @@ use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance, StreamConsumer};
 use rdkafka::error::KafkaError;
 use rdkafka::message::{BorrowedMessage, Headers, Message};
-use rdkafka::{ClientContext, Offset, TopicPartitionList};
+use rdkafka::{Offset, TopicPartitionList};
 use rdkafka_sys::RDKafkaErrorCode;
 
 const KAFKA_CONSUMER_META_KEY: &str = "kafka_consumer";

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -18,26 +18,20 @@
 use std::time::Duration;
 
 use crate::connectors::impls::kafka::{
-    is_failed_connect_error, is_fatal_error, SmolRuntime, TremorRDKafkaContext,
-    KAFKA_CONNECT_TIMEOUT,
+    is_fatal_error, SmolRuntime, TremorRDKafkaContext, KAFKA_CONNECT_TIMEOUT,
 };
-use crate::connectors::metrics::make_metrics_payload;
 use crate::connectors::prelude::*;
 use async_broadcast::{broadcast, Receiver as BroadcastReceiver};
 use async_std::channel::{bounded, Sender};
 use async_std::prelude::FutureExt;
 use async_std::task;
-use beef::Cow;
 use halfbrown::HashMap;
 use rdkafka::config::{ClientConfig, FromClientConfigAndContext};
-use rdkafka::producer::{DeliveryFuture, Producer, ProducerContext};
+use rdkafka::producer::{DeliveryFuture, Producer};
 use rdkafka::{
-    error::KafkaError,
     message::OwnedHeaders,
     producer::{FutureProducer, FutureRecord},
 };
-use rdkafka::{ClientContext, Statistics};
-use rdkafka_sys::RDKafkaErrorCode;
 use tremor_common::time::nanotime;
 
 const KAFKA_PRODUCER_META_KEY: &str = "kafka_producer";

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -17,18 +17,20 @@
 
 use std::time::Duration;
 
-use super::SmolRuntime;
-use crate::connectors::impls::kafka::{is_failed_connect_error, KAFKA_CONNECT_TIMEOUT};
+use crate::connectors::impls::kafka::{
+    is_failed_connect_error, is_fatal_error, SmolRuntime, TremorRDKafkaContext,
+    KAFKA_CONNECT_TIMEOUT,
+};
 use crate::connectors::metrics::make_metrics_payload;
 use crate::connectors::prelude::*;
-use async_broadcast::{broadcast, Receiver as BroadcastReceiver, Sender as BroadcastSender};
+use async_broadcast::{broadcast, Receiver as BroadcastReceiver};
 use async_std::channel::{bounded, Sender};
 use async_std::prelude::FutureExt;
 use async_std::task;
 use beef::Cow;
 use halfbrown::HashMap;
 use rdkafka::config::{ClientConfig, FromClientConfigAndContext};
-use rdkafka::producer::{DeliveryFuture, Producer};
+use rdkafka::producer::{DeliveryFuture, Producer, ProducerContext};
 use rdkafka::{
     error::KafkaError,
     message::OwnedHeaders,
@@ -117,69 +119,6 @@ impl ConnectorBuilder for Builder {
     }
 }
 
-struct TremorProducerContext {
-    ctx: SinkContext,
-    /// during connect we poll the producer to peek for errors, like AllBrokersDown and similar
-    /// We try to send it to a special `bounded(1)` channel to fail the connect attempt
-    connect_tx: Sender<KafkaError>,
-    // using a broadcast channel as a hack, as it supports overflow handling
-    // and will this always only have the latest metrics value available, which is what we want,
-    // old shit is old
-    metrics_tx: BroadcastSender<EventPayload>,
-}
-
-impl ClientContext for TremorProducerContext {
-    #[allow(clippy::cast_sign_loss)] // Sadly we need to use the kafka types
-    fn stats(&self, stats: Statistics) {
-        if stats.client_type.eq("producer") {
-            let timestamp = stats.time as u64 * 1_000_000_000;
-            let mut fields = HashMap::with_capacity(3);
-            fields.insert(Cow::const_str("tx_msgs"), Value::from(stats.txmsgs));
-            fields.insert(
-                Cow::const_str("tx_msg_bytes"),
-                Value::from(stats.txmsg_bytes),
-            );
-            fields.insert(Cow::const_str("queued_msgs"), Value::from(stats.msg_cnt));
-
-            let mut tags = HashMap::with_capacity(1);
-            tags.insert(
-                Cow::const_str("connector"),
-                Value::from(self.ctx.alias.clone()),
-            );
-
-            let metrics_payload =
-                make_metrics_payload("kafka_producer_stats", fields, tags, timestamp);
-
-            if let Err(e) = self.metrics_tx.try_broadcast(metrics_payload) {
-                warn!("{} Erro sending kafka stats: {e}", self.ctx);
-            }
-        }
-    }
-
-    fn error(&self, error: KafkaError, reason: &str) {
-        error!("{} Kafka Error: {}: {}", &self.ctx, error, reason);
-
-        // send to the connect sender if it is not yet closed, that is if we are still waiting in connect
-        // otherwise notify the runtime
-        if !self.connect_tx.is_closed() {
-            if is_fatal(&error) || is_failed_connect_error(&error) {
-                // ignore any errors here, if the queue is full, we are probably not in the connect phase anymore
-                if let Err(e) = self.connect_tx.try_send(error) {
-                    warn!("{} Erro sending connect message: {e}", self.ctx);
-                }
-                self.connect_tx.close();
-            }
-        } else if is_fatal(&error) {
-            // issue a reconnect upon fatal errors
-            let notifier = self.ctx.notifier().clone();
-            task::spawn(async move {
-                notifier.connection_lost().await?;
-                Ok::<(), Error>(())
-            });
-        }
-    }
-}
-
 struct KafkaProducerConnector {
     config: Config,
     producer_config: ClientConfig,
@@ -205,10 +144,12 @@ impl Connector for KafkaProducerConnector {
     }
 }
 
+type TremorProducer = FutureProducer<TremorRDKafkaContext<SinkContext>, SmolRuntime>;
+
 struct KafkaProducerSink {
     config: Config,
     producer_config: ClientConfig,
-    producer: Option<FutureProducer<TremorProducerContext, SmolRuntime>>,
+    producer: Option<TremorProducer>,
     reply_tx: Sender<AsyncSinkReply>,
     metrics_rx: Option<BroadcastReceiver<EventPayload>>,
 }
@@ -287,7 +228,7 @@ impl Sink for KafkaProducerSink {
                     }
                     Err((e, _)) => {
                         error!("{ctx} Failed to enqueue message: {e}");
-                        if is_fatal(&e) {
+                        if is_fatal_error(&e) {
                             error!("{ctx} Fatal Kafka Error: {e}. Attempting a reconnect.");
                             ctx.notifier.connection_lost().await?;
                         }
@@ -328,16 +269,12 @@ impl Sink for KafkaProducerSink {
         let (mut metrics_tx, metrics_rx) = broadcast(1);
         metrics_tx.set_overflow(true);
         self.metrics_rx = Some(metrics_rx);
-        let context = TremorProducerContext {
-            ctx: ctx.clone(),
-            connect_tx: tx,
-            metrics_tx,
-        };
+        let context = TremorRDKafkaContext::new(ctx.clone(), tx, metrics_tx);
         let (version_n, version_s) = rdkafka::util::get_rdkafka_version();
         info!("{ctx} Connecting kafka producer with rdkafka 0x{version_n:08x} {version_s}");
 
         let producer_config = self.producer_config.clone();
-        let producer: FutureProducer<TremorProducerContext, SmolRuntime> =
+        let producer: TremorProducer =
             FutureProducer::from_config_and_context(&producer_config, context)?;
         // check if we receive any error callbacks
         match rx.recv().timeout(KAFKA_CONNECT_TIMEOUT).await {
@@ -396,7 +333,7 @@ async fn wait_for_delivery(
         Ok(results) => {
             if let Some((kafka_error, _)) = results.into_iter().find_map(std::result::Result::err) {
                 error!("{ctx} Error delivering kafka record: {kafka_error}");
-                if is_fatal(&kafka_error) && ctx.notifier().connection_lost().await.is_err() {
+                if is_fatal_error(&kafka_error) && ctx.notifier().connection_lost().await.is_err() {
                     error!("{ctx} Error notifying runtime of fatal Kafka error");
                 }
                 cf_data.map(AsyncSinkReply::Fail)
@@ -415,25 +352,4 @@ async fn wait_for_delivery(
         };
     }
     Ok(())
-}
-
-/// check if a kafka error is fatal for the producer
-fn is_fatal(e: &KafkaError) -> bool {
-    match e {
-        // Generic fatal errors
-        KafkaError::AdminOp(code)
-        | KafkaError::ConsumerCommit(code)
-        | KafkaError::Global(code)
-        | KafkaError::GroupListFetch(code)
-        | KafkaError::MessageConsumption(code)
-        | KafkaError::MessageProduction(code)
-        | KafkaError::MetadataFetch(code)
-        | KafkaError::OffsetFetch(code)
-        | KafkaError::SetPartitionOffset(code)
-        | KafkaError::StoreOffset(code) => matches!(code, RDKafkaErrorCode::Fatal),
-        // Check if it is a fatal transaction error
-        KafkaError::Transaction(e) => e.is_fatal(),
-        // This is required due to `KafkaError` being mared as `#[non_exhaustive]`
-        _ => false,
-    }
 }

--- a/tremor-cli/tests/integration/kafka_connectors/config.troy
+++ b/tremor-cli/tests/integration/kafka_connectors/config.troy
@@ -109,6 +109,7 @@ flow
                 "rdkafka_options": {
                     "enable.auto.commit": "false",
                     "auto.offset.reset": "beginning",
+                    "debug": "consumer"
                 }
             }
     end;


### PR DESCRIPTION
Also refactor kafka contexts a bit and deduplicate implementation.

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->



## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

nope.


