### PR TITLE
DRAFT: Initial attempt at concurrent gRPC for GCL writer

### DIFF
--- a/src/connectors/impls/gcl/writer/sink.rs
+++ b/src/connectors/impls/gcl/writer/sink.rs
@@ -12,25 +12,222 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use super::meta;
 use crate::connectors::google::AuthInterceptor;
 use crate::connectors::impls::gcl::writer::Config;
 use crate::connectors::prelude::*;
 use crate::connectors::utils::pb;
+use async_std::channel::bounded;
+use async_std::channel::Sender;
 use async_std::prelude::FutureExt;
+use async_std::task::JoinHandle;
 use googapis::google::logging::v2::log_entry::Payload;
 use googapis::google::logging::v2::logging_service_v2_client::LoggingServiceV2Client;
 use googapis::google::logging::v2::{LogEntry, WriteLogEntriesRequest};
 use gouth::Token;
 use prost_types::Timestamp;
-use std::time::Duration;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 use tonic::{Code, Status};
+use tremor_common::time::nanotime;
+
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum GclEvent {
+    #[allow(dead_code)] // NOTE This is used by the tests and not intended for use in production
+    Shutdown,
+    LogEvent(Event, Vec<LogEntry>),
+}
+
+impl GclEvent {
+    async fn log_event(config: &Config, event: Event) -> Result<GclEvent> {
+        let timestamp = event.ingest_ns;
+        let mut entries = Vec::with_capacity(event.len());
+        for (data, meta) in event.value_meta_iter() {
+            let meta = meta.get("gcl_writer").or(None);
+            #[allow(clippy::cast_precision_loss)]
+            #[allow(clippy::cast_possible_wrap)]
+            let mut timestamp = Timestamp {
+                seconds: (timestamp / 1_000_000_000) as i64,
+                nanos: (timestamp % 1_000_000_000) as i32,
+            };
+            timestamp.normalize();
+            entries.push(value_to_log_entry(timestamp, config, data, meta)?);
+        }
+
+        Ok(GclEvent::LogEvent(event, entries))
+    }
+}
+
+pub(crate) struct GclClient {
+    #[allow(unused)] // NOTE FIXME consider kill switch and quiescence
+    join_handle: JoinHandle<Result<()>>,
+    #[allow(unused)] // NOTE Preserved so that auth token can be refreshed and renewed
+    token: Token,
+    sender: Sender<GclEvent>,
+}
+
+pub(crate) struct GclClients {
+    client_senders: Vec<GclClient>,
+    idx: usize,
+}
+
+impl GclClients {
+    // FIXME This will need to be refactored for fake/mock unit testing
+    async fn make_client(
+        config: &Config,
+        token: &Token,
+    ) -> std::result::Result<
+        LoggingServiceV2Client<InterceptedService<Channel, AuthInterceptor>>,
+        Error,
+    > {
+        let tls_config = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(googapis::CERTIFICATES))
+            .domain_name("logging.googleapis.com");
+
+        let channel = Channel::from_static("https://logging.googleapis.com")
+            .connect_timeout(Duration::from_nanos(config.connect_timeout))
+            .tls_config(tls_config)?
+            .keep_alive_while_idle(true)
+            .tcp_keepalive(Some(Duration::from_secs(10)))
+            .http2_keep_alive_interval(Duration::from_secs(10))
+            .connect()
+            .await?;
+
+        let token_header_value = token.header_value();
+        Ok(LoggingServiceV2Client::with_interceptor(
+            channel,
+            AuthInterceptor {
+                token: Box::new(move || match &token_header_value {
+                    Ok(val) => Ok(val.clone()),
+                    Err(e) => {
+                        error!("Failed to get token for Google Logging Client: {}", e);
+
+                        // Fail and bail
+                        Err(Status::unavailable(
+                            "Failed to retrieve authentication token.",
+                        ))
+                    }
+                }),
+            },
+        ))
+    }
+
+    async fn with_capacity(config: &Config, reply_tx: &Sender<AsyncSinkReply>) -> Result<Self> {
+        let mut client_senders = Vec::with_capacity(config.concurrency);
+        for i in 0..config.concurrency {
+            let (sender, receiver) = bounded(1);
+            let token = Token::new()?;
+            let config = config.clone();
+            let mut client = GclClients::make_client(&config, &token).await?;
+            let reply_tx = reply_tx.clone();
+            let join_handle = async_std::task::Builder::new()
+                .name(format!("gcl_client_task-{}-of-{}", i, config.concurrency))
+                .spawn::<_, Result<()>>(async move {
+                    loop {
+                        match receiver.recv().await {
+                            Ok(GclEvent::LogEvent(ref event, entries)) => {
+                                let log_entries_response = client
+                                    .write_log_entries(WriteLogEntriesRequest {
+                                        log_name: config.log_name(None),
+                                        resource: super::value_to_monitored_resource(
+                                            config.resource.as_ref(),
+                                        )?,
+                                        labels: config.labels.clone(),
+                                        entries,
+                                        partial_success: config.partial_success,
+                                        dry_run: config.dry_run,
+                                    })
+                                    .timeout(Duration::from_nanos(config.request_timeout))
+                                    .await;
+
+                                if let Err(error) = log_entries_response? {
+                                    error!("Failed to write a log entries: {}", error);
+
+                                    if matches!(
+                                        error.code(),
+                                        Code::Aborted
+                                            | Code::Cancelled
+                                            | Code::DataLoss
+                                            | Code::DeadlineExceeded
+                                            | Code::Internal
+                                            | Code::ResourceExhausted
+                                            | Code::Unavailable
+                                            | Code::Unknown
+                                    ) {
+                                        // return Err("Failed to notify about Google Cloud Logging connection loss".into());
+                                        if event.transactional {
+                                            reply_tx
+                                                .send(AsyncSinkReply::Fail(ContraflowData::from(
+                                                    event,
+                                                )))
+                                                .await?;
+                                        }
+                                        continue;
+                                    }
+                                    // return Err("Unexpected gRPC failure with Google Cloud Logging endpoint".into());
+                                    if event.transactional {
+                                        reply_tx
+                                            .send(AsyncSinkReply::Fail(ContraflowData::from(event)))
+                                            .await?;
+                                    }
+                                };
+
+                                if event.transactional {
+                                    reply_tx
+                                        .send(AsyncSinkReply::Ack(
+                                            ContraflowData::from(event),
+                                            nanotime() - event.ingest_ns,
+                                        ))
+                                        .await?;
+                                }
+                            }
+                            Ok(GclEvent::Shutdown) => {
+                                info!("GCL client task - graceful channel shutdown");
+                                return Ok(()); // Because the channel is empty and closed.
+                            }
+                            Err(e) => {
+                                error!("GCL client task - unexpected channel closed: {}", e);
+                                return Ok(()); // Because the channel is empty and closed.
+                            }
+                        }
+                    }
+                })?;
+            client_senders.push(GclClient {
+                join_handle,
+                token,
+                sender,
+            });
+        }
+
+        Ok(Self {
+            client_senders,
+            idx: 0,
+        })
+    }
+
+    fn next(&mut self) -> &mut Sender<GclEvent> {
+        let idx = self.idx;
+        self.idx = (self.idx + 1) % self.client_senders.len();
+        &mut self.client_senders[idx].sender
+    }
+
+    #[cfg(test)]
+    async fn shutdown(&mut self) -> Result<()> {
+        for client in &mut self.client_senders.iter_mut() {
+            client.sender.send(GclEvent::Shutdown).await?;
+        }
+        Ok(())
+    }
+}
 
 pub(crate) struct GclSink {
-    client: Option<LoggingServiceV2Client<InterceptedService<Channel, AuthInterceptor>>>,
+    clients: Option<GclClients>,
     config: Config,
+    _origin_uri: EventOriginUri,
+    reply_tx: Sender<AsyncSinkReply>,
+    _response_tx: Sender<SourceReply>,
 }
 
 fn value_to_log_entry(
@@ -58,19 +255,32 @@ fn value_to_log_entry(
 }
 
 impl GclSink {
-    pub fn new(config: Config) -> Self {
+    pub fn new(
+        config: Config,
+        response_tx: Sender<SourceReply>,
+        reply_tx: Sender<AsyncSinkReply>,
+    ) -> Self {
         Self {
-            client: None,
+            clients: None,
             config,
+            _response_tx: response_tx,
+            reply_tx,
+            _origin_uri: EventOriginUri {
+                scheme: String::from("gcl_writer"),
+                host: String::from("dummy"), // will be replaced in `on_event`
+                port: None,
+                path: vec![],
+            },
         }
     }
 
     #[cfg(test)]
-    pub fn set_client(
-        &mut self,
-        client: LoggingServiceV2Client<InterceptedService<Channel, AuthInterceptor>>,
-    ) {
-        self.client = Some(client);
+    #[allow(dead_code)]
+    async fn shutdown(&mut self) -> Result<()> {
+        if let Some(clients) = &mut self.clients {
+            clients.shutdown().await?;
+        }
+        Ok(())
     }
 }
 
@@ -84,93 +294,32 @@ impl Sink for GclSink {
         _serializer: &mut EventSerializer,
         _start: u64,
     ) -> Result<SinkReply> {
-        let client = self.client.as_mut().ok_or(ErrorKind::ClientNotAvailable(
-            "Google Cloud Logging",
-            "The client is not connected",
-        ))?;
-
-        let mut entries = Vec::with_capacity(event.len());
-        for (data, meta) in event.value_meta_iter() {
-            let meta = meta.get("gcl_writer").or(None);
-            #[allow(clippy::cast_precision_loss)]
-            #[allow(clippy::cast_possible_wrap)]
-            let mut timestamp = Timestamp {
-                seconds: (event.ingest_ns / 1_000_000_000) as i64,
-                nanos: (event.ingest_ns % 1_000_000_000) as i32,
-            };
-            timestamp.normalize();
-            entries.push(value_to_log_entry(timestamp, &self.config, data, meta)?);
+        if event.is_empty() {
+            debug!("{ctx} Received empty event. Won't send it to GCL");
+            return Ok(SinkReply::NONE);
         }
 
-        let log_entries_response = client
-            .write_log_entries(WriteLogEntriesRequest {
-                log_name: self.config.log_name(None),
-                resource: super::value_to_monitored_resource(self.config.resource.as_ref())?,
-                labels: self.config.labels.clone(),
-                entries,
-                partial_success: self.config.partial_success,
-                dry_run: self.config.dry_run,
-            })
-            .timeout(Duration::from_nanos(self.config.request_timeout))
-            .await?;
-
-        if let Err(error) = log_entries_response {
-            error!("Failed to write a log entries: {}", error);
-
-            if matches!(
-                error.code(),
-                Code::Aborted
-                    | Code::Cancelled
-                    | Code::DataLoss
-                    | Code::DeadlineExceeded
-                    | Code::Internal
-                    | Code::ResourceExhausted
-                    | Code::Unavailable
-                    | Code::Unknown
-            ) {
-                ctx.swallow_err(
-                    ctx.notifier.connection_lost().await,
-                    "Failed to notify about Google Cloud Logging connection loss",
-                );
-            }
-
-            Ok(SinkReply::FAIL)
+        trace!("{ctx} sending event [{}] to Google Cloud Logging", event.id);
+        if let Some(clients) = &mut self.clients {
+            let client = clients.next();
+            client
+                .send(GclEvent::log_event(&self.config, event).await?)
+                .await?;
         } else {
-            Ok(SinkReply::ACK)
+            error!("{} No GCL client available.", &ctx);
+            if event.transactional {
+                self.reply_tx
+                    .send(AsyncSinkReply::Fail(ContraflowData::from(event)))
+                    .await?;
+            };
         }
+
+        Ok(SinkReply::NONE)
     }
 
     async fn connect(&mut self, ctx: &SinkContext, _attempt: &Attempt) -> Result<bool> {
         info!("{} Connecting to Google Cloud Logging", ctx);
-        let token = Token::new()?;
-
-        let tls_config = ClientTlsConfig::new()
-            .ca_certificate(Certificate::from_pem(googapis::CERTIFICATES))
-            .domain_name("logging.googleapis.com");
-
-        let channel = Channel::from_static("https://logging.googleapis.com")
-            .connect_timeout(Duration::from_nanos(self.config.connect_timeout))
-            .tls_config(tls_config)?
-            .connect()
-            .await?;
-
-        let client = LoggingServiceV2Client::with_interceptor(
-            channel,
-            AuthInterceptor {
-                token: Box::new(move || match token.header_value() {
-                    Ok(val) => Ok(val),
-                    Err(e) => {
-                        error!("Failed to get token for Google Logging Client: {}", e);
-
-                        Err(Status::unavailable(
-                            "Failed to retrieve authentication token.",
-                        ))
-                    }
-                }),
-            },
-        );
-
-        self.client = Some(client);
+        self.clients = Some(GclClients::with_capacity(&self.config, &self.reply_tx).await?);
 
         Ok(true)
     }
@@ -180,14 +329,49 @@ impl Sink for GclSink {
     }
 }
 
+/// handle an error for the whole event
+///
+/// send event to err port
+#[allow(dead_code)]
+async fn handle_error<E>(
+    e: E,
+    event: &Event,
+    origin_uri: &EventOriginUri,
+    response_tx: &Sender<SourceReply>,
+) -> Result<()>
+where
+    E: std::error::Error,
+{
+    let e_str = e.to_string();
+    let mut meta = literal!({
+        "gcl_writer": {
+            "success": false
+        },
+        "error": e_str.clone()
+    });
+    if let Some(correlation) = event.correlation_meta() {
+        meta.try_insert("correlation", correlation);
+    }
+
+    let data = Value::object_with_capacity(1);
+    let event_payload: EventPayload = (data, meta).into();
+    let source_reply = SourceReply::Structured {
+        origin_uri: origin_uri.clone(),
+        payload: event_payload,
+        stream: DEFAULT_STREAM_ID,
+        port: Some(ERR),
+    };
+    response_tx.send(source_reply).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::connectors::impls::gcl;
     use crate::connectors::tests::ConnectorHarness;
-    use crate::connectors::ConnectionLostNotifier;
+    //    use crate::connectors::ConnectionLostNotifier;
     use googapis::google::logging::r#type::LogSeverity;
-    use std::sync::Arc;
     use tremor_value::{literal, structurize};
 
     #[test]
@@ -227,17 +411,20 @@ mod test {
         Ok(())
     }
 
+    #[cfg(see_make_client_comment)]
     #[async_std::test]
-    async fn on_event_fails_if_client_is_not_conected() -> Result<()> {
+    async fn on_event_fails_if_client_is_not_connected() -> Result<()> {
         let (rx, _tx) = async_std::channel::unbounded();
         let config = Config::new(&literal!({
-            "connect_timeout": 1_000_000
-        }))
-        .unwrap();
+            "connect_timeout": 1_000_000,
+            "concurrency": 1,
+        }))?;
 
-        let mut sink = GclSink::new(config);
+        let (sr_sender, sr_receiver) = bounded(1);
+        let (asr_sender, _asr_receiver) = bounded(1);
+        let mut sink = GclSink::new(config, sr_sender, asr_sender);
 
-        let result = sink
+        let _result = sink
             .on_event(
                 "",
                 Event::signal_tick(),
@@ -258,28 +445,35 @@ mod test {
                 .unwrap(),
                 0,
             )
-            .await;
+            .await?;
 
-        assert!(result.is_err());
+        //        assert_eq!(SinkReply::NONE, result);
+        // let disposition = asr_receiver.try_recv()?;
+        // dbg!(disposition);
+        // assert!(disposition.is_fail());
+        // assert!(!disposition.is_cb());
+        // assert!(!disposition.is_ack());
+        let _result = sr_receiver.try_recv()?;
+        dbg!(_result);
+
+        sink.shutdown().await?; // signal background gcl client tasks to shutdown
+                                //        drop(sink);
         Ok(())
     }
 
+    #[cfg(see_make_client_comment)]
     #[async_std::test]
     async fn on_event_fails_if_write_stream_is_not_connected() -> Result<()> {
         let (rx, _tx) = async_std::channel::unbounded();
         let config = Config::new(&literal!({
             "connect_timeout": 1_000_000,
-            "request_timeout": 1_000_000
-        }))
-        .unwrap();
+            "request_timeout": 1_000_000,
+            "concurrency": 1,
+        }))?;
 
-        let mut sink = GclSink::new(config);
-        sink.set_client(LoggingServiceV2Client::with_interceptor(
-            Channel::from_static("http://example.com").connect_lazy(),
-            AuthInterceptor {
-                token: Box::new(|| Ok(Arc::new(String::new()))),
-            },
-        ));
+        let (sr_sender, sr_receiver) = bounded(1);
+        let (asr_sender, asr_receiver) = bounded(1);
+        let mut sink = GclSink::new(config, sr_sender, asr_sender);
 
         assert!(!sink.auto_ack());
 
@@ -304,8 +498,17 @@ mod test {
                 .unwrap(),
                 0,
             )
-            .await;
-        assert!(result.is_err());
+            .await?;
+
+        assert_eq!(SinkReply::NONE, result);
+        let disposition = asr_receiver.recv().await?;
+        assert!(disposition.is_fail());
+        assert!(!disposition.is_cb());
+        assert!(!disposition.is_ack());
+        let _result = sr_receiver.recv().await?;
+
+        sink.shutdown().await?; // signal background gcl client tasks to shutdown
+        drop(sink);
         Ok(())
     }
 

--- a/src/connectors/sink.rs
+++ b/src/connectors/sink.rs
@@ -131,6 +131,33 @@ pub(crate) enum AsyncSinkReply {
     CB(ContraflowData, CbAction),
 }
 
+#[allow(dead_code)]
+impl AsyncSinkReply {
+    #[cfg(test)]
+    pub(crate) fn is_ack(&self) -> bool {
+        match self {
+            Self::Ack(_, _) => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_fail(&self) -> bool {
+        match self {
+            Self::Fail(_) => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_cb(&self) -> bool {
+        match self {
+            Self::CB(_, _) => true,
+            _ => false,
+        }
+    }
+}
+
 /// connector sink - receiving events
 #[async_trait::async_trait]
 pub(crate) trait Sink: Send {


### PR DESCRIPTION
Signed-off-by: Darach Ennis <darach@gmail.com>

# Pull request

Attempt to add bounded concurrent in flight requests to GCL writer which is the first gRPC / tonic
based connector to require it. As the `ConcurrencyCap` method does not work here as tonic clients
are not cloneable - we attempt to use a preallocated set of tasks. However, a preallocated set of
tasks may introduce blocking further downstream and complicates ( makes practically impossible )
unit testing 😬 

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


