### PR TITLE
Into error statement and definition for pipelines 

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -584,6 +584,11 @@ pub(crate) async fn pipeline_task(
                 target,
             }) => {
                 info!("{ctx} Connecting port '{port}' to {endpoint}",);
+                // add error statement for port out in pipeline, currently no error messages
+                if output_doesnt_exist(&port, &pipeline) {
+                    error!("{ctx} Error connecting output pipeline {port}");
+                    continue;
+                }
                 // notify other pipeline about a new input
                 if let OutputTarget::Pipeline(pipe) = &target {
                     // avoid linking the same pipeline as input to itself
@@ -672,6 +677,11 @@ pub(crate) async fn pipeline_task(
 
     info!("{ctx} Stopped.");
     Ok(())
+}
+
+fn output_doesnt_exist(port: &Cow<'static, str>, pipeline: &ExecutableGraph) -> bool {
+    // function checks if port is in pipeline
+    return !pipeline.outputs.contains_key(port);
 }
 
 #[cfg(test)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -681,7 +681,7 @@ pub(crate) async fn pipeline_task(
 
 fn output_doesnt_exist(port: &Cow<'static, str>, pipeline: &ExecutableGraph) -> bool {
     // function checks if port is in pipeline
-    return !pipeline.outputs.contains_key(port);
+    !pipeline.outputs.contains_key(port)
 }
 
 #[cfg(test)]

--- a/tremor-pipeline/src/executable_graph.rs
+++ b/tremor-pipeline/src/executable_graph.rs
@@ -255,6 +255,8 @@ pub struct ExecutableGraph {
     pub(crate) last_metrics: u64,
     pub(crate) metric_interval: Option<u64>,
     pub(crate) metrics_channel: MetricsSender,
+    /// outputs in pipeline
+    pub outputs: HashMap<Cow<'static, str>, usize>,
     /// snot
     pub insights: Vec<(usize, Event)>,
     /// the dot representation of the graph
@@ -786,6 +788,9 @@ mod test {
         let mut inputs = HashMap::new();
         inputs.insert("in".into(), 0);
 
+        let mut outputs = HashMap::new();
+        outputs.insert("out".into(), 3);
+
         let mut port_indexes = ExecPortIndexMap::new();
         // link out from
         port_indexes.insert((0, "out".into()), vec![(1, "in".into())]);
@@ -814,6 +819,7 @@ mod test {
             contraflow: vec![3, 2],
             port_indexes,
             metrics,
+            outputs,
             // The index of the metrics node in our pipeline
             last_metrics: 0,
             metric_interval: Some(1),
@@ -876,6 +882,9 @@ mod test {
         let mut inputs = HashMap::new();
         inputs.insert("in".into(), 0);
 
+        let mut outputs = HashMap::new();
+        outputs.insert("out".into(), 4);
+
         let mut port_indexes = ExecPortIndexMap::new();
         // link out from
         port_indexes.insert((0, "out".into()), vec![(1, "in".into())]);
@@ -911,6 +920,7 @@ mod test {
             contraflow: vec![3, 2],
             port_indexes,
             metrics,
+            outputs,
             // The index of the metrics node in our pipeline
             last_metrics: 0,
             metric_interval: None,

--- a/tremor-pipeline/src/query.rs
+++ b/tremor-pipeline/src/query.rs
@@ -243,6 +243,15 @@ impl Query {
                         )
                         .into());
                     }
+                    if !nodes_by_name.contains_key(&s.into.0.id) {
+                        return Err(query_stream_not_defined_err(
+                            s,
+                            &s.into.0,
+                            s.into.0.to_string(),
+                            s.into.1.to_string(),
+                        )
+                        .into());
+                    }
                     let e = select.stmt.extent();
                     let mut h = Dumb::new();
                     let label = h


### PR DESCRIPTION
# Pull request

## Description

Added into error definition to print out error statements when there's an error in port 'out' in the pipelines

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


