### PR TITLE
Include flow-alias in pipeline- and connector-alias

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -28,7 +28,6 @@ jobs:
     env:
       TREMOR_PATH: "${{ github.workspace }}/tremor-script/lib:${{ github.workspace }}/tremor-cli/tests/lib"
       RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_feature }}
-      RUST_LOG: debug
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - Allow `kafka_consumer` connector to reconnect upon more error conditions and avoid stalls.
+- Include flow alias in pipeline and connector aliases reported via metrics events and logging in order to deduplicate entries
 
 ## [0.12.4]
 

--- a/src/connectors/impls/bench.rs
+++ b/src/connectors/impls/bench.rs
@@ -83,7 +83,7 @@ fn decode<T: AsRef<[u8]>>(base64: bool, data: T) -> Result<Vec<u8>> {
 impl ConnectorBuilder for Builder {
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         kill_switch: &KillSwitch,

--- a/src/connectors/impls/bench.rs
+++ b/src/connectors/impls/bench.rs
@@ -83,7 +83,7 @@ fn decode<T: AsRef<[u8]>>(base64: bool, data: T) -> Result<Vec<u8>> {
 impl ConnectorBuilder for Builder {
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         kill_switch: &KillSwitch,

--- a/src/connectors/impls/cb.rs
+++ b/src/connectors/impls/cb.rs
@@ -54,7 +54,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         kill_switch: &KillSwitch,
@@ -218,7 +218,7 @@ impl CbSource {
         };
         self.finished && all_received
     }
-    async fn new(config: &Config, alias: &ConnectorAlias, kill_switch: KillSwitch) -> Result<Self> {
+    async fn new(config: &Config, alias: &Alias, kill_switch: KillSwitch) -> Result<Self> {
         if let Some(path) = config.path.as_ref() {
             let file = open(path).await?;
             Ok(Self {

--- a/src/connectors/impls/cb.rs
+++ b/src/connectors/impls/cb.rs
@@ -17,7 +17,7 @@
 use std::time::Duration;
 
 use crate::system::{KillSwitch, ShutdownMode};
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_connector_def};
 use async_std::io::prelude::BufReadExt;
 use async_std::stream::StreamExt;
 use async_std::{fs::File, io};
@@ -54,7 +54,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         raw: &Value,
         kill_switch: &KillSwitch,
@@ -218,7 +218,7 @@ impl CbSource {
         };
         self.finished && all_received
     }
-    async fn new(config: &Config, alias: &str, kill_switch: KillSwitch) -> Result<Self> {
+    async fn new(config: &Config, alias: &ConnectorAlias, kill_switch: KillSwitch) -> Result<Self> {
         if let Some(path) = config.path.as_ref() {
             let file = open(path).await?;
             Ok(Self {
@@ -236,7 +236,7 @@ impl CbSource {
                 kill_switch,
             })
         } else {
-            Err(err_conector_def(alias, "Missing path key."))
+            Err(err_connector_def(alias, "Missing path key."))
         }
     }
 }

--- a/src/connectors/impls/clickhouse.rs
+++ b/src/connectors/impls/clickhouse.rs
@@ -35,7 +35,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _alias: &str,
+        _alias: &ConnectorAlias,
         _config: &ConnectorConfig,
         connector_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/clickhouse.rs
+++ b/src/connectors/impls/clickhouse.rs
@@ -35,7 +35,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _alias: &ConnectorAlias,
+        _alias: &Alias,
         _config: &ConnectorConfig,
         connector_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/crononome.rs
+++ b/src/connectors/impls/crononome.rs
@@ -38,7 +38,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/crononome.rs
+++ b/src/connectors/impls/crononome.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 mod handler;
 
-use crate::{connectors::prelude::*, errors::err_conector_def, system::KillSwitch};
+use crate::{connectors::prelude::*, errors::err_connector_def, system::KillSwitch};
 use handler::{ChronomicQueue, CronEntryInt};
 use serde_yaml::Value as YamlValue;
 use tremor_common::time::nanotime;
@@ -38,7 +38,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,
@@ -59,7 +59,7 @@ impl ConnectorBuilder for Builder {
                 .map(CronEntryInt::try_from)
                 .collect::<Result<Vec<CronEntryInt>>>()?
         } else {
-            return Err(err_conector_def(id, "missing `entries` array"));
+            return Err(err_connector_def(id, "missing `entries` array"));
         };
 
         Ok(Box::new(Crononome { entries }))

--- a/src/connectors/impls/discord.rs
+++ b/src/connectors/impls/discord.rs
@@ -49,7 +49,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/discord.rs
+++ b/src/connectors/impls/discord.rs
@@ -49,7 +49,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/dns/client.rs
+++ b/src/connectors/impls/dns/client.rs
@@ -35,7 +35,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _raw_config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/dns/client.rs
+++ b/src/connectors/impls/dns/client.rs
@@ -35,7 +35,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _raw_config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/elastic.rs
+++ b/src/connectors/impls/elastic.rs
@@ -21,7 +21,7 @@ use crate::{
         impls::http::utils::Header, prelude::*, sink::concurrency_cap::ConcurrencyCap,
         utils::tls::TLSClientConfig,
     },
-    errors::{err_conector_def, Error, Result},
+    errors::{err_connector_def, Error, Result},
 };
 use async_std::{
     channel::{bounded, Receiver, Sender},
@@ -99,19 +99,19 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(raw_config)?;
         if config.nodes.is_empty() {
-            Err(err_conector_def(id, "empty nodes provided"))
+            Err(err_connector_def(id, "empty nodes provided"))
         } else {
             let node_urls = config
                 .nodes
                 .iter()
-                .map(|s| Url::parse(s.as_str()).map_err(|e| err_conector_def(id, &e)))
+                .map(|s| Url::parse(s.as_str()).map_err(|e| err_connector_def(id, &e)))
                 .collect::<Result<Vec<Url>>>()?;
             let tls_config = match config.tls.as_ref() {
                 Some(Either::Left(tls_config)) => Some(tls_config.clone()),
@@ -122,7 +122,7 @@ impl ConnectorBuilder for Builder {
                 for node_url in &node_urls {
                     if node_url.scheme() != "https" {
                         let e = format!("Node URL '{node_url}' needs 'https' scheme with tls.");
-                        return Err(err_conector_def(id, &e));
+                        return Err(err_connector_def(id, &e));
                     }
                 }
             }
@@ -935,7 +935,7 @@ mod tests {
     use elasticsearch::http::request::Body;
 
     use super::*;
-    use crate::config::Connector as ConnectorConfig;
+    use crate::{config::Connector as ConnectorConfig, system::flow::FlowAlias};
 
     #[async_std::test]
     async fn connector_builder_empty_nodes() -> Result<()> {
@@ -944,14 +944,17 @@ mod tests {
                 "nodes": []
             }
         });
-        let id = "my_elastic";
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_elastic");
         let builder = super::Builder::default();
-        let connector_config = ConnectorConfig::from_config(id, builder.connector_type(), &config)?;
+        let connector_config =
+            ConnectorConfig::from_config(&alias, builder.connector_type(), &config)?;
         let kill_switch = KillSwitch::dummy();
         assert_eq!(
-            String::from("Invalid Definition for connector \"my_elastic\": empty nodes provided"),
+            String::from(
+                "Invalid Definition for connector \"flow::my_elastic\": empty nodes provided"
+            ),
             builder
-                .build("my_elastic", &connector_config, &kill_switch)
+                .build(&alias, &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap()
@@ -970,16 +973,17 @@ mod tests {
                 ]
             }
         });
-        let id = "my_elastic";
+        let alias = ConnectorAlias::new(FlowAlias::new("snot"), "my_elastic");
         let builder = super::Builder::default();
-        let connector_config = ConnectorConfig::from_config(id, builder.connector_type(), &config)?;
+        let connector_config =
+            ConnectorConfig::from_config(&alias, builder.connector_type(), &config)?;
         let kill_switch = KillSwitch::dummy();
         assert_eq!(
             String::from(
-                "Invalid Definition for connector \"my_elastic\": relative URL without a base"
+                "Invalid Definition for connector \"snot::my_elastic\": relative URL without a base"
             ),
             builder
-                .build("my_elastic", &connector_config, &kill_switch)
+                .build(&alias, &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap()

--- a/src/connectors/impls/elastic.rs
+++ b/src/connectors/impls/elastic.rs
@@ -99,7 +99,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,
@@ -935,7 +935,7 @@ mod tests {
     use elasticsearch::http::request::Body;
 
     use super::*;
-    use crate::{config::Connector as ConnectorConfig, system::flow::FlowAlias};
+    use crate::config::Connector as ConnectorConfig;
 
     #[async_std::test]
     async fn connector_builder_empty_nodes() -> Result<()> {
@@ -944,7 +944,7 @@ mod tests {
                 "nodes": []
             }
         });
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_elastic");
+        let alias = Alias::new("flow", "my_elastic");
         let builder = super::Builder::default();
         let connector_config =
             ConnectorConfig::from_config(&alias, builder.connector_type(), &config)?;
@@ -973,7 +973,7 @@ mod tests {
                 ]
             }
         });
-        let alias = ConnectorAlias::new(FlowAlias::new("snot"), "my_elastic");
+        let alias = Alias::new("snot", "my_elastic");
         let builder = super::Builder::default();
         let connector_config =
             ConnectorConfig::from_config(&alias, builder.connector_type(), &config)?;

--- a/src/connectors/impls/exit.rs
+++ b/src/connectors/impls/exit.rs
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         config: &ConnectorConfig,
         kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/exit.rs
+++ b/src/connectors/impls/exit.rs
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         config: &ConnectorConfig,
         kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/file.rs
+++ b/src/connectors/impls/file.rs
@@ -96,7 +96,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/file.rs
+++ b/src/connectors/impls/file.rs
@@ -96,7 +96,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gbq/writer.rs
+++ b/src/connectors/impls/gbq/writer.rs
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gbq/writer.rs
+++ b/src/connectors/impls/gbq/writer.rs
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gbq/writer/sink.rs
+++ b/src/connectors/impls/gbq/writer/sink.rs
@@ -377,7 +377,7 @@ impl Sink for GbqSink {
     }
 
     async fn connect(&mut self, ctx: &SinkContext, _attempt: &Attempt) -> Result<bool> {
-        error!("{} Connecting to BigQuery", ctx);
+        info!("{ctx} Connecting to BigQuery");
         let token = Token::new()?;
 
         let tls_config = ClientTlsConfig::new()
@@ -390,13 +390,14 @@ impl Sink for GbqSink {
             .connect()
             .await?;
 
+        let interceptor_ctx = ctx.clone();
         let mut client = BigQueryWriteClient::with_interceptor(
             channel,
             AuthInterceptor {
                 token: Box::new(move || match token.header_value() {
                     Ok(val) => Ok(val),
                     Err(e) => {
-                        error!("Failed to get token for BigQuery: {}", e);
+                        error!("{interceptor_ctx} Failed to get token for BigQuery: {}", e);
 
                         Err(Status::unavailable(
                             "Failed to retrieve authentication token.",
@@ -449,6 +450,7 @@ mod test {
     use crate::connectors::impls::gbq;
     use crate::connectors::reconnect::ConnectionLostNotifier;
     use crate::connectors::tests::ConnectorHarness;
+    use crate::system::flow::FlowAlias;
     use googapis::google::cloud::bigquery::storage::v1::table_field_schema::Mode;
     use std::sync::Arc;
     use value_trait::StaticNode;
@@ -471,7 +473,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: "".to_string(),
+                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -500,7 +502,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: "".to_string(),
+                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -538,7 +540,7 @@ mod test {
                 }],
                 &SinkContext {
                     uid: Default::default(),
-                    alias: "".to_string(),
+                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -578,7 +580,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: "".to_string(),
+                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -803,7 +805,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -852,7 +854,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -896,7 +898,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -941,7 +943,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -984,7 +986,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -1019,7 +1021,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: "".to_string(),
+            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -1079,7 +1081,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: "".to_string(),
+                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -1089,7 +1091,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    "",
+                    &ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                 )
                 .unwrap(),
                 0,
@@ -1124,7 +1126,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: "".to_string(),
+                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -1134,7 +1136,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    "",
+                    &ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
                 )
                 .unwrap(),
                 0,

--- a/src/connectors/impls/gbq/writer/sink.rs
+++ b/src/connectors/impls/gbq/writer/sink.rs
@@ -450,7 +450,6 @@ mod test {
     use crate::connectors::impls::gbq;
     use crate::connectors::reconnect::ConnectionLostNotifier;
     use crate::connectors::tests::ConnectorHarness;
-    use crate::system::flow::FlowAlias;
     use googapis::google::cloud::bigquery::storage::v1::table_field_schema::Mode;
     use std::sync::Arc;
     use value_trait::StaticNode;
@@ -473,7 +472,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                alias: Alias::new("flow", "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -502,7 +501,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                alias: Alias::new("flow", "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -540,7 +539,7 @@ mod test {
                 }],
                 &SinkContext {
                     uid: Default::default(),
-                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                    alias: Alias::new("flow", "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -580,7 +579,7 @@ mod test {
             }],
             &SinkContext {
                 uid: Default::default(),
-                alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                alias: Alias::new("flow", "connector"),
                 connector_type: Default::default(),
                 quiescence_beacon: Default::default(),
                 notifier: ConnectionLostNotifier::new(rx),
@@ -805,7 +804,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -854,7 +853,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -898,7 +897,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -943,7 +942,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -986,7 +985,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -1021,7 +1020,7 @@ mod test {
 
         let sink_context = SinkContext {
             uid: Default::default(),
-            alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+            alias: Alias::new("flow", "connector"),
             connector_type: Default::default(),
             quiescence_beacon: Default::default(),
             notifier: ConnectionLostNotifier::new(rx),
@@ -1081,7 +1080,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                    alias: Alias::new("flow", "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -1091,7 +1090,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    &ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                    &Alias::new("flow", "connector"),
                 )
                 .unwrap(),
                 0,
@@ -1126,7 +1125,7 @@ mod test {
                 Event::signal_tick(),
                 &SinkContext {
                     uid: Default::default(),
-                    alias: ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                    alias: Alias::new("flow", "connector"),
                     connector_type: Default::default(),
                     quiescence_beacon: Default::default(),
                     notifier: ConnectionLostNotifier::new(rx),
@@ -1136,7 +1135,7 @@ mod test {
                     CodecReq::Structured,
                     vec![],
                     &ConnectorType::from(""),
-                    &ConnectorAlias::new(FlowAlias::new("flow"), "connector"),
+                    &Alias::new("flow", "connector"),
                 )
                 .unwrap(),
                 0,

--- a/src/connectors/impls/gpubsub/consumer.rs
+++ b/src/connectors/impls/gpubsub/consumer.rs
@@ -70,7 +70,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &str,
+        alias: &ConnectorAlias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gpubsub/consumer.rs
+++ b/src/connectors/impls/gpubsub/consumer.rs
@@ -70,7 +70,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &ConnectorAlias,
+        alias: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -14,7 +14,7 @@
 
 use crate::connectors::google::AuthInterceptor;
 use crate::connectors::prelude::{
-    Attempt, ConnectorAlias, ErrorKind, EventSerializer, KillSwitch, SinkAddr, SinkContext,
+    Alias, Attempt, ErrorKind, EventSerializer, KillSwitch, SinkAddr, SinkContext,
     SinkManagerBuilder, SinkReply, Url,
 };
 use crate::connectors::sink::Sink;
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _alias: &ConnectorAlias,
+        _alias: &Alias,
         _config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/gpubsub/producer.rs
+++ b/src/connectors/impls/gpubsub/producer.rs
@@ -14,8 +14,8 @@
 
 use crate::connectors::google::AuthInterceptor;
 use crate::connectors::prelude::{
-    Attempt, ErrorKind, EventSerializer, KillSwitch, SinkAddr, SinkContext, SinkManagerBuilder,
-    SinkReply, Url,
+    Attempt, ConnectorAlias, ErrorKind, EventSerializer, KillSwitch, SinkAddr, SinkContext,
+    SinkManagerBuilder, SinkReply, Url,
 };
 use crate::connectors::sink::Sink;
 use crate::connectors::utils::url::HttpsDefaults;
@@ -60,7 +60,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _alias: &str,
+        _alias: &ConnectorAlias,
         _config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/http/client.rs
+++ b/src/connectors/impls/http/client.rs
@@ -29,7 +29,7 @@ use super::utils::{Header, RequestId};
 use crate::connectors::sink::concurrency_cap::ConcurrencyCap;
 use crate::connectors::utils::mime::MimeCodecMap;
 use crate::connectors::utils::tls::{tls_client_config, TLSClientConfig};
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_connector_def};
 
 const CONNECTOR_TYPE: &str = "http_client";
 const DEFAULT_CODEC: &str = "json";
@@ -87,7 +87,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         connector_config: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -103,9 +103,9 @@ impl ConnectorBuilder for Builder {
             Some(Either::Right(false)) | None => None,
         };
         if config.url.scheme() == "https" && tls_client_config.is_none() {
-            return Err(err_conector_def(
+            return Err(err_connector_def(
                     id,
-                    &format!("missing tls config for {id} with 'https' url. Set 'tls' to 'true' or provide a full tls config."),
+                    &format!("missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config."),
                 ));
         }
         let (response_tx, response_rx) = bounded(crate::QSIZE.load(Ordering::Relaxed));

--- a/src/connectors/impls/http/client.rs
+++ b/src/connectors/impls/http/client.rs
@@ -87,7 +87,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         connector_config: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/http/client.rs
+++ b/src/connectors/impls/http/client.rs
@@ -105,7 +105,7 @@ impl ConnectorBuilder for Builder {
         if config.url.scheme() == "https" && tls_client_config.is_none() {
             return Err(err_connector_def(
                     id,
-                    &format!("missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config."),
+                    "missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config.",
                 ));
         }
         let (response_tx, response_rx) = bounded(crate::QSIZE.load(Ordering::Relaxed));

--- a/src/connectors/impls/http/meta.rs
+++ b/src/connectors/impls/http/meta.rs
@@ -323,6 +323,8 @@ pub(super) fn extract_response_meta(response: &Response) -> Value<'static> {
 
 #[cfg(test)]
 mod test {
+    use crate::system::flow::FlowAlias;
+
     use super::*;
     #[async_std::test]
     async fn builder() -> Result<()> {
@@ -338,7 +340,7 @@ mod test {
             CodecReq::Optional("json"),
             vec![],
             &ConnectorType("http".into()),
-            "http",
+            &ConnectorAlias::new(FlowAlias::new("flow"), "http"),
         )?;
         let config = client::Config::new(&c)?;
         let configured_codec = "json";

--- a/src/connectors/impls/http/meta.rs
+++ b/src/connectors/impls/http/meta.rs
@@ -323,8 +323,6 @@ pub(super) fn extract_response_meta(response: &Response) -> Value<'static> {
 
 #[cfg(test)]
 mod test {
-    use crate::system::flow::FlowAlias;
-
     use super::*;
     #[async_std::test]
     async fn builder() -> Result<()> {
@@ -340,7 +338,7 @@ mod test {
             CodecReq::Optional("json"),
             vec![],
             &ConnectorType("http".into()),
-            &ConnectorAlias::new(FlowAlias::new("flow"), "http"),
+            &Alias::new("flow", "http"),
         )?;
         let config = client::Config::new(&c)?;
         let configured_codec = "json";

--- a/src/connectors/impls/http/server.rs
+++ b/src/connectors/impls/http/server.rs
@@ -70,7 +70,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         raw_config: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/http/server.rs
+++ b/src/connectors/impls/http/server.rs
@@ -16,7 +16,7 @@ use crate::connectors::{
     prelude::*,
     utils::{mime::MimeCodecMap, tls::TLSServerConfig},
 };
-use crate::{connectors::spawn_task, errors::err_conector_def};
+use crate::{connectors::spawn_task, errors::err_connector_def};
 use async_std::channel::unbounded;
 use async_std::{
     channel::{bounded, Receiver, Sender},
@@ -70,7 +70,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         raw_config: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -79,7 +79,7 @@ impl ConnectorBuilder for Builder {
         let tls_server_config = config.tls.clone();
 
         if tls_server_config.is_some() && config.url.scheme() != "https" {
-            return Err(err_conector_def(id, Self::HTTPS_REQUIRED));
+            return Err(err_connector_def(id, Self::HTTPS_REQUIRED));
         }
         let origin_uri = EventOriginUri {
             scheme: "http-server".to_string(),

--- a/src/connectors/impls/kafka.rs
+++ b/src/connectors/impls/kafka.rs
@@ -15,8 +15,8 @@ pub(crate) mod consumer;
 pub(crate) mod producer;
 
 use crate::{
-    connectors::{metrics::make_metrics_payload, Context},
-    errors::{err_conector_def, Result},
+    connectors::{metrics::make_metrics_payload, prelude::ConnectorAlias, Context},
+    errors::{err_connector_def, Result},
 };
 use async_broadcast::Sender as BroadcastSender;
 use async_std::{channel::Sender, task::JoinHandle};
@@ -55,7 +55,7 @@ impl AsyncRuntime for SmolRuntime {
 }
 
 /// verify broker host:port pairs in kafka connector configs
-fn verify_brokers(id: &str, brokers: &[String]) -> Result<(String, Option<u16>)> {
+fn verify_brokers(alias: &ConnectorAlias, brokers: &[String]) -> Result<(String, Option<u16>)> {
     let mut first_broker: Option<(String, Option<u16>)> = None;
     for broker in brokers {
         match broker.split(':').collect::<Vec<_>>().as_slice() {
@@ -63,18 +63,18 @@ fn verify_brokers(id: &str, brokers: &[String]) -> Result<(String, Option<u16>)>
                 first_broker.get_or_insert_with(|| ((*host).to_string(), None));
             }
             [host, port] => {
-                let port: u16 = port
-                    .parse()
-                    .map_err(|_| err_conector_def(id, &format!("Invalid broker: {host}:{port}")))?;
+                let port: u16 = port.parse().map_err(|_| {
+                    err_connector_def(alias, &format!("Invalid broker: {host}:{port}"))
+                })?;
                 first_broker.get_or_insert_with(|| ((*host).to_string(), Some(port)));
             }
             b => {
                 let e = format!("Invalid broker: {}", b.join(":"));
-                return Err(err_conector_def(id, &e));
+                return Err(err_connector_def(alias, &e));
             }
         }
     }
-    first_broker.ok_or_else(|| err_conector_def(id, "Missing brokers."))
+    first_broker.ok_or_else(|| err_connector_def(alias, "Missing brokers."))
 }
 
 /// Returns `true` if the error denotes a failed connect attempt
@@ -354,7 +354,7 @@ mod tests {
             &literal!({
                 "measurement": "kafka_consumer_stats",
                 "tags": {
-                    "connector": "snot"
+                    "connector": "fake::fake"
                 },
                 "fields": {
                     "rx_msgs": 42,

--- a/src/connectors/impls/kafka.rs
+++ b/src/connectors/impls/kafka.rs
@@ -14,10 +14,7 @@
 pub(crate) mod consumer;
 pub(crate) mod producer;
 
-use crate::{
-    connectors::{metrics::make_metrics_payload, prelude::ConnectorAlias, Context},
-    errors::{err_connector_def, Result},
-};
+use crate::connectors::prelude::*;
 use async_broadcast::Sender as BroadcastSender;
 use async_std::{channel::Sender, task::JoinHandle};
 use beef::Cow;
@@ -55,7 +52,7 @@ impl AsyncRuntime for SmolRuntime {
 }
 
 /// verify broker host:port pairs in kafka connector configs
-fn verify_brokers(alias: &ConnectorAlias, brokers: &[String]) -> Result<(String, Option<u16>)> {
+fn verify_brokers(alias: &Alias, brokers: &[String]) -> Result<(String, Option<u16>)> {
     let mut first_broker: Option<(String, Option<u16>)> = None;
     for broker in brokers {
         match broker.split(':').collect::<Vec<_>>().as_slice() {

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -76,7 +76,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &ConnectorAlias,
+        alias: &Alias,
         config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -76,7 +76,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &str,
+        alias: &ConnectorAlias,
         config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -71,7 +71,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &str,
+        alias: &ConnectorAlias,
         config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -71,7 +71,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        alias: &ConnectorAlias,
+        alias: &Alias,
         config: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/kv.rs
+++ b/src/connectors/impls/kv.rs
@@ -19,7 +19,7 @@ use crate::{
         Codec,
     },
     connectors::prelude::*,
-    errors::err_conector_def,
+    errors::err_connector_def,
 };
 use async_std::channel::{bounded, Receiver, Sender};
 use async_std::path::PathBuf;
@@ -181,14 +181,14 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config: Config = Config::new(config)?;
         if !PathBuf::from(&config.dir).is_dir().await {
-            return Err(err_conector_def(id, Builder::INVALID_DIR));
+            return Err(err_connector_def(id, Builder::INVALID_DIR));
         }
 
         let (tx, rx) = bounded(crate::QSIZE.load(Ordering::Relaxed));

--- a/src/connectors/impls/kv.rs
+++ b/src/connectors/impls/kv.rs
@@ -181,7 +181,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/metrics.rs
+++ b/src/connectors/impls/metrics.rs
@@ -57,7 +57,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/metrics.rs
+++ b/src/connectors/impls/metrics.rs
@@ -57,7 +57,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/metronome.rs
+++ b/src/connectors/impls/metronome.rs
@@ -37,7 +37,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,
@@ -137,18 +137,11 @@ impl Source for MetronomeSource {
 #[cfg(test)]
 mod tests {
 
-    use crate::{
-        config::Reconnect,
-        connectors::{
-            prelude::{ConnectorAlias, KillSwitch},
-            ConnectorBuilder,
-        },
-        errors::{Error, Kind as ErrorKind, Result},
-        system::flow::FlowAlias,
-    };
+    use crate::{config::Reconnect, connectors::prelude::*};
+
     #[async_std::test]
     async fn missing_config() -> Result<()> {
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "connector");
+        let alias = Alias::new("flow", "connector");
         let builder = super::Builder::default();
         let connector_config = super::ConnectorConfig {
             connector_type: builder.connector_type(),

--- a/src/connectors/impls/metronome.rs
+++ b/src/connectors/impls/metronome.rs
@@ -37,7 +37,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,
@@ -139,11 +139,16 @@ mod tests {
 
     use crate::{
         config::Reconnect,
-        connectors::{prelude::KillSwitch, ConnectorBuilder},
+        connectors::{
+            prelude::{ConnectorAlias, KillSwitch},
+            ConnectorBuilder,
+        },
         errors::{Error, Kind as ErrorKind, Result},
+        system::flow::FlowAlias,
     };
     #[async_std::test]
     async fn missing_config() -> Result<()> {
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "connector");
         let builder = super::Builder::default();
         let connector_config = super::ConnectorConfig {
             connector_type: builder.connector_type(),
@@ -157,7 +162,7 @@ mod tests {
         let kill_switch = KillSwitch::dummy();
         assert!(matches!(
             builder
-                .build("snot", &connector_config, &kill_switch)
+                .build(&alias, &connector_config, &kill_switch)
                 .await
                 .err()
                 .unwrap(),

--- a/src/connectors/impls/null.rs
+++ b/src/connectors/impls/null.rs
@@ -28,7 +28,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _alias: &ConnectorAlias,
+        _alias: &Alias,
         _config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/null.rs
+++ b/src/connectors/impls/null.rs
@@ -28,7 +28,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build(
         &self,
-        _alias: &str,
+        _alias: &ConnectorAlias,
         _config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/otel/client.rs
+++ b/src/connectors/impls/otel/client.rs
@@ -67,7 +67,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -204,13 +204,11 @@ impl Sink for OtelSink {
 
 #[cfg(test)]
 mod tests {
-    use crate::system::flow::FlowAlias;
-
     use super::*;
 
     #[async_std::test]
     async fn otel_client_builder() -> Result<()> {
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_otel_client");
+        let alias = Alias::new("flow", "my_otel_client");
         let with_processors = literal!({
             "config": {
                 "host": "localhost",

--- a/src/connectors/impls/otel/client.rs
+++ b/src/connectors/impls/otel/client.rs
@@ -67,7 +67,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -204,10 +204,13 @@ impl Sink for OtelSink {
 
 #[cfg(test)]
 mod tests {
+    use crate::system::flow::FlowAlias;
+
     use super::*;
 
     #[async_std::test]
     async fn otel_client_builder() -> Result<()> {
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_otel_client");
         let with_processors = literal!({
             "config": {
                 "host": "localhost",
@@ -215,14 +218,14 @@ mod tests {
             },
         });
         let config: ConnectorConfig = crate::config::Connector::from_config(
-            "my_otel_client",
+            &alias,
             ConnectorType("otel_client".into()),
             &with_processors,
         )?;
 
         let builder = super::Builder::default();
         let kill_switch = KillSwitch::dummy();
-        let _connector = builder.build("foo", &config, &kill_switch).await?;
+        let _connector = builder.build(&alias, &config, &kill_switch).await?;
 
         Ok(())
     }

--- a/src/connectors/impls/otel/server.rs
+++ b/src/connectors/impls/otel/server.rs
@@ -67,7 +67,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -193,15 +193,13 @@ impl Source for OtelSource {
 
 #[cfg(test)]
 mod tests {
-    use crate::system::flow::FlowAlias;
-
     use super::*;
     // use env_logger;
     // use http_types::Method;
 
     #[async_std::test]
     async fn otel_client_builder() -> Result<()> {
-        let alias = ConnectorAlias::new(FlowAlias::new("test"), "my_otel_server");
+        let alias = Alias::new("test", "my_otel_server");
         let with_processors = literal!({
             "config": {
                 "url": "localhost:4317",
@@ -212,7 +210,7 @@ mod tests {
             ConnectorType("otel_server".into()),
             &with_processors,
         )?;
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_otel_server");
+        let alias = Alias::new("flow", "my_otel_server");
 
         let builder = super::Builder::default();
         let kill_switch = KillSwitch::dummy();

--- a/src/connectors/impls/otel/server.rs
+++ b/src/connectors/impls/otel/server.rs
@@ -67,7 +67,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -193,26 +193,30 @@ impl Source for OtelSource {
 
 #[cfg(test)]
 mod tests {
+    use crate::system::flow::FlowAlias;
+
     use super::*;
     // use env_logger;
     // use http_types::Method;
 
     #[async_std::test]
     async fn otel_client_builder() -> Result<()> {
+        let alias = ConnectorAlias::new(FlowAlias::new("test"), "my_otel_server");
         let with_processors = literal!({
             "config": {
                 "url": "localhost:4317",
             },
         });
         let config: ConnectorConfig = crate::config::Connector::from_config(
-            "my_otel_server",
+            &alias,
             ConnectorType("otel_server".into()),
             &with_processors,
         )?;
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "my_otel_server");
 
         let builder = super::Builder::default();
         let kill_switch = KillSwitch::dummy();
-        let _connector = builder.build("foo", &config, &kill_switch).await?;
+        let _connector = builder.build(&alias, &config, &kill_switch).await?;
 
         Ok(())
     }

--- a/src/connectors/impls/s3/reader.rs
+++ b/src/connectors/impls/s3/reader.rs
@@ -84,7 +84,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/s3/reader.rs
+++ b/src/connectors/impls/s3/reader.rs
@@ -84,7 +84,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/s3/writer.rs
+++ b/src/connectors/impls/s3/writer.rs
@@ -59,7 +59,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/s3/writer.rs
+++ b/src/connectors/impls/s3/writer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::Event;
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_connector_def};
 use std::mem;
 use value_trait::ValueAccess;
 
@@ -59,7 +59,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -68,7 +68,7 @@ impl ConnectorBuilder for Builder {
 
         // Maintain the minimum size of 5 MBs.
         if config.min_part_size < MORE_THEN_FIVEMBS {
-            return Err(err_conector_def(id, Self::PART_SIZE));
+            return Err(err_connector_def(id, Self::PART_SIZE));
         }
         Ok(Box::new(S3Connector { config }))
     }

--- a/src/connectors/impls/stdio.rs
+++ b/src/connectors/impls/stdio.rs
@@ -61,7 +61,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _raw_config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/stdio.rs
+++ b/src/connectors/impls/stdio.rs
@@ -61,7 +61,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _raw_config: &ConnectorConfig,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {

--- a/src/connectors/impls/tcp.rs
+++ b/src/connectors/impls/tcp.rs
@@ -36,7 +36,7 @@ where
     wrapped_stream: S,
     underlying_stream: TcpStream,
     buffer: Vec<u8>,
-    alias: String,
+    alias: ConnectorAlias,
     origin_uri: EventOriginUri,
     meta: Value<'static>,
 }
@@ -45,7 +45,7 @@ impl TcpReader<TcpStream> {
     fn new(
         stream: TcpStream,
         buffer: Vec<u8>,
-        alias: String,
+        alias: ConnectorAlias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {
@@ -65,7 +65,7 @@ impl TcpReader<ReadHalf<async_tls::server::TlsStream<TcpStream>>> {
         stream: ReadHalf<async_tls::server::TlsStream<TcpStream>>,
         underlying_stream: TcpStream,
         buffer: Vec<u8>,
-        alias: String,
+        alias: ConnectorAlias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {
@@ -85,7 +85,7 @@ impl TcpReader<ReadHalf<async_tls::client::TlsStream<TcpStream>>> {
         stream: ReadHalf<async_tls::client::TlsStream<TcpStream>>,
         underlying_stream: TcpStream,
         buffer: Vec<u8>,
-        alias: String,
+        alias: ConnectorAlias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {

--- a/src/connectors/impls/tcp.rs
+++ b/src/connectors/impls/tcp.rs
@@ -36,7 +36,7 @@ where
     wrapped_stream: S,
     underlying_stream: TcpStream,
     buffer: Vec<u8>,
-    alias: ConnectorAlias,
+    alias: Alias,
     origin_uri: EventOriginUri,
     meta: Value<'static>,
 }
@@ -45,7 +45,7 @@ impl TcpReader<TcpStream> {
     fn new(
         stream: TcpStream,
         buffer: Vec<u8>,
-        alias: ConnectorAlias,
+        alias: Alias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {
@@ -65,7 +65,7 @@ impl TcpReader<ReadHalf<async_tls::server::TlsStream<TcpStream>>> {
         stream: ReadHalf<async_tls::server::TlsStream<TcpStream>>,
         underlying_stream: TcpStream,
         buffer: Vec<u8>,
-        alias: ConnectorAlias,
+        alias: Alias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {
@@ -85,7 +85,7 @@ impl TcpReader<ReadHalf<async_tls::client::TlsStream<TcpStream>>> {
         stream: ReadHalf<async_tls::client::TlsStream<TcpStream>>,
         underlying_stream: TcpStream,
         buffer: Vec<u8>,
-        alias: ConnectorAlias,
+        alias: Alias,
         origin_uri: EventOriginUri,
         meta: Value<'static>,
     ) -> Self {

--- a/src/connectors/impls/tcp/client.rs
+++ b/src/connectors/impls/tcp/client.rs
@@ -20,7 +20,7 @@
 
 use super::TcpReader;
 use crate::connectors::utils::tls::{tls_client_connector, TLSClientConfig};
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_connector_def};
 use async_std::channel::{bounded, Receiver, Sender};
 use async_std::net::TcpStream;
 use async_std::prelude::*;
@@ -68,18 +68,18 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
     ) -> Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         if config.url.port().is_none() {
-            return Err(err_conector_def(id, Self::MISSING_PORT));
+            return Err(err_connector_def(id, Self::MISSING_PORT));
         }
         let host = match config.url.host_str() {
             Some(host) => host.to_string(),
-            None => return Err(err_conector_def(id, Self::MISSING_HOST)),
+            None => return Err(err_connector_def(id, Self::MISSING_HOST)),
         };
         let (tls_connector, tls_domain) = match config.tls.as_ref() {
             Some(Either::Right(true)) => {

--- a/src/connectors/impls/tcp/client.rs
+++ b/src/connectors/impls/tcp/client.rs
@@ -68,7 +68,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/tcp/server.rs
+++ b/src/connectors/impls/tcp/server.rs
@@ -21,7 +21,7 @@ use crate::{
             ConnectionMeta,
         },
     },
-    errors::err_conector_def,
+    errors::err_connector_def,
 };
 use async_std::{
     channel::{bounded, Receiver, Sender},
@@ -67,14 +67,14 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
     ) -> crate::errors::Result<Box<dyn Connector>> {
         let config = Config::new(config)?;
         if config.url.port().is_none() {
-            return Err(err_conector_def(id, "Missing port for TCP server"));
+            return Err(err_connector_def(id, "Missing port for TCP server"));
         }
         let tls_server_config = if let Some(tls_config) = config.tls.as_ref() {
             Some(load_server_config(tls_config)?)

--- a/src/connectors/impls/tcp/server.rs
+++ b/src/connectors/impls/tcp/server.rs
@@ -67,7 +67,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/udp/client.rs
+++ b/src/connectors/impls/udp/client.rs
@@ -43,7 +43,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/udp/client.rs
+++ b/src/connectors/impls/udp/client.rs
@@ -43,7 +43,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/udp/server.rs
+++ b/src/connectors/impls/udp/server.rs
@@ -42,7 +42,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/udp/server.rs
+++ b/src/connectors/impls/udp/server.rs
@@ -42,7 +42,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         raw: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/unix_socket/client.rs
+++ b/src/connectors/impls/unix_socket/client.rs
@@ -43,7 +43,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         conf: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/unix_socket/client.rs
+++ b/src/connectors/impls/unix_socket/client.rs
@@ -43,7 +43,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         conf: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/unix_socket/server.rs
+++ b/src/connectors/impls/unix_socket/server.rs
@@ -66,7 +66,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/unix_socket/server.rs
+++ b/src/connectors/impls/unix_socket/server.rs
@@ -66,7 +66,7 @@ impl ConnectorBuilder for Builder {
 
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/wal.rs
+++ b/src/connectors/impls/wal.rs
@@ -45,7 +45,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &str,
+        _: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/wal.rs
+++ b/src/connectors/impls/wal.rs
@@ -45,7 +45,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _: &ConnectorAlias,
+        _: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/ws/client.rs
+++ b/src/connectors/impls/ws/client.rs
@@ -64,7 +64,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &ConnectorAlias,
+        id: &Alias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/ws/client.rs
+++ b/src/connectors/impls/ws/client.rs
@@ -17,7 +17,7 @@
 
 use super::{WsReader, WsWriter};
 use crate::connectors::utils::tls::{tls_client_connector, TLSClientConfig};
-use crate::{connectors::prelude::*, errors::err_conector_def};
+use crate::{connectors::prelude::*, errors::err_connector_def};
 use async_std::net::TcpStream;
 use async_tls::TlsConnector;
 use async_tungstenite::client_async;
@@ -64,7 +64,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        id: &str,
+        id: &ConnectorAlias,
         _: &ConnectorConfig,
         config: &Value,
         _kill_switch: &KillSwitch,
@@ -73,11 +73,11 @@ impl ConnectorBuilder for Builder {
         let host = config
             .url
             .host()
-            .ok_or_else(|| err_conector_def(id, Self::MISSING_HOST))?
+            .ok_or_else(|| err_connector_def(id, Self::MISSING_HOST))?
             .to_string();
         // TODO: do we really need to make the port required when we have a default defined on the URL?
         if config.url.port().is_none() {
-            return Err(err_conector_def(id, Self::MISSING_PORT));
+            return Err(err_connector_def(id, Self::MISSING_PORT));
         };
 
         let (tls_connector, tls_domain) = match config.tls.as_ref() {

--- a/src/connectors/impls/ws/server.rs
+++ b/src/connectors/impls/ws/server.rs
@@ -56,7 +56,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _id: &ConnectorAlias,
+        _id: &Alias,
         _: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/impls/ws/server.rs
+++ b/src/connectors/impls/ws/server.rs
@@ -56,7 +56,7 @@ impl ConnectorBuilder for Builder {
     }
     async fn build_cfg(
         &self,
-        _id: &str,
+        _id: &ConnectorAlias,
         _: &ConnectorConfig,
         raw_config: &Value,
         _kill_switch: &KillSwitch,

--- a/src/connectors/prelude.rs
+++ b/src/connectors/prelude.rs
@@ -31,7 +31,7 @@ pub(crate) use crate::connectors::{
     StreamDone, StreamIdGen, ACCEPT_TIMEOUT,
 };
 pub(crate) use crate::errors::{Error, Kind as ErrorKind, Result};
-pub(crate) use crate::system::KillSwitch;
+pub(crate) use crate::system::{flow::ConnectorAlias, KillSwitch};
 pub(crate) use crate::utils::hostname;
 pub(crate) use crate::{Event, QSIZE};
 pub(crate) use std::sync::atomic::Ordering;

--- a/src/connectors/prelude.rs
+++ b/src/connectors/prelude.rs
@@ -27,11 +27,11 @@ pub(crate) use crate::connectors::utils::{
     url::{Defaults, Url},
 };
 pub(crate) use crate::connectors::{
-    spawn_task, CodecReq, Connector, ConnectorBuilder, ConnectorContext, ConnectorType, Context,
-    StreamDone, StreamIdGen, ACCEPT_TIMEOUT,
+    metrics::make_metrics_payload, spawn_task, Alias, CodecReq, Connector, ConnectorBuilder,
+    ConnectorContext, ConnectorType, Context, StreamDone, StreamIdGen, ACCEPT_TIMEOUT,
 };
-pub(crate) use crate::errors::{Error, Kind as ErrorKind, Result};
-pub(crate) use crate::system::{flow::ConnectorAlias, KillSwitch};
+pub(crate) use crate::errors::{err_connector_def, Error, Kind as ErrorKind, Result};
+pub(crate) use crate::system::KillSwitch;
 pub(crate) use crate::utils::hostname;
 pub(crate) use crate::{Event, QSIZE};
 pub(crate) use std::sync::atomic::Ordering;

--- a/src/connectors/sink.rs
+++ b/src/connectors/sink.rs
@@ -28,12 +28,11 @@ use crate::config::{
     Codec as CodecConfig, Connector as ConnectorConfig, Postprocessor as PostprocessorConfig,
 };
 use crate::connectors::utils::reconnect::{Attempt, ConnectionLostNotifier};
-use crate::connectors::{ConnectorType, Context, Msg, QuiescenceBeacon, StreamDone};
+use crate::connectors::{Alias, ConnectorType, Context, Msg, QuiescenceBeacon, StreamDone};
 use crate::errors::Result;
 use crate::pipeline;
 use crate::postprocessor::{finish, make_postprocessors, postprocess, Postprocessors};
 use crate::primerge::PriorityMerge;
-use crate::system::flow::ConnectorAlias;
 use async_std::channel::{bounded, unbounded, Receiver, Sender};
 use async_std::stream::StreamExt; // for .next() on PriorityMerge
 use async_std::task;
@@ -253,7 +252,7 @@ pub(crate) struct SinkContext {
     /// the connector unique identifier
     pub(crate) uid: SinkId,
     /// the connector alias
-    pub(crate) alias: ConnectorAlias,
+    pub(crate) alias: Alias,
     /// the connector type
     pub(crate) connector_type: ConnectorType,
 
@@ -271,7 +270,7 @@ impl Display for SinkContext {
 }
 
 impl Context for SinkContext {
-    fn alias(&self) -> &ConnectorAlias {
+    fn alias(&self) -> &Alias {
         &self.alias
     }
 
@@ -389,7 +388,7 @@ impl SinkManagerBuilder {
 pub(crate) fn builder(
     config: &ConnectorConfig,
     connector_codec_requirement: CodecReq,
-    alias: &ConnectorAlias,
+    alias: &Alias,
     qsize: usize,
     metrics_reporter: SinkReporter,
 ) -> Result<SinkManagerBuilder> {
@@ -436,7 +435,7 @@ impl EventSerializer {
         default_codec: CodecReq,
         postprocessor_configs: Vec<PostprocessorConfig>,
         connector_type: &ConnectorType,
-        alias: &ConnectorAlias,
+        alias: &Alias,
     ) -> Result<Self> {
         let codec_config = match default_codec {
             CodecReq::Structured => {

--- a/src/connectors/source.rs
+++ b/src/connectors/source.rs
@@ -38,7 +38,7 @@ use crate::config::{
 use crate::connectors::{
     metrics::SourceReporter,
     utils::reconnect::{Attempt, ConnectionLostNotifier},
-    ConnectorType, Context, Msg, QuiescenceBeacon, StreamDone,
+    Alias, ConnectorType, Context, Msg, QuiescenceBeacon, StreamDone,
 };
 use crate::errors::{Error, Result};
 use crate::pipeline;
@@ -46,7 +46,6 @@ use crate::preprocessor::{finish, make_preprocessors, preprocess, Preprocessors}
 use crate::{
     codec::{self, Codec},
     pipeline::InputTarget,
-    system::flow::ConnectorAlias,
 };
 use async_std::channel::{Receiver, Sender};
 use beef::Cow;
@@ -283,7 +282,7 @@ pub(crate) struct SourceContext {
     /// connector uid
     pub uid: SourceId,
     /// connector alias
-    pub(crate) alias: ConnectorAlias,
+    pub(crate) alias: Alias,
 
     /// connector type
     pub(crate) connector_type: ConnectorType,
@@ -301,7 +300,7 @@ impl Display for SourceContext {
 }
 
 impl Context for SourceContext {
-    fn alias(&self) -> &ConnectorAlias {
+    fn alias(&self) -> &Alias {
         &self.alias
     }
 
@@ -1275,7 +1274,7 @@ where
 /// preprocessor or codec errors are turned into events to the ERR port of the source/connector
 #[allow(clippy::too_many_arguments)]
 fn build_events(
-    alias: &ConnectorAlias,
+    alias: &Alias,
     stream_state: &mut StreamState,
     ingest_ns: &mut u64,
     pull_id: u64,
@@ -1344,7 +1343,7 @@ fn build_events(
 /// preprocessor or codec errors are turned into events to the ERR port of the source/connector
 #[allow(clippy::too_many_arguments)]
 fn build_last_events(
-    alias: &ConnectorAlias,
+    alias: &Alias,
     stream_state: &mut StreamState,
     ingest_ns: &mut u64,
     pull_id: u64,
@@ -1405,7 +1404,7 @@ fn build_last_events(
 
 /// create an error payload
 fn make_error(
-    connector_alias: &ConnectorAlias,
+    connector_alias: &Alias,
     error: &Error,
     stream_id: u64,
     pull_id: u64,

--- a/src/connectors/source.rs
+++ b/src/connectors/source.rs
@@ -46,6 +46,7 @@ use crate::preprocessor::{finish, make_preprocessors, preprocess, Preprocessors}
 use crate::{
     codec::{self, Codec},
     pipeline::InputTarget,
+    system::flow::ConnectorAlias,
 };
 use async_std::channel::{Receiver, Sender};
 use beef::Cow;
@@ -282,7 +283,7 @@ pub(crate) struct SourceContext {
     /// connector uid
     pub uid: SourceId,
     /// connector alias
-    pub(crate) alias: String,
+    pub(crate) alias: ConnectorAlias,
 
     /// connector type
     pub(crate) connector_type: ConnectorType,
@@ -300,7 +301,7 @@ impl Display for SourceContext {
 }
 
 impl Context for SourceContext {
-    fn alias(&self) -> &str {
+    fn alias(&self) -> &ConnectorAlias {
         &self.alias
     }
 
@@ -1274,7 +1275,7 @@ where
 /// preprocessor or codec errors are turned into events to the ERR port of the source/connector
 #[allow(clippy::too_many_arguments)]
 fn build_events(
-    alias: &str,
+    alias: &ConnectorAlias,
     stream_state: &mut StreamState,
     ingest_ns: &mut u64,
     pull_id: u64,
@@ -1343,7 +1344,7 @@ fn build_events(
 /// preprocessor or codec errors are turned into events to the ERR port of the source/connector
 #[allow(clippy::too_many_arguments)]
 fn build_last_events(
-    alias: &str,
+    alias: &ConnectorAlias,
     stream_state: &mut StreamState,
     ingest_ns: &mut u64,
     pull_id: u64,
@@ -1404,7 +1405,7 @@ fn build_last_events(
 
 /// create an error payload
 fn make_error(
-    connector_alias: &str,
+    connector_alias: &ConnectorAlias,
     error: &Error,
     stream_id: u64,
     pull_id: u64,

--- a/src/connectors/tests/http/client.rs
+++ b/src/connectors/tests/http/client.rs
@@ -642,7 +642,7 @@ async fn missing_tls_config_https() -> Result<()> {
         .err()
         .unwrap();
 
-    assert_eq!("Invalid Definition for connector \"missing_tls_config_https\": missing tls config for missing_tls_config_https with 'https' url. Set 'tls' to 'true' or provide a full tls config.", &res.to_string());
+    assert_eq!("Invalid Definition for connector \"test::missing_tls_config_https\": missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config.", &res.to_string());
 
     Ok(())
 }

--- a/src/connectors/tests/kafka/consumer.rs
+++ b/src/connectors/tests/kafka/consumer.rs
@@ -250,7 +250,7 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "connector_kafka_consumer_transactional_retry",
+            "source": "test::connector_kafka_consumer_transactional_retry",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),
@@ -477,7 +477,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "connector_kafka_consumer_transactional_no_retry",
+            "source": "test::connector_kafka_consumer_transactional_no_retry",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),
@@ -705,7 +705,7 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "connector_kafka_consumer_non_transactional",
+            "source": "test::connector_kafka_consumer_non_transactional",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),

--- a/src/connectors/tests/mod.rs
+++ b/src/connectors/tests/mod.rs
@@ -58,11 +58,14 @@ mod bench;
 
 use crate::{
     config,
-    connectors::{self, builtin_connector_types, source::SourceMsg, Connectivity, StatusReport},
+    connectors::{
+        self, builtin_connector_types, source::SourceMsg, Alias as ConnectorAlias, Connectivity,
+        StatusReport,
+    },
     errors::Result,
     instance::State,
     pipeline,
-    system::flow::{ConnectorAlias, FlowAlias, PipelineAlias},
+    system::flow::Alias as FlowAlias,
     Event, QSIZE,
 };
 use async_std::{
@@ -96,7 +99,7 @@ impl ConnectorHarness {
         input_ports: Vec<Cow<'static, str>>,
         output_ports: Vec<Cow<'static, str>>,
     ) -> Result<Self> {
-        let alias = ConnectorAlias::new(FlowAlias::new("test"), alias);
+        let alias = ConnectorAlias::new("test", alias);
         let mut connector_id_gen = ConnectorIdGen::new();
         let mut known_connectors = HashMap::new();
 
@@ -354,7 +357,7 @@ impl TestPipeline {
         let (tx, rx) = bounded(qsize);
         let (tx_cf, rx_cf) = bounded(qsize);
         let (tx_mgmt, rx_mgmt) = bounded(qsize);
-        let pipeline_id = PipelineAlias::new(flow_id, alias);
+        let pipeline_id = pipeline::Alias::new(flow_id, alias);
         let addr = pipeline::Addr::new(tx, tx_cf, tx_mgmt, pipeline_id);
         Self {
             rx,

--- a/src/connectors/utils/metrics.rs
+++ b/src/connectors/utils/metrics.rs
@@ -20,7 +20,7 @@ use tremor_pipeline::MetricsSender;
 use tremor_script::EventPayload;
 use tremor_value::prelude::*;
 
-use crate::system::flow::ConnectorAlias;
+use crate::connectors::Alias;
 
 const FLOW: Cow<'static, str> = Cow::const_str("flow");
 const CONNECTOR: Cow<'static, str> = Cow::const_str("connector");
@@ -29,7 +29,7 @@ const CONNECTOR_EVENTS: Cow<'static, str> = Cow::const_str("connector_events");
 
 /// metrics reporter for connector sources
 pub struct SourceReporter {
-    alias: ConnectorAlias,
+    alias: Alias,
     metrics_out: u64,
     metrics_err: u64,
     tx: MetricsSender,
@@ -38,11 +38,7 @@ pub struct SourceReporter {
 }
 
 impl SourceReporter {
-    pub(crate) fn new(
-        alias: ConnectorAlias,
-        tx: MetricsSender,
-        flush_interval_s: Option<u64>,
-    ) -> Self {
+    pub(crate) fn new(alias: Alias, tx: MetricsSender, flush_interval_s: Option<u64>) -> Self {
         Self {
             alias,
             metrics_out: 0,
@@ -89,7 +85,7 @@ impl SourceReporter {
 
 /// metrics reporter for connector sinks
 pub(crate) struct SinkReporter {
-    alias: ConnectorAlias,
+    alias: Alias,
     metrics_in: u64,
     tx: MetricsSender,
     flush_interval_ns: Option<u64>,
@@ -97,11 +93,7 @@ pub(crate) struct SinkReporter {
 }
 
 impl SinkReporter {
-    pub(crate) fn new(
-        alias: ConnectorAlias,
-        tx: MetricsSender,
-        flush_interval_s: Option<u64>,
-    ) -> Self {
+    pub(crate) fn new(alias: Alias, tx: MetricsSender, flush_interval_s: Option<u64>) -> Self {
         Self {
             alias,
             metrics_in: 0,
@@ -138,7 +130,7 @@ impl SinkReporter {
 
 // this is simple forwarding
 // #[cfg_attr(coverage, no_coverage)]
-pub(crate) fn send(tx: &MetricsSender, metric: EventPayload, alias: &ConnectorAlias) {
+pub(crate) fn send(tx: &MetricsSender, metric: EventPayload, alias: &Alias) {
     use tremor_pipeline::MetricsMsg;
 
     if let Err(_e) = tx.try_broadcast(MetricsMsg::new(metric, None)) {
@@ -154,7 +146,7 @@ pub(crate) fn make_event_count_metrics_payload(
     timestamp: u64,
     port: Cow<'static, str>,
     count: u64,
-    connector_id: &ConnectorAlias,
+    connector_id: &Alias,
 ) -> EventPayload {
     let mut tags: HashMap<Cow<'static, str>, Value<'static>> = HashMap::with_capacity(2);
     tags.insert_nocheck(FLOW, Value::from(connector_id.flow_alias().to_string()));

--- a/src/connectors/utils/reconnect.rs
+++ b/src/connectors/utils/reconnect.rs
@@ -16,9 +16,8 @@
 use crate::config::Reconnect;
 use crate::connectors::sink::SinkMsg;
 use crate::connectors::source::SourceMsg;
-use crate::connectors::{Addr, Connectivity, Connector, ConnectorContext, Context, Msg};
+use crate::connectors::{Addr, Alias, Connectivity, Connector, ConnectorContext, Context, Msg};
 use crate::errors::{Error, Result};
-use crate::system::flow::ConnectorAlias;
 use async_std::channel::{bounded, Sender};
 use async_std::task::{self, JoinHandle};
 use futures::future::{join3, ready, FutureExt};
@@ -189,7 +188,7 @@ pub(crate) struct ReconnectRuntime {
     addr: Addr,
     notifier: ConnectionLostNotifier,
     retry_task: Option<JoinHandle<()>>,
-    alias: ConnectorAlias,
+    alias: Alias,
 }
 
 /// Notifier that connector implementations
@@ -230,7 +229,7 @@ impl ReconnectRuntime {
     }
     fn inner(
         addr: Addr,
-        alias: ConnectorAlias,
+        alias: Alias,
         notifier: ConnectionLostNotifier,
         config: &Reconnect,
     ) -> Self {
@@ -381,10 +380,7 @@ impl ReconnectRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        connectors::{utils::quiescence::QuiescenceBeacon, CodecReq},
-        system::flow::FlowAlias,
-    };
+    use crate::connectors::{utils::quiescence::QuiescenceBeacon, CodecReq};
 
     /// does not connect
     struct FakeConnector {
@@ -446,7 +442,7 @@ mod tests {
     async fn failfast_runtime() -> Result<()> {
         let (tx, rx) = async_std::channel::unbounded();
         let notifier = ConnectionLostNotifier::new(tx.clone());
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "test");
+        let alias = Alias::new("flow", "test");
         let addr = Addr {
             alias: alias.clone(),
             source: None,
@@ -480,7 +476,7 @@ mod tests {
         use async_std::prelude::FutureExt;
         let (tx, rx) = async_std::channel::unbounded();
         let notifier = ConnectionLostNotifier::new(tx.clone());
-        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "test");
+        let alias = Alias::new("flow", "test");
         let addr = Addr {
             alias: alias.clone(),
             source: None,

--- a/src/connectors/utils/reconnect.rs
+++ b/src/connectors/utils/reconnect.rs
@@ -18,6 +18,7 @@ use crate::connectors::sink::SinkMsg;
 use crate::connectors::source::SourceMsg;
 use crate::connectors::{Addr, Connectivity, Connector, ConnectorContext, Context, Msg};
 use crate::errors::{Error, Result};
+use crate::system::flow::ConnectorAlias;
 use async_std::channel::{bounded, Sender};
 use async_std::task::{self, JoinHandle};
 use futures::future::{join3, ready, FutureExt};
@@ -188,7 +189,7 @@ pub(crate) struct ReconnectRuntime {
     addr: Addr,
     notifier: ConnectionLostNotifier,
     retry_task: Option<JoinHandle<()>>,
-    alias: String,
+    alias: ConnectorAlias,
 }
 
 /// Notifier that connector implementations
@@ -229,7 +230,7 @@ impl ReconnectRuntime {
     }
     fn inner(
         addr: Addr,
-        alias: String,
+        alias: ConnectorAlias,
         notifier: ConnectionLostNotifier,
         config: &Reconnect,
     ) -> Self {
@@ -380,7 +381,10 @@ impl ReconnectRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connectors::{utils::quiescence::QuiescenceBeacon, CodecReq};
+    use crate::{
+        connectors::{utils::quiescence::QuiescenceBeacon, CodecReq},
+        system::flow::FlowAlias,
+    };
 
     /// does not connect
     struct FakeConnector {
@@ -442,7 +446,7 @@ mod tests {
     async fn failfast_runtime() -> Result<()> {
         let (tx, rx) = async_std::channel::unbounded();
         let notifier = ConnectionLostNotifier::new(tx.clone());
-        let alias = String::from("test");
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "test");
         let addr = Addr {
             alias: alias.clone(),
             source: None,
@@ -476,7 +480,7 @@ mod tests {
         use async_std::prelude::FutureExt;
         let (tx, rx) = async_std::channel::unbounded();
         let notifier = ConnectionLostNotifier::new(tx.clone());
-        let alias = String::from("test");
+        let alias = ConnectorAlias::new(FlowAlias::new("flow"), "test");
         let addr = Addr {
             alias: alias.clone(),
             source: None,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -381,7 +381,7 @@ error_chain! {
     }
 }
 
-pub(crate) fn err_conector_def<C: ToString + ?Sized, E: ToString + ?Sized>(c: &C, e: &E) -> Error {
+pub(crate) fn err_connector_def<C: ToString + ?Sized, E: ToString + ?Sized>(c: &C, e: &E) -> Error {
     ErrorKind::InvalidConnectorDefinition(c.to_string(), e.to_string()).into()
 }
 
@@ -392,7 +392,7 @@ mod test {
 
     #[test]
     fn test_err_conector_def() {
-        let r = err_conector_def("snot", "badger").0;
+        let r = err_connector_def("snot", "badger").0;
         assert_matches!(r, ErrorKind::InvalidConnectorDefinition(_, _))
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -16,6 +16,7 @@ use crate::{
     errors::Result,
     instance::State,
     primerge::PriorityMerge,
+    system::flow::PipelineAlias,
 };
 use async_std::{
     channel::{bounded, unbounded, Receiver, Sender},
@@ -40,7 +41,7 @@ pub struct Addr {
     addr: Sender<Box<Msg>>,
     cf_addr: Sender<CfMsg>,
     mgmt_addr: Sender<MgmtMsg>,
-    alias: String,
+    alias: PipelineAlias,
 }
 
 impl Addr {
@@ -50,7 +51,7 @@ impl Addr {
         addr: Sender<Box<Msg>>,
         cf_addr: Sender<CfMsg>,
         mgmt_addr: Sender<MgmtMsg>,
-        alias: String,
+        alias: PipelineAlias,
     ) -> Self {
         Self {
             addr,
@@ -143,7 +144,7 @@ impl TryFrom<connectors::Addr> for OutputTarget {
 }
 
 pub(crate) fn spawn(
-    alias: &str,
+    pipeline_alias: PipelineAlias,
     config: &tremor_pipeline::query::Query,
     operator_id_gen: &mut OperatorIdGen,
 ) -> Result<Addr> {
@@ -173,11 +174,15 @@ pub(crate) fn spawn(
 
     let tick_handler = task::spawn(tick(tx.clone()));
 
-    let addr = Addr::new(tx, cf_tx, mgmt_tx, alias.to_string());
+    let addr = Addr::new(tx, cf_tx, mgmt_tx, pipeline_alias.clone());
     task::Builder::new()
-        .name(format!("pipeline-{}", alias))
+        .name(format!(
+            "pipeline-{}-{}",
+            pipeline_alias.flow_alias(),
+            pipeline_alias.pipeline_alias()
+        ))
         .spawn(pipeline_task(
-            alias.to_string(),
+            pipeline_alias,
             pipeline,
             addr.clone(),
             rx,
@@ -354,18 +359,18 @@ async fn send_events(eventset: &mut EventSet, dests: &mut Dests) -> Result<()> {
 }
 
 #[inline]
-async fn send_signal(own_id: &str, signal: Event, dests: &mut Dests) -> Result<()> {
+async fn send_signal(own_id: &PipelineAlias, signal: Event, dests: &mut Dests) -> Result<()> {
     let mut destinations = dests.values_mut().flatten();
     let first = destinations.next();
     for (id, dest) in destinations {
         // if we are connected to ourselves we should not forward signals
-        if matches!(dest, OutputTarget::Sink(_)) || id.alias() != own_id {
+        if matches!(dest, OutputTarget::Sink(_)) || id.alias() != own_id.pipeline_alias() {
             dest.send_signal(signal.clone()).await?;
         }
     }
     if let Some((id, dest)) = first {
         // if we are connected to ourselves we should not forward signals
-        if matches!(dest, OutputTarget::Sink(_)) || id.alias() != own_id {
+        if matches!(dest, OutputTarget::Sink(_)) || id.alias() != own_id.pipeline_alias() {
             dest.send_signal(signal).await?;
         }
     }
@@ -439,9 +444,25 @@ fn maybe_send(r: Result<()>) {
     }
 }
 
+struct PipelineContext {
+    id: String,
+}
+
+impl std::fmt::Display for PipelineContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[Pipeline::{}]", &self.id)
+    }
+}
+
+impl From<&PipelineAlias> for PipelineContext {
+    fn from(id: &PipelineAlias) -> Self {
+        Self { id: id.to_string() }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn pipeline_task(
-    alias: String,
+    id: PipelineAlias,
     mut pipeline: ExecutableGraph,
     addr: Addr,
     rx: Receiver<Box<Msg>>,
@@ -449,7 +470,9 @@ pub(crate) async fn pipeline_task(
     mgmt_rx: Receiver<MgmtMsg>,
     tick_handler: JoinHandle<()>,
 ) -> Result<()> {
-    pipeline.id = alias.clone();
+    pipeline.id = id.to_string();
+
+    let ctx = PipelineContext::from(&id);
 
     let mut dests: Dests = halfbrown::HashMap::new();
     let mut inputs: Inputs = halfbrown::HashMap::new();
@@ -457,7 +480,7 @@ pub(crate) async fn pipeline_task(
 
     let mut state: State = State::Initializing;
 
-    info!("[Pipeline::{alias}] Starting Pipeline.");
+    info!("{ctx} Starting Pipeline.");
 
     let ff = rx.map(|e| AnyMsg::Flow(*e));
     let cf = cf_rx.map(AnyMsg::Contraflow);
@@ -485,7 +508,7 @@ pub(crate) async fn pipeline_task(
                         } else {
                             format!(" {e}")
                         };
-                        error!("[Pipeline::{alias}] Error handling event:{err_str}");
+                        error!("{ctx} Error handling event:{err_str}");
                     }
                 }
             }
@@ -497,9 +520,9 @@ pub(crate) async fn pipeline_task(
                     } else {
                         format!(" {:?}", e)
                     };
-                    error!("[Pipeline::{}] Error handling signal:{}", alias, err_str);
+                    error!("{ctx} Error handling signal: {err_str}");
                 } else {
-                    maybe_send(send_signal(&alias, signal, &mut dests).await);
+                    maybe_send(send_signal(&id, signal, &mut dests).await);
                     handle_insights(&mut pipeline, &inputs).await;
                     maybe_send(send_events(&mut eventset, &mut dests).await);
                 }
@@ -509,7 +532,7 @@ pub(crate) async fn pipeline_task(
                 target,
                 is_transactional,
             }) => {
-                info!("[Pipeline::{}] Connecting {} to port 'in'", alias, endpoint);
+                info!("{ctx} Connecting {endpoint} to port 'in'");
                 inputs.insert(endpoint, (is_transactional, target));
             }
             AnyMsg::Mgmt(MgmtMsg::ConnectOutput {
@@ -517,29 +540,27 @@ pub(crate) async fn pipeline_task(
                 endpoint,
                 target,
             }) => {
-                info!(
-                    "[Pipeline::{}] Connecting port '{}' to {}",
-                    alias, &port, &endpoint
-                );
+                info!("{ctx} Connecting port '{port}' to {endpoint}",);
                 // notify other pipeline about a new input
                 if let OutputTarget::Pipeline(pipe) = &target {
                     // avoid linking the same pipeline as input to itself
                     // as this will create a nasty circle filling up queues.
                     // In general this does not avoid cycles via more complex constructs.
                     //
-                    if alias == endpoint.alias() {
+                    if id.pipeline_alias() == endpoint.alias() {
                         if let Err(e) = pipe
                             .send_mgmt(MgmtMsg::ConnectInput {
-                                endpoint: DeployEndpoint::new(&alias, &port, endpoint.meta()),
+                                endpoint: DeployEndpoint::new(
+                                    id.pipeline_alias(),
+                                    &port,
+                                    endpoint.meta(),
+                                ),
                                 target: InputTarget::Pipeline(Box::new(addr.clone())),
                                 is_transactional: true,
                             })
                             .await
                         {
-                            error!(
-                                "[Pipeline::{}] Error connecting input pipeline {}: {}",
-                                alias, &endpoint, e
-                            );
+                            error!("{ctx} Error connecting input pipeline {endpoint}: {e}",);
                         }
                     }
                 }
@@ -555,33 +576,24 @@ pub(crate) async fn pipeline_task(
                 state = State::Running;
             }
             AnyMsg::Mgmt(MgmtMsg::Start) => {
-                info!(
-                    "[Pipeline::{}] Ignoring Start Msg. Current state: {}",
-                    alias, &state
-                );
+                info!("{ctx} Ignoring Start Msg. Current state: {state}",);
             }
             AnyMsg::Mgmt(MgmtMsg::Pause) if state == State::Running => {
                 // No-op
                 state = State::Paused;
             }
             AnyMsg::Mgmt(MgmtMsg::Pause) => {
-                info!(
-                    "[Pipeline::{}] Ignoring Pause Msg. Current state: {}",
-                    alias, &state
-                );
+                info!("{ctx} Ignoring Pause Msg. Current state: {state}",);
             }
             AnyMsg::Mgmt(MgmtMsg::Resume) if state == State::Paused => {
                 // No-op
                 state = State::Running;
             }
             AnyMsg::Mgmt(MgmtMsg::Resume) => {
-                info!(
-                    "[Pipeline::{}] Ignoring Resume Msg. Current state: {}",
-                    alias, &state
-                );
+                info!("{ctx} Ignoring Resume Msg. Current state: {state}",);
             }
             AnyMsg::Mgmt(MgmtMsg::Stop) => {
-                info!("[Pipeline::{}] Stopping...", alias);
+                info!("{ctx} Stopping...");
                 break;
             }
             #[cfg(test)]
@@ -607,7 +619,7 @@ pub(crate) async fn pipeline_task(
                     outputs,
                 };
                 if tx.send(report).await.is_err() {
-                    error!("[Pipeline::{alias}] Error sending status report.");
+                    error!("{ctx} Error sending status report.");
                 }
             }
         }
@@ -615,7 +627,7 @@ pub(crate) async fn pipeline_task(
     // stop ticks
     tick_handler.cancel().await;
 
-    info!("[Pipeline::{alias}] Stopped.");
+    info!("{ctx} Stopped.");
     Ok(())
 }
 
@@ -626,10 +638,12 @@ mod tests {
     use crate::{
         connectors::{prelude::SinkAddr, source::SourceAddr},
         pipeline::report::{InputReport, OutputReport},
+        system::flow::FlowAlias,
     };
     use std::time::Instant;
     use tremor_common::{
-        ids::{Id, SourceId},
+        ids::Id as _,
+        ids::SourceId,
         ports::{IN, OUT},
     };
     use tremor_pipeline::{EventId, OpMeta};
@@ -642,11 +656,24 @@ mod tests {
         let mut operator_id_gen = OperatorIdGen::new();
         let trickle = r#"select event from in into out;"#;
         let aggr_reg = aggr_registry();
+        let flow_id = FlowAlias::new("report");
         let query =
             tremor_pipeline::query::Query::parse(trickle, &*FN_REGISTRY.read()?, &aggr_reg)?;
-        let addr = spawn("test-pipe1", &query, &mut operator_id_gen)?;
-        let addr2 = spawn("test-pipe2", &query, &mut operator_id_gen)?;
-        let addr3 = spawn("test-pipe3", &query, &mut operator_id_gen)?;
+        let addr = spawn(
+            PipelineAlias::new(flow_id.clone(), "test-pipe1"),
+            &query,
+            &mut operator_id_gen,
+        )?;
+        let addr2 = spawn(
+            PipelineAlias::new(flow_id.clone(), "test-pipe2"),
+            &query,
+            &mut operator_id_gen,
+        )?;
+        let addr3 = spawn(
+            PipelineAlias::new(flow_id.clone(), "test-pipe3"),
+            &query,
+            &mut operator_id_gen,
+        )?;
         println!("{:?}", addr); // coverage
         let yolo_mid = NodeMeta::new(Location::yolo(), Location::yolo());
         // interconnect 3 pipelines
@@ -745,9 +772,10 @@ mod tests {
         let mut operator_id_gen = OperatorIdGen::new();
         let trickle = r#"select event from in into out;"#;
         let aggr_reg = aggr_registry();
+        let pipeline_id = PipelineAlias::new(FlowAlias::new("flow"), "test-pipe");
         let query =
             tremor_pipeline::query::Query::parse(trickle, &*FN_REGISTRY.read()?, &aggr_reg)?;
-        let addr = spawn("test-pipe", &query, &mut operator_id_gen)?;
+        let addr = spawn(pipeline_id, &query, &mut operator_id_gen)?;
 
         let (tx, rx) = unbounded();
         addr.send_mgmt(MgmtMsg::Inspect(tx.clone())).await?;

--- a/src/system.rs
+++ b/src/system.rs
@@ -162,7 +162,7 @@ impl World {
     ///  * if we fail to send the request or fail to receive it
     pub async fn get_flow(&self, flow_id: String) -> Result<Flow> {
         let (flow_tx, flow_rx) = bounded(1);
-        let flow_id = flow::Id(flow_id);
+        let flow_id = flow::FlowAlias::new(flow_id);
         self.system
             .send(flow_supervisor::Msg::GetFlow(flow_id.clone(), flow_tx))
             .await?;

--- a/src/system.rs
+++ b/src/system.rs
@@ -162,7 +162,7 @@ impl World {
     ///  * if we fail to send the request or fail to receive it
     pub async fn get_flow(&self, flow_id: String) -> Result<Flow> {
         let (flow_tx, flow_rx) = bounded(1);
-        let flow_id = flow::FlowAlias::new(flow_id);
+        let flow_id = flow::Alias::new(flow_id);
         self.system
             .send(flow_supervisor::Msg::GetFlow(flow_id.clone(), flow_tx))
             .await?;

--- a/src/system/flow.rs
+++ b/src/system/flow.rs
@@ -169,7 +169,7 @@ pub struct Flow {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StatusReport {
     /// the id of the instance this report describes
-    pub id: FlowAlias,
+    pub alias: FlowAlias,
     /// the current state
     pub status: State,
     /// the crated connectors
@@ -651,7 +651,7 @@ async fn spawn_task(
                     // TODO: aggregate states of all containing instances
                     let connectors = connectors.keys().cloned().collect();
                     let report = StatusReport {
-                        id: id.clone(),
+                        alias: id.clone(),
                         status: state,
                         connectors,
                     };

--- a/src/system/flow.rs
+++ b/src/system/flow.rs
@@ -36,6 +36,7 @@ use tremor_script::{
 };
 
 /// unique identifier of a flow instance within a tremor instance
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, PartialEq, PartialOrd, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct FlowAlias(String);
 
@@ -46,6 +47,7 @@ impl FlowAlias {
     }
 
     /// reference this id as a stringy thing again
+    #[must_use]
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
@@ -77,7 +79,7 @@ pub struct ConnectorAlias {
 }
 
 impl ConnectorAlias {
-    /// construct a new ConnectorId from the id of the containing flow and the connector instance id
+    /// construct a new `ConnectorId` from the id of the containing flow and the connector instance id
     pub fn new(flow_alias: FlowAlias, connector_alias: impl Into<String>) -> Self {
         Self {
             flow_alias,
@@ -86,13 +88,15 @@ impl ConnectorAlias {
     }
 
     /// get a reference to the flow alias
+    #[must_use]
     pub fn flow_alias(&self) -> &FlowAlias {
         &self.flow_alias
     }
 
     /// get a reference to the connector alias
+    #[must_use]
     pub fn connector_alias(&self) -> &str {
-        &self.connector_alias.as_str()
+        self.connector_alias.as_str()
     }
 }
 

--- a/tremor-api/src/api.rs
+++ b/tremor-api/src/api.rs
@@ -222,10 +222,7 @@ mod tests {
     use tremor_runtime::{
         errors::Result as RuntimeResult,
         instance::State as InstanceState,
-        system::{
-            flow::{ConnectorAlias, StatusReport},
-            ShutdownMode, WorldConfig,
-        },
+        system::{flow::StatusReport, ShutdownMode, WorldConfig},
     };
     use tremor_script::{aggr_registry, ast::DeployStmt, deploy::Deploy, FN_REGISTRY};
     use tremor_value::{literal, value::StaticValue};
@@ -336,10 +333,10 @@ mod tests {
             .body_json::<Vec<StatusReport>>()
             .await?;
         assert_eq!(1, body.len());
-        assert_eq!("api_test".to_string(), body[0].alias);
+        assert_eq!("api_test", body[0].id.as_str());
         assert_eq!(InstanceState::Running, body[0].status);
         assert_eq!(1, body[0].connectors.len());
-        assert_eq!(ConnectorAlias::from("my_null"), body[0].connectors[0]);
+        assert_eq!(String::from("my_null"), body[0].connectors[0]);
 
         // get flow
         let res = client.get("/v1/flows/i_do_not_exist").await?;
@@ -351,10 +348,10 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test".to_string(), body.alias);
+        assert_eq!("api_test", body.id.as_str());
         assert_eq!(InstanceState::Running, body.status);
         assert_eq!(1, body.connectors.len());
-        assert_eq!(ConnectorAlias::from("my_null"), body.connectors[0]);
+        assert_eq!(String::from("my_null"), body.connectors[0]);
 
         // patch flow status
         let body = client
@@ -366,10 +363,10 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test".to_string(), body.alias);
+        assert_eq!("api_test", body.id.as_str());
         assert_eq!(InstanceState::Paused, body.status);
         assert_eq!(1, body.connectors.len());
-        assert_eq!(ConnectorAlias::from("my_null"), body.connectors[0]);
+        assert_eq!(String::from("my_null"), body.connectors[0]);
 
         // invalid patch
         let mut res = client
@@ -391,10 +388,10 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test".to_string(), body.alias);
+        assert_eq!("api_test", body.id.as_str());
         assert_eq!(InstanceState::Running, body.status);
         assert_eq!(1, body.connectors.len());
-        assert_eq!(ConnectorAlias::from("my_null"), body.connectors[0]);
+        assert_eq!(String::from("my_null"), body.connectors[0]);
 
         // list flow connectors
         let body = client

--- a/tremor-api/src/api.rs
+++ b/tremor-api/src/api.rs
@@ -333,7 +333,7 @@ mod tests {
             .body_json::<Vec<StatusReport>>()
             .await?;
         assert_eq!(1, body.len());
-        assert_eq!("api_test", body[0].id.as_str());
+        assert_eq!("api_test", body[0].alias.as_str());
         assert_eq!(InstanceState::Running, body[0].status);
         assert_eq!(1, body[0].connectors.len());
         assert_eq!(String::from("my_null"), body[0].connectors[0]);
@@ -348,7 +348,7 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test", body.id.as_str());
+        assert_eq!("api_test", body.alias.as_str());
         assert_eq!(InstanceState::Running, body.status);
         assert_eq!(1, body.connectors.len());
         assert_eq!(String::from("my_null"), body.connectors[0]);
@@ -363,7 +363,7 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test", body.id.as_str());
+        assert_eq!("api_test", body.alias.as_str());
         assert_eq!(InstanceState::Paused, body.status);
         assert_eq!(1, body.connectors.len());
         assert_eq!(String::from("my_null"), body.connectors[0]);
@@ -388,7 +388,7 @@ mod tests {
             .body_json::<StatusReport>()
             .await?;
 
-        assert_eq!("api_test", body.id.as_str());
+        assert_eq!("api_test", body.alias.as_str());
         assert_eq!(InstanceState::Running, body.status);
         assert_eq!(1, body.connectors.len());
         assert_eq!(String::from("my_null"), body.connectors[0]);

--- a/tremor-api/src/api.rs
+++ b/tremor-api/src/api.rs
@@ -24,9 +24,11 @@ use http_types::{
 };
 use serde::{Deserialize, Serialize};
 use tide::Response;
+use tremor_runtime::instance::State as InstanceState;
 use tremor_runtime::system::World;
 
 pub mod flow;
+pub mod model;
 pub mod prelude;
 pub mod status;
 pub mod version;
@@ -222,12 +224,12 @@ mod tests {
     use tremor_runtime::{
         errors::Result as RuntimeResult,
         instance::State as InstanceState,
-        system::{flow::StatusReport, ShutdownMode, WorldConfig},
+        system::{ShutdownMode, WorldConfig},
     };
     use tremor_script::{aggr_registry, ast::DeployStmt, deploy::Deploy, FN_REGISTRY};
     use tremor_value::{literal, value::StaticValue};
 
-    use crate::flow::PatchStatus;
+    use crate::api::model::{ApiFlowStatusReport, PatchStatus};
 
     use super::*;
 
@@ -330,7 +332,7 @@ mod tests {
         let body = client
             .get("/v1/flows")
             .await?
-            .body_json::<Vec<StatusReport>>()
+            .body_json::<Vec<ApiFlowStatusReport>>()
             .await?;
         assert_eq!(1, body.len());
         assert_eq!("api_test", body[0].alias.as_str());
@@ -345,7 +347,7 @@ mod tests {
         let body = client
             .get("/v1/flows/api_test")
             .await?
-            .body_json::<StatusReport>()
+            .body_json::<ApiFlowStatusReport>()
             .await?;
 
         assert_eq!("api_test", body.alias.as_str());
@@ -360,7 +362,7 @@ mod tests {
                 status: InstanceState::Paused,
             })?
             .await?
-            .body_json::<StatusReport>()
+            .body_json::<ApiFlowStatusReport>()
             .await?;
 
         assert_eq!("api_test", body.alias.as_str());
@@ -385,7 +387,7 @@ mod tests {
                 status: InstanceState::Running,
             })?
             .await?
-            .body_json::<StatusReport>()
+            .body_json::<ApiFlowStatusReport>()
             .await?;
 
         assert_eq!("api_test", body.alias.as_str());

--- a/tremor-api/src/api/model.rs
+++ b/tremor-api/src/api/model.rs
@@ -1,0 +1,91 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::api::prelude::*;
+use halfbrown::HashMap;
+use tremor_runtime::{
+    connectors::{Connectivity, StatusReport as ConnectorStatusReport},
+    instance::State,
+    system::flow::{Alias as FlowAlias, StatusReport as FlowStatusReport},
+};
+use tremor_script::ast::DeployEndpoint;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ApiFlowStatusReport {
+    pub(crate) alias: FlowAlias,
+    pub(crate) status: State,
+    pub(crate) connectors: Vec<String>,
+}
+
+impl From<FlowStatusReport> for ApiFlowStatusReport {
+    fn from(sr: FlowStatusReport) -> Self {
+        Self {
+            alias: sr.alias,
+            status: sr.status,
+            connectors: sr
+                .connectors
+                .into_iter()
+                .map(|ca| ca.connector_alias().to_string())
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Pipeline {
+    alias: String,
+    port: String,
+}
+
+impl From<&DeployEndpoint> for Pipeline {
+    fn from(de: &DeployEndpoint) -> Self {
+        Self {
+            alias: de.alias().to_string(),
+            port: de.port().to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ApiConnectorStatusReport {
+    pub(crate) alias: String,
+    pub(crate) status: State,
+    pub(crate) connectivity: Connectivity,
+    pub(crate) pipelines: HashMap<String, Vec<Pipeline>>,
+}
+
+impl From<ConnectorStatusReport> for ApiConnectorStatusReport {
+    fn from(csr: ConnectorStatusReport) -> Self {
+        Self {
+            alias: csr.alias().connector_alias().to_string(),
+            status: csr.status().clone(),
+            connectivity: *csr.connectivity(),
+            pipelines: csr
+                .pipelines()
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_string(),
+                        v.into_iter().map(Pipeline::from).collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct PatchStatus {
+    pub(crate) status: InstanceState,
+}

--- a/tremor-api/src/api/model.rs
+++ b/tremor-api/src/api/model.rs
@@ -69,7 +69,7 @@ impl From<ConnectorStatusReport> for ApiConnectorStatusReport {
     fn from(csr: ConnectorStatusReport) -> Self {
         Self {
             alias: csr.alias().connector_alias().to_string(),
-            status: csr.status().clone(),
+            status: *csr.status(),
             connectivity: *csr.connectivity(),
             pipelines: csr
                 .pipelines()
@@ -77,7 +77,7 @@ impl From<ConnectorStatusReport> for ApiConnectorStatusReport {
                 .map(|(k, v)| {
                     (
                         k.to_string(),
-                        v.into_iter().map(Pipeline::from).collect::<Vec<_>>(),
+                        v.iter().map(Pipeline::from).collect::<Vec<_>>(),
                     )
                 })
                 .collect(),

--- a/tremor-cli/tests/integration/elastic-sink-only/assert.yaml
+++ b/tremor-cli/tests/integration/elastic-sink-only/assert.yaml
@@ -6,4 +6,4 @@ asserts:
       - |
         All required CB events received. 
       - |
-        Error sending Elasticsearch Bulk Request: Missing field `$elastic["_id"]`
+        Got acks: []

--- a/tremor-cli/tests/integration/elastic-sink-only/config.troy
+++ b/tremor-cli/tests/integration/elastic-sink-only/config.troy
@@ -17,7 +17,7 @@ flow
   with
     config =  {
       "path": "in.json",
-      "timeout": nanos::from_seconds(5),
+      "timeout": nanos::from_seconds(8),
 
     }
   end;

--- a/tremor-cli/tests/integration/system-metrics/config.troy
+++ b/tremor-cli/tests/integration/system-metrics/config.troy
@@ -70,27 +70,30 @@ flow
         # initialize state
         default => {
           "source_out": 0,   # source port `out`
-          "pipeline_in": 0, # pipeline port `in`
+          "source_err": 0,   # source port `err`
+          "pipeline_in": 0,  # pipeline port `in`
           "pipeline_out": 0, # pipeline port `out`
-          "sink_in": 0      # sink port `in`
+          "sink_in": 0       # sink port `in`
         }
       end;
       # update state counters
       match event of 
-        case matched = %{ tags ~= %{`pipeline` == "main", port == "in" }, fields ~= %{ present count } } =>
+        case matched = %{ tags ~= %{`pipeline` == "main1::main1", port == "in" }, fields ~= %{ present count } } =>
           let state.pipeline_in = matched.fields.count
-        case matched = %{ tags ~= %{ `pipeline` == "main", port == "out"}, fields ~= %{ present count } } =>
+        case matched = %{ tags ~= %{ `pipeline` == "main1::main1", port == "out"}, fields ~= %{ present count } } =>
           let state.pipeline_out = matched.fields.count
-        case matched = %{ tags ~= %{ `connector` == "in", port == "out" }, fields ~= %{ present count } } => 
+        case matched = %{ tags ~= %{ `connector` == "main1::in_here", port == "out" }, fields ~= %{ present count } } => 
           let state.source_out = matched.fields.count
-        case matched = %{ tags ~= %{ `connector` == "out", port == "in" }, fields ~= %{ present count } } => 
+        case matched = %{ tags ~= %{ `connector` == "main1::in_here", port == "err" }, fields ~= %{ present count } } => 
+          let state.source_err = matched.fields.count
+        case matched = %{ tags ~= %{ `connector` == "main1::out_here", port == "in" }, fields ~= %{ present count } } => 
           let state.sink_in = matched.fields.count
         default => null
       end;
 
       # exit if we have at least 10 events
       match state of
-        case %{ source_out >= 10, pipeline_in >= 10, pipeline_in >= 10, sink_in >= 10} =>
+        case %{ source_out >= 10, source_err == 0, pipeline_in >= 10, pipeline_in >= 10, sink_in >= 10} =>
           emit {"EXIT": "NOW"} => "exit"
         default =>
           emit state => "out"
@@ -107,20 +110,20 @@ flow
   end;
 
   # creating connectors
-  create connector in;
-  create connector out;
+  create connector in_here from in;
+  create connector out_here from out;
 
   create connector exit from connectors::exit;
   create connector metrics from connectors::metrics;
   create connector stdio from connectors::console;
 
   # creating pipelines
-  create pipeline main;
+  create pipeline main1 from main;
   create pipeline metrics;
 
   # connects
-  connect /connector/in to  /pipeline/main;
-  connect /pipeline/main/out to /connector/out;
+  connect /connector/in_here to  /pipeline/main1;
+  connect /pipeline/main1/out to /connector/out_here;
 
   connect /connector/metrics to /pipeline/metrics;
   # catching other outputs, just in case
@@ -133,4 +136,4 @@ flow
 
 end;
 
-deploy flow main;
+deploy flow main1 from main;

--- a/tremor-erl/README.md
+++ b/tremor-erl/README.md
@@ -24,7 +24,9 @@ This is home to the `tremor_api` erlang library to property test the API exposed
 
 To run the EQC tests defined in `tremor_api`, you first need to start a tremor server with the API enabled. This is our system to test:
 
-    $ tremor server run
+    $ tremor server run config.troy
+
+A bunch of `config.troy` files to try can be found in the `samples` directory.
 
 Then run the tests with rebar3:
 

--- a/tremor-pipeline/src/executable_graph.rs
+++ b/tremor-pipeline/src/executable_graph.rs
@@ -242,7 +242,7 @@ impl NodeMetrics {
 /// form of a pipeline
 #[derive(Debug)]
 pub struct ExecutableGraph {
-    /// ID of the graph
+    /// ID of the graph, contains the flow id and pipeline id
     pub id: String,
     pub(crate) graph: Vec<OperatorNode>,
     pub(crate) state: State,
@@ -805,7 +805,7 @@ mod test {
         };
         let mut rx = METRICS_CHANNEL.rx();
         let mut g = ExecutableGraph {
-            id: "test".into(),
+            id: "flow::pipe".into(),
             graph,
             state,
             inputs,

--- a/tremor-script/src/ast/deploy.rs
+++ b/tremor-script/src/ast/deploy.rs
@@ -185,6 +185,8 @@ impl ConnectStmt {
 /// A deployment endpoint
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct DeployEndpoint {
+    /// This alias is the instance-id of the instance targeted without the containing flow id
+    /// as we currently do not allow inter-flow connection, this needs to change if we do
     alias: String,
     /// Refers to a local artefact being deployed in a troy definition
     port: String,


### PR DESCRIPTION
# Pull request

## Description

Include flow-alias in pipeline- and connector-alias for deduplicating log and metrics output when multiple flows with the same connector aliases are deployed.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->


* Related Issues: fixes #1802 

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
