### PR TITLE
Issue less coordinator requests to kafka group-coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixes
 
+- Fix `elastic` sink not acking messages handles successfully if no source is connected.
 - Allow `kafka_consumer` connector to reconnect upon more error conditions and avoid stalls.
 - Include flow alias in pipeline and connector aliases reported via metrics events and logging in order to deduplicate entries
 - Rename `gcs_appender` to `gcs_streamer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- Introduce breaking change in `kafka_consumer` configuration, by adding `mode`.
 - Update grok to 0.2, optional patterns are now omitted no longer ""
 - Unify to `url` instead of `endpoint` for google and s3 connectors so they're in line with every other connector
 - Unify to `urls` for `elastic` connector
@@ -19,7 +20,9 @@
 
 ### Fixes
 
-- Fix `elastic` sink not acking messages handles successfully if no source is connected.
+- Fix `elastic` sink not acking events handled successfully if no source is connected.
+- Fix `kafka_consumer` possibly committing earlier offsets, thus replaying events that have already been handled.
+- Fix off-by-one error in `kafka_consumer` committing offsets, thus replaying the last committed event.
 - Allow `kafka_consumer` connector to reconnect upon more error conditions and avoid stalls.
 - Include flow alias in pipeline and connector aliases reported via metrics events and logging in order to deduplicate entries
 - Rename `gcs_appender` to `gcs_streamer`

--- a/src/connectors/impls/elastic.rs
+++ b/src/connectors/impls/elastic.rs
@@ -495,11 +495,12 @@ impl Sink for ElasticSink {
                                     .await,
                                     "Error handling ES response",
                                 );
-                                task_ctx.swallow_err(
-                                    send_ack(event, start, &reply_tx).await,
-                                    "Error sending ack CB",
-                                );
                             }
+
+                            task_ctx.swallow_err(
+                                send_ack(event, start, &reply_tx).await,
+                                "Error sending ack CB",
+                            );
                         }
                     }
                     drop(guard);

--- a/src/connectors/impls/kafka.rs
+++ b/src/connectors/impls/kafka.rs
@@ -24,7 +24,10 @@ use halfbrown::HashMap;
 use rdkafka::{error::KafkaError, util::AsyncRuntime, ClientContext, Statistics};
 use rdkafka_sys::RDKafkaErrorCode;
 use std::{
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 use tremor_script::EventPayload;
@@ -94,6 +97,8 @@ where
     connect_tx: Sender<KafkaError>,
     metrics_tx: BroadcastSender<EventPayload>,
     active: AtomicBool,
+    // for synchronizing when the consumer should clear its assignment cache
+    last_rebalance_ts: Arc<AtomicU64>,
 }
 
 impl<Ctx> TremorRDKafkaContext<Ctx>
@@ -114,7 +119,22 @@ where
     const CONSUMER_LAG: Cow<'static, str> = Cow::const_str("consumer_lag");
     const KAFKA_CONSUMER_STATS: &'static str = "kafka_consumer_stats";
 
-    fn new(
+    fn consumer(
+        ctx: Ctx,
+        connect_tx: Sender<KafkaError>,
+        metrics_tx: BroadcastSender<EventPayload>,
+        last_rebalance_ts: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            ctx,
+            connect_tx,
+            metrics_tx,
+            active: AtomicBool::new(true),
+            last_rebalance_ts,
+        }
+    }
+
+    fn producer(
         ctx: Ctx,
         connect_tx: Sender<KafkaError>,
         metrics_tx: BroadcastSender<EventPayload>,
@@ -124,6 +144,7 @@ where
             connect_tx,
             metrics_tx,
             active: AtomicBool::new(true),
+            last_rebalance_ts: Arc::new(AtomicU64::new(0)), // not used for the producer, just a dummy here
         }
     }
 
@@ -280,6 +301,8 @@ fn is_fatal_error(e: &KafkaError) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::{ClientContext, TremorRDKafkaContext};
@@ -298,7 +321,12 @@ mod tests {
         let (connect_tx, _connect_rx) = bounded(1);
         let (metrics_tx, _metrics_rx) = broadcast(1);
         let fake_ctx = FakeContext::new(ctx_tx);
-        let ctx = TremorRDKafkaContext::new(fake_ctx, connect_tx, metrics_tx);
+        let ctx = TremorRDKafkaContext::consumer(
+            fake_ctx,
+            connect_tx,
+            metrics_tx,
+            Arc::new(AtomicU64::new(0)),
+        );
         ctx.on_connection_lost().await;
         let msg = ctx_rx.recv().timeout(Duration::from_secs(1)).await??;
         assert!(matches!(msg, Msg::ConnectionLost));
@@ -316,7 +344,12 @@ mod tests {
         let (connect_tx, _connect_rx) = bounded(1);
         let (metrics_tx, mut metrics_rx) = broadcast(1);
         let fake_ctx = FakeContext::new(ctx_tx);
-        let ctx = TremorRDKafkaContext::new(fake_ctx, connect_tx, metrics_tx);
+        let ctx = TremorRDKafkaContext::consumer(
+            fake_ctx,
+            connect_tx,
+            metrics_tx,
+            Arc::new(AtomicU64::new(0)),
+        );
 
         let s = Statistics {
             name: "snot".to_string(),
@@ -372,7 +405,12 @@ mod tests {
         let (metrics_tx, metrics_rx) = broadcast(1);
         metrics_rx.close();
         let fake_ctx = FakeContext::new(ctx_tx);
-        let ctx = TremorRDKafkaContext::new(fake_ctx, connect_tx, metrics_tx);
+        let ctx = TremorRDKafkaContext::consumer(
+            fake_ctx,
+            connect_tx,
+            metrics_tx,
+            Arc::new(AtomicU64::new(0)),
+        );
 
         let s = Statistics {
             name: "snot".to_string(),
@@ -411,7 +449,12 @@ mod tests {
         let (connect_tx, _connect_rx) = bounded(1);
         let (metrics_tx, metrics_rx) = broadcast(1);
         let fake_ctx = FakeContext::new(ctx_tx);
-        let ctx = TremorRDKafkaContext::new(fake_ctx, connect_tx, metrics_tx);
+        let ctx = TremorRDKafkaContext::consumer(
+            fake_ctx,
+            connect_tx,
+            metrics_tx,
+            Arc::new(AtomicU64::new(0)),
+        );
         let s = Statistics::default();
         ctx.stats(s);
         assert!(metrics_rx.is_empty());
@@ -425,7 +468,12 @@ mod tests {
         let (connect_tx, _connect_rx) = bounded(1);
         let (metrics_tx, _metrics_rx) = broadcast(1);
         let fake_ctx = FakeContext::new(ctx_tx);
-        let ctx = TremorRDKafkaContext::new(fake_ctx, connect_tx, metrics_tx);
+        let ctx = TremorRDKafkaContext::consumer(
+            fake_ctx,
+            connect_tx,
+            metrics_tx,
+            Arc::new(AtomicU64::new(0)),
+        );
 
         ctx.log(rdkafka::config::RDKafkaLogLevel::Emerg, "consumer", "snot");
         ctx.log(rdkafka::config::RDKafkaLogLevel::Alert, "consumer", "snot");

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -624,7 +624,9 @@ impl Source for KafkaConsumerSource {
                                 consumer.commit(&tpl, CommitMode::Async)?;
                             }
                         } else {
-                            debug!("{ctx} Not committing {topic} {partition}: {offset:?}: {offsets:?}");
+                            debug!(
+                                "{ctx} Not committing {topic} {partition}: {offset:?}: {offsets:?}"
+                            );
                         }
                     } else {
                         debug!("{ctx} Unable to store/commit offset={offset:?} for event with stream={stream_id}, pull_id={pull_id}");

--- a/src/connectors/impls/kafka/consumer.rs
+++ b/src/connectors/impls/kafka/consumer.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use async_std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::Duration;
+use tremor_common::time::nanotime;
 
 use crate::connectors::impls::kafka::{
     SmolRuntime, TremorRDKafkaContext, KAFKA_CONNECT_TIMEOUT, NO_ERROR,
@@ -27,8 +29,8 @@ use halfbrown::HashMap;
 use indexmap::IndexMap;
 use log::Level::Debug;
 use rdkafka::config::ClientConfig;
-use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance, StreamConsumer};
-use rdkafka::error::KafkaError;
+use rdkafka::consumer::{Consumer, ConsumerContext, Rebalance, StreamConsumer};
+use rdkafka::error::{KafkaError, KafkaResult};
 use rdkafka::message::{BorrowedMessage, Headers, Message};
 use rdkafka::{Offset, TopicPartitionList};
 use rdkafka_sys::RDKafkaErrorCode;
@@ -39,16 +41,28 @@ const KAFKA_CONSUMER_META_KEY: &str = "kafka_consumer";
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// consumer group id to register with
-    pub group_id: String,
+    group_id: String,
     /// List of topics to subscribe to
-    pub topics: Vec<String>,
+    topics: Vec<String>,
     /// List of bootstrap brokers
-    pub brokers: Vec<String>,
+    brokers: Vec<String>,
 
-    /// This config determines the behaviour of this source
-    /// if `enable.auto.commit` is set to false in `rdkafka_options`:
+    /// Whether or not to commit offsets of received messages immediately
+    /// or only upon received ack messages.
     ///
-    /// if set to true this source will reset the consumer offset to a
+    /// If `auto_commit` is set to `false`, events emitted from this consumer
+    /// are considered transactional, soliciting an ack/fail message upon successful or failed handling downstream.
+    #[serde(default = "default_true")]
+    auto_commit: bool,
+
+    /// The interval in nanoseconds in which this consumer sends committed offsets to the broker acting as group-coordinator
+    #[serde(default = "default_commit_interval")]
+    commit_interval: u64,
+
+    /// This config determines the behaviour of this source. DANGER: this might lead to a lot of traffic to the group-coordinator
+    /// if `auto_commit` is set to `false`:
+    ///
+    /// if set to `true` this source will reset the consumer offset to a
     /// failed message, so it will effectively retry those messages.
     ///
     /// If set to `false` this source will only commit the consumer offset
@@ -57,13 +71,19 @@ pub(crate) struct Config {
     /// This might lead to events being sent multiple times.
     /// This should not be used when persistent errors are expected (e.g. if the message content is malformed and will lead to repeated errors)
     #[serde(default = "default_false")]
-    pub retry_failed_events: bool,
+    retry_failed_events: bool,
 
     /// Optional rdkafka configuration
-    pub rdkafka_options: Option<HashMap<String, String>>,
+    ///
+    /// Can be overwritten by tremor for settings required for `auto_commit` and/or `retry_failed_events`.
+    rdkafka_options: Option<HashMap<String, String>>,
 }
 
 impl ConfigImpl for Config {}
+
+fn default_commit_interval() -> u64 {
+    5_000_000_000 // 5 seconds, the default from librdkafka
+}
 
 #[derive(Default, Debug)]
 pub(crate) struct Builder {}
@@ -95,23 +115,13 @@ impl ConnectorBuilder for Builder {
         let tid = task::current().id();
         let client_id = format!("tremor-{}-{}-{:?}", hostname(), alias, tid);
         let mut client_config = ClientConfig::new();
-        client_config
-            .set("group.id", config.group_id.clone())
-            .set("client.id", &client_id)
-            .set("bootstrap.servers", &config.brokers.join(","));
+
         // .set("enable.partition.eof", "false")
         // .set("session.timeout.ms", "6000")
         // .set("enable.auto.commit", "true")
         // .set("auto.commit.interval.ms", "5000")
         // .set("enable.auto.offset.store", "true");
 
-        if let Some(metrics_interval_s) = metrics_interval_s {
-            // enable stats collection
-            client_config.set(
-                "statistics.interval.ms",
-                format!("{}", metrics_interval_s * 1000),
-            );
-        }
         config
             .rdkafka_options
             .iter()
@@ -120,10 +130,45 @@ impl ConnectorBuilder for Builder {
                 client_config.set(k, v);
             });
 
-        debug!(
-            "[Connector::{}] Kafka Consumer Config: {:?}",
-            alias, &client_config
+        // we do overwrite the rdkafka options to ensure a sane config
+        overwrite_client_config_with(
+            &mut client_config,
+            "group.id",
+            config.group_id.as_str(),
+            &alias,
         );
+        overwrite_client_config_with(&mut client_config, "client.id", client_id.as_str(), &alias);
+        overwrite_client_config_with(
+            &mut client_config,
+            "bootstrap.servers",
+            &config.brokers.join(","),
+            &alias,
+        );
+        let auto_commit_interval = Duration::from_nanos(config.commit_interval);
+        overwrite_client_config_with(
+            &mut client_config,
+            "auto.commit.interval.ms",
+            &format!("{}", auto_commit_interval.as_millis()),
+            &alias,
+        );
+
+        if let Some(metrics_interval_s) = metrics_interval_s {
+            // enable stats collection
+            overwrite_client_config_with(
+                &mut client_config,
+                "statistics.interval.ms",
+                &format!("{}", metrics_interval_s * 1000),
+                &alias,
+            );
+        }
+        overwrite_client_config_with(
+            &mut client_config,
+            "enable.auto.offset.store",
+            &format!("{}", config.auto_commit),
+            &alias,
+        );
+
+        info!("[Connector::{alias}] Kafka Consumer Config: {client_config:?}",);
 
         Ok(Box::new(KafkaConsumerConnector {
             config,
@@ -133,11 +178,24 @@ impl ConnectorBuilder for Builder {
     }
 }
 
-#[derive(Debug, Clone)]
-struct KafkaStats {}
+fn overwrite_client_config_with<'config>(
+    client_config: &'config mut ClientConfig,
+    key: &'static str,
+    value: &str,
+    alias: &Alias,
+) -> &'config mut ClientConfig {
+    if let Some(existing_value) = client_config.get(key) {
+        if existing_value != value {
+            warn!("[Connector::{alias}] Overwriting \"{key}\" in `rdkafka_options` from \"{existing_value}\" to \"{value}\".");
+        }
+    }
+    client_config.set(key, value)
+}
 
 impl ConsumerContext for TremorRDKafkaContext<SourceContext> {
     fn post_rebalance<'a>(&self, rebalance: &rdkafka::consumer::Rebalance<'a>) {
+        // store the last timestamp
+        self.last_rebalance_ts.store(nanotime(), Ordering::Release);
         match rebalance {
             Rebalance::Assign(tpl) => {
                 let offset_strings: Vec<String> = tpl
@@ -298,6 +356,8 @@ struct KafkaConsumerSource {
     consumer: Option<Arc<TremorConsumer>>,
     consumer_task: Option<JoinHandle<()>>,
     metrics_rx: Option<BroadcastReceiver<EventPayload>>,
+    last_rebalance_ts: Arc<AtomicU64>,
+    cached_assignment: Option<(TopicPartitionList, u64)>,
 }
 
 impl KafkaConsumerSource {
@@ -310,9 +370,6 @@ impl KafkaConsumerSource {
             ..
         } = config;
         let topic_resolver = TopicResolver::new(topics.clone());
-        let auto_commit = client_config
-            .get("enable.auto.commit")
-            .map_or(true, |v| v == "true");
         let seek_timeout = client_config
             // this will put the default from kafka if not present
             .create_native_config()
@@ -329,7 +386,7 @@ impl KafkaConsumerSource {
             origin_uri,
             topics,
             topic_resolver,
-            transactional: !auto_commit,
+            transactional: !config.auto_commit,
             retry_failed_events,
             seek_timeout,
             source_tx,
@@ -337,6 +394,40 @@ impl KafkaConsumerSource {
             consumer: None,
             consumer_task: None,
             metrics_rx: None,
+            last_rebalance_ts: Arc::new(AtomicU64::new(0)),
+            cached_assignment: None,
+        }
+    }
+
+    /// gets the current assignment from the cache or fetches it from the group coordinator
+    /// if we witnessed a rebalance in between
+    ///
+    /// This tries to avoid excess assignment calls to the group coordinator
+    // FIXME: wanted to return a `&TopicPartitionList` but failed because of the borrow checker, so i cloned it instead, fight me
+    fn get_assignment(&mut self) -> KafkaResult<TopicPartitionList> {
+        let KafkaConsumerSource {
+            cached_assignment,
+            consumer,
+            ..
+        } = self;
+        if let Some(consumer) = consumer {
+            let last_rebalance_ts = self.last_rebalance_ts.load(Ordering::Acquire);
+            match cached_assignment {
+                Some((tpl, created)) if last_rebalance_ts <= *created => {
+                    KafkaResult::Ok(tpl.clone())
+                }
+                ca => {
+                    // if we witnessed a new rebalance, we gotta fetch the new assignment
+                    let new_assignment = consumer.assignment()?;
+                    ca.insert((new_assignment.clone(), last_rebalance_ts));
+                    KafkaResult::Ok(new_assignment)
+                }
+            }
+        } else {
+            // highly unlikely
+            return KafkaResult::Err(KafkaError::ClientCreation(
+                "No client available".to_string(),
+            ));
         }
     }
 }
@@ -361,8 +452,12 @@ impl Source for KafkaConsumerSource {
         let (mut metrics_tx, metrics_rx) = broadcast(1);
         metrics_tx.set_overflow(true);
         self.metrics_rx = Some(metrics_rx);
-        let consumer_context =
-            TremorConsumerContext::new(ctx.clone(), connect_result_tx.clone(), metrics_tx);
+        let consumer_context = TremorConsumerContext::consumer(
+            ctx.clone(),
+            connect_result_tx.clone(),
+            metrics_tx,
+            self.last_rebalance_ts.clone(),
+        );
         let consumer: TremorConsumer = self.client_config.create_with_context(consumer_context)?;
 
         let topics: Vec<&str> = self
@@ -425,11 +520,15 @@ impl Source for KafkaConsumerSource {
                 if let Some((topic, partition, offset)) =
                     self.topic_resolver.resolve_topic(stream_id, pull_id)
                 {
-                    let mut tpl: TopicPartitionList = TopicPartitionList::with_capacity(1);
-                    tpl.add_partition_offset(topic, partition, offset)?;
-                    consumer.commit(&tpl, CommitMode::Async)?;
+                    // we deliberately do not send a commit to the group-coordinator by calling `consumer.commit`
+                    // but instead use the client-local memory store of committed offsets
+                    if let Some(raw_offset) = offset.to_raw() {
+                        consumer.store_offset(topic, partition, raw_offset)?;
+                    } else {
+                        debug!("{ctx} Unable to commit offset={offset:?} for event with stream={stream_id}, pull_id={pull_id}");
+                    }
                 } else {
-                    error!("{} Could not ack event with stream={}, pull_id={}. Unable to detect topic from internal state.", &ctx, stream_id, pull_id);
+                    error!("{ctx} Could not ack event with stream={stream_id}, pull_id={pull_id}. Unable to detect topic from internal state.");
                 }
             }
         }
@@ -437,6 +536,8 @@ impl Source for KafkaConsumerSource {
     }
 
     async fn fail(&mut self, stream_id: u64, pull_id: u64, ctx: &SourceContext) -> Result<()> {
+        // FIXME: we obviously cannot simply store the offset in the local offset store, i do think rdkafka would simply ignore a smaller offset
+        // so we need to seek. But this could cause a lot of traffic in the worst case. HELP!
         if self.transactional && self.retry_failed_events {
             if let Some(consumer) = self.consumer.as_ref() {
                 if let Some((topic, partition, offset)) =
@@ -456,36 +557,32 @@ impl Source for KafkaConsumerSource {
     }
 
     async fn on_cb_close(&mut self, _ctx: &SourceContext) -> Result<()> {
+        let assignment = self.get_assignment()?;
         if let Some(consumer) = self.consumer.as_ref() {
-            consumer
-                .assignment()
-                .and_then(|partitions| consumer.pause(&partitions))?;
+            consumer.pause(&assignment)?;
         }
         Ok(())
     }
     async fn on_cb_open(&mut self, _ctx: &SourceContext) -> Result<()> {
-        if let Some(consumer) = self.consumer.as_ref() {
-            consumer
-                .assignment()
-                .and_then(|partitions| consumer.resume(&partitions))?;
+        let assignment = self.get_assignment()?;
+        if let Some(consumer) = self.consumer.as_mut() {
+            consumer.resume(&assignment)?;
         }
         Ok(())
     }
 
     async fn on_pause(&mut self, _ctx: &SourceContext) -> Result<()> {
-        if let Some(consumer) = self.consumer.as_ref() {
-            consumer
-                .assignment()
-                .and_then(|partitions| consumer.pause(&partitions))?;
+        let assignment = self.get_assignment()?;
+        if let Some(consumer) = self.consumer.as_mut() {
+            consumer.pause(&assignment)?;
         }
         Ok(())
     }
 
     async fn on_resume(&mut self, _ctx: &SourceContext) -> Result<()> {
-        if let Some(consumer) = self.consumer.as_ref() {
-            consumer
-                .assignment()
-                .and_then(|partitions| consumer.resume(&partitions))?;
+        let assignment = self.get_assignment()?;
+        if let Some(consumer) = self.consumer.as_mut() {
+            consumer.resume(&assignment)?;
         }
         Ok(())
     }

--- a/src/connectors/impls/kafka/producer.rs
+++ b/src/connectors/impls/kafka/producer.rs
@@ -55,7 +55,7 @@ pub(crate) struct Config {
     /// * `message.timeout.ms` - `"5000"`
     /// * `queue.buffering.max.ms` - `"0"` - don't buffer for lower latency (high)
     #[serde(default = "Default::default")]
-    pub rdkafka_options: Option<HashMap<String, String>>,
+    rdkafka_options: Option<HashMap<String, String>>,
 }
 
 impl ConfigImpl for Config {}
@@ -263,7 +263,7 @@ impl Sink for KafkaProducerSink {
         let (mut metrics_tx, metrics_rx) = broadcast(1);
         metrics_tx.set_overflow(true);
         self.metrics_rx = Some(metrics_rx);
-        let context = TremorRDKafkaContext::new(ctx.clone(), tx, metrics_tx);
+        let context = TremorRDKafkaContext::producer(ctx.clone(), tx, metrics_tx);
         let (version_n, version_s) = rdkafka::util::get_rdkafka_version();
         info!("{ctx} Connecting kafka producer with rdkafka 0x{version_n:08x} {version_s}");
 

--- a/src/connectors/tests/kafka.rs
+++ b/src/connectors/tests/kafka.rs
@@ -22,7 +22,7 @@ use testcontainers::{
 };
 
 const IMAGE: &str = "vectorized/redpanda";
-const VERSION: &str = "v21.11.15";
+const VERSION: &str = "v22.1.7";
 
 async fn redpanda_container<'d>(docker: &'d DockerCli) -> Result<Container<'d, GenericImage>> {
     let kafka_port = find_free_tcp_port().await?;

--- a/src/connectors/tests/kafka/consumer.rs
+++ b/src/connectors/tests/kafka/consumer.rs
@@ -91,10 +91,8 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
             "topics": [
                 topic
             ],
-            "retry_failed_events": true,
-            "rdkafka_options": {
-                "enable.auto.commit": "false"
-            //    "debug": "all"
+            "mode": {
+                "transactional": {}
             }
         }
     });
@@ -331,9 +329,14 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
             "topics": [
                 topic
             ],
-            "rdkafka_options": {
-                "enable.auto.commit": "false"
-            //    "debug": "all"
+            "mode": {
+                "custom": {
+                    "rdkafka_options": {
+                        "enable.auto.commit": "false"
+                    //    "debug": "all"
+                    },
+                    "retry_failed_events": false
+                }
             }
         }
     });
@@ -559,9 +562,7 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
             "topics": [
                 topic
             ],
-            "rdkafka_options": {
-            //    "debug": "all"
-            }
+            "mode": "performance"
         }
     });
     let harness = ConnectorHarness::new(
@@ -757,9 +758,7 @@ async fn connector_kafka_consumer_unreachable() -> Result<()> {
             "topics": [
                 "snot"
             ],
-            "rdkafka_options": {
-            //    "debug": "all"
-            }
+            "mode": "performance"
         }
     });
     let harness = ConnectorHarness::new(
@@ -829,8 +828,13 @@ async fn connector_kafka_consumer_pause_resume() -> Result<()> {
             "topics": [
                 topic
             ],
-            "rdkafka_options": {
-            //    "debug": "all"
+            "mode": {
+                "custom": {
+                    "rdkafka_options": {
+                        "debug": "all"
+                    },
+                    "retry_failed_events": false
+                }
             }
         }
     });

--- a/src/connectors/tests/kafka/consumer.rs
+++ b/src/connectors/tests/kafka/consumer.rs
@@ -19,8 +19,12 @@ use crate::{
     errors::Result,
 };
 use async_std::task;
+use async_std::prelude::FutureExt;
 use beef::Cow;
+use std::collections::HashMap;
 use rdkafka::{
+    Offset, error::KafkaResult,
+    consumer::{BaseConsumer, Consumer},
     admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     config::FromClientConfig,
     message::OwnedHeaders,
@@ -36,7 +40,7 @@ use value_trait::Builder;
 
 #[async_std::test]
 #[serial(kafka)]
-async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
+async fn transactional_retry() -> Result<()> {
     serial_test::set_max_wait(Duration::from_secs(600));
 
     let _ = env_logger::try_init();
@@ -248,7 +252,7 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "test::connector_kafka_consumer_transactional_retry",
+            "source": "test::transactional_retry",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),
@@ -272,14 +276,41 @@ async fn connector_kafka_consumer_transactional_retry() -> Result<()> {
     let (out_events, err_events) = harness.stop().await?;
     assert!(out_events.is_empty());
     assert!(err_events.is_empty());
+
+    // check out the committed offsets with another consumer
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(1)));
+    assert_eq!(offsets.get(&(topic.to_string(), 1)), Some(&Offset::Offset(1)));
+    assert_eq!(offsets.get(&(topic.to_string(), 2)), Some(&Offset::Invalid)); // nothing committed yet
+    
+
     // cleanup
     drop(container);
     Ok(())
 }
 
+async fn get_offsets(broker: &str, group_id: &str, topic: &str) -> KafkaResult<HashMap<(String, i32), Offset>> {
+    let consumer: BaseConsumer = ClientConfig::new()
+        .set("bootstrap.servers", broker)
+        .set("group.id", group_id)
+        .create().expect("Error creating consumer");
+    consumer.subscribe(&[topic])?;
+    let mut assignment = consumer.assignment()?;
+    while assignment.count() == 0 {
+        task::sleep(Duration::from_millis(100)).await;
+        consumer.poll(Duration::ZERO);
+        assignment = consumer.assignment()?;
+    }
+    drop(assignment);
+    
+    let offsets = consumer.committed(Duration::from_secs(5))?.to_topic_map();
+    drop(consumer);
+    Ok(offsets)
+}
+
 #[async_std::test]
 #[serial(kafka)]
-async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
+async fn transactional_no_retry() -> Result<()> {
     serial_test::set_max_wait(Duration::from_secs(600));
 
     let _ = env_logger::try_init();
@@ -291,6 +322,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
     let mut admin_config = ClientConfig::new();
     let broker = format!("127.0.0.1:{}", port);
     let topic = "tremor_test_no_retry";
+    let group_id = "test1";
     admin_config
         .set("client.id", "test-admin")
         .set("bootstrap.servers", &broker);
@@ -325,7 +357,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
             "brokers": [
                 broker.clone()
             ],
-            "group_id": "test1",
+            "group_id": group_id,
             "topics": [
                 topic
             ],
@@ -480,7 +512,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "test::connector_kafka_consumer_transactional_no_retry",
+            "source": "test::transactional_no_retry",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),
@@ -504,6 +536,11 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
     let (out_events, err_events) = harness.stop().await?;
     assert!(out_events.is_empty());
     assert!(err_events.is_empty());
+
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Invalid));
+    assert_eq!(offsets.get(&(topic.to_string(), 1)), Some(&Offset::Offset(1)));
+    assert_eq!(offsets.get(&(topic.to_string(), 2)), Some(&Offset::Invalid));
     // cleanup
     drop(container);
     Ok(())
@@ -511,7 +548,7 @@ async fn connector_kafka_consumer_transactional_no_retry() -> Result<()> {
 
 #[async_std::test]
 #[serial(kafka)]
-async fn connector_kafka_consumer_non_transactional() -> Result<()> {
+async fn performance() -> Result<()> {
     serial_test::set_max_wait(Duration::from_secs(600));
 
     let _ = env_logger::try_init();
@@ -706,7 +743,7 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError at character 0 ('}')",
-            "source": "test::connector_kafka_consumer_non_transactional",
+            "source": "test::performance",
             "stream_id": 8589934592_u64,
             "pull_id": 1u64
         }),
@@ -730,6 +767,12 @@ async fn connector_kafka_consumer_non_transactional() -> Result<()> {
     let (out_events, err_events) = harness.stop().await?;
     assert!(out_events.is_empty());
     assert!(err_events.is_empty());
+
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(1)));
+    assert_eq!(offsets.get(&(topic.to_string(), 1)), Some(&Offset::Offset(1)));
+    assert_eq!(offsets.get(&(topic.to_string(), 2)), Some(&Offset::Offset(2)));
+
     // cleanup
     drop(container);
     Ok(())
@@ -899,4 +942,392 @@ async fn connector_kafka_consumer_pause_resume() -> Result<()> {
     // cleanup
     drop(container);
     Ok(())
+}
+
+
+#[async_std::test]
+#[serial(kafka)]
+async fn transactional_store_offset_handling() -> Result<()> {
+    serial_test::set_max_wait(Duration::from_secs(600));
+
+    let _ = env_logger::try_init();
+
+    let docker = DockerCli::default();
+    let container = redpanda_container(&docker).await?;
+
+    let port = container.get_host_port_ipv4(9092);
+    let mut admin_config = ClientConfig::new();
+
+    let broker = format!("127.0.0.1:{}", port);
+    let topic = "tremor_test_store_offsets";
+    let group_id = "group_transactional_store_offsets";
+
+    admin_config
+        .set("client.id", "test-admin")
+        .set("bootstrap.servers", &broker);
+    let admin_client = AdminClient::from_config(&admin_config)?;
+    let options = AdminOptions::default();
+    let res = admin_client
+        .create_topics(
+            vec![&NewTopic::new(topic, 1, TopicReplication::Fixed(1))],
+            &options,
+        )
+        .await?;
+    for r in res {
+        match r {
+            Err((topic, err)) => {
+                error!("Error creating topic {}: {}", &topic, err);
+            }
+            Ok(topic) => {
+                info!("Created topic {}", topic);
+            }
+        }
+    }
+    let producer: BaseProducer = ClientConfig::new()
+        .set("bootstrap.servers", &broker)
+        .create()
+        .expect("Producer creation error");
+    let commit_interval: u64 = Duration::from_millis(100).as_nanos().try_into()?;
+    let connector_config = literal!({
+        "codec": "json-sorted",
+        "config": {
+            "brokers": [
+                broker.clone()
+            ],
+            "group_id": group_id,
+            "topics": [
+                topic
+            ],
+            "mode": {
+                "transactional": {
+                    "commit_interval": commit_interval
+                }
+            }
+        }
+    });
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    let out = harness.out().expect("No pipe connected to port OUT");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    task::sleep(Duration::from_secs(5)).await;
+
+    // send message 1
+    let record1 = BaseRecord::to(topic)
+        .key("1")
+        .payload("1")
+        .partition(0)
+        .timestamp(1);
+    if producer.send(record1).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    // send message 2
+    let record2 = BaseRecord::to(topic)
+        .key("2")
+        .payload("2")
+        .partition(0)
+        .timestamp(2);
+    if producer.send(record2).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    producer.flush(Duration::from_secs(1));
+
+    // send message 3
+    let record3 = BaseRecord::to(topic)
+        .key("3")
+        .payload("3")
+        .partition(0)
+        .timestamp(3);
+    if producer.send(record3).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    producer.flush(Duration::from_secs(1));
+
+    // receive events
+    let event1 = out.get_event().await?;
+    assert_eq!(&Value::from(1), event1.data.suffix().value());
+    let event2 = out.get_event().await?;
+    assert_eq!(&Value::from(2), event2.data.suffix().value());
+    let event3 = out.get_event().await?;
+    assert_eq!(&Value::from(3), event3.data.suffix().value());
+
+    // ack message 3
+    harness
+        .send_contraflow(CbAction::Ack, event3.id.clone())
+        .await?;
+    // ack message 1
+    harness
+        .send_contraflow(CbAction::Ack, event1.id.clone())
+        .await?;
+
+    // stop harness
+    let (out_events, err_events) = harness.stop().await?;
+    assert!(out_events.is_empty());
+    assert!(err_events.is_empty());
+
+    debug!("getting offsets...");
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(3)));
+
+    debug!("before start");
+    // start new harness
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+    debug!("connected");
+
+    // fail message 2
+    harness.send_contraflow(CbAction::Fail, event2.id.clone()).await?;
+
+    debug!("failed event2");
+
+    // stop harness
+    let _ = harness.stop().await?;
+
+    // check that fail did reset the offset correctly
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(1)));
+    drop(offsets);
+
+    // start new harness
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    let out = harness.out().expect("No pipe connected to port OUT");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    // ensure message 2 and 3 are received
+    // for some strange reason rdkafka might consumer event2 twice
+    let mut event_again = out.get_event().await?;
+    let mut data = event_again.data.suffix().value();
+    while data == &Value::from(2) {
+        event_again = out.get_event().await?;
+        data = event_again.data.suffix().value();
+    }
+    assert_eq!(&Value::from(3), data);
+    
+    // ack message 3 only
+    harness.send_contraflow(CbAction::Ack, event_again.id.clone()).await?;
+
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(3)));
+
+    // stop harness
+    let _ = harness.stop().await?;
+
+    drop(container);
+    Ok(())
+}
+
+#[async_std::test]
+#[serial(kafka)]
+async fn transactional_commit_offset_handling() -> Result<()> {
+    serial_test::set_max_wait(Duration::from_secs(600));
+
+    let _ = env_logger::try_init();
+
+    let docker = DockerCli::default();
+    let container = redpanda_container(&docker).await?;
+
+    let port = container.get_host_port_ipv4(9092);
+    let mut admin_config = ClientConfig::new();
+
+    let broker = format!("127.0.0.1:{}", port);
+    let topic = "tremor_test_commit_offset";
+    let group_id = "group_commit_offset";
+
+    admin_config
+        .set("client.id", "test-admin")
+        .set("bootstrap.servers", &broker);
+    let admin_client = AdminClient::from_config(&admin_config)?;
+    let options = AdminOptions::default();
+    let res = admin_client
+        .create_topics(
+            vec![&NewTopic::new(topic, 1, TopicReplication::Fixed(1))],
+            &options,
+        )
+        .await?;
+    for r in res {
+        match r {
+            Err((topic, err)) => {
+                error!("Error creating topic {}: {}", &topic, err);
+            }
+            Ok(topic) => {
+                info!("Created topic {}", topic);
+            }
+        }
+    }
+    let producer: BaseProducer = ClientConfig::new()
+        .set("bootstrap.servers", &broker)
+        .create()
+        .expect("Producer creation error");
+    let connector_config = literal!({
+        "codec": "json-sorted",
+        "config": {
+            "brokers": [
+                broker.clone()
+            ],
+            "group_id": group_id,
+            "topics": [
+                topic
+            ],
+            "mode": {
+                // "custom": {
+                //     "retry_failed_events": true,
+                //     "rdkafka_options": {
+                //         "enable.auto.commit": "true",
+                //         "enable.auto.offset.store": "false",
+                //         "debug": "all"
+                //     }
+                // }
+                "transactional": {
+                   "commit_interval": 0 // trigger direct commits
+                }
+            }
+        }
+    });
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    let out = harness.out().expect("No pipe connected to port OUT");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    task::sleep(Duration::from_secs(5)).await;
+
+    // send message 1
+    let record1 = BaseRecord::to(topic)
+        .key("1")
+        .payload("1")
+        .partition(0)
+        .timestamp(1);
+    if producer.send(record1).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    // send message 2
+    let record2 = BaseRecord::to(topic)
+        .key("2")
+        .payload("2")
+        .partition(0)
+        .timestamp(2);
+    if producer.send(record2).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    producer.flush(Duration::from_secs(1));
+
+    // send message 3
+    let record3 = BaseRecord::to(topic)
+        .key("3")
+        .payload("3")
+        .partition(0)
+        .timestamp(3);
+    if producer.send(record3).is_err() {
+        return Err("Unable to send record to Kafka".into());
+    }
+    producer.flush(Duration::from_secs(1));
+
+    // receive events
+    let event1 = out.get_event().await?;
+    assert_eq!(&Value::from(1), event1.data.suffix().value());
+    let event2 = out.get_event().await?;
+    assert_eq!(&Value::from(2), event2.data.suffix().value());
+    let event3 = out.get_event().await?;
+    assert_eq!(&Value::from(3), event3.data.suffix().value());
+
+    // ack message 3
+    harness
+        .send_contraflow(CbAction::Ack, event3.id.clone())
+        .await?;
+    // ack message 1
+    harness
+        .send_contraflow(CbAction::Ack, event1.id.clone())
+        .await?;
+
+    // stop harness
+    let (out_events, err_events) = harness.stop().await?;
+    assert!(out_events.is_empty());
+    assert!(err_events.is_empty());
+
+
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(3)));
+
+    // start new harness
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    let out = harness.out().expect("No pipe connected to port OUT");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    // ensure no message is received
+    assert!(out.get_event().timeout(Duration::from_millis(200)).await.is_err());
+
+    // fail message 2
+    harness.send_contraflow(CbAction::Fail, event2.id.clone()).await?;
+    
+    // ensure message 2 is the next - seek was effective
+    let event2_again = out.get_event().await?;
+    assert_eq!(&Value::from(2), event2_again.data.suffix().value());
+
+    // stop harness
+    let _ = harness.stop().await?;
+
+    // check that fail did reset the offset correctly - commit was effective
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(1)));
+
+    // start new harness
+    let harness = ConnectorHarness::new(
+        function_name!(),
+        &kafka::consumer::Builder::default(),
+        &connector_config,
+    )
+    .await?;
+    let out = harness.out().expect("No pipe connected to port OUT");
+    harness.start().await?;
+    harness.wait_for_connected().await?;
+
+    // ensure message 2 and 3 are received
+    // for some strange reason rdkafka might consumer event2 twice
+    let mut event_again = out.get_event().await?;
+    let mut data = event_again.data.suffix().value();
+    while data == &Value::from(2) {
+        event_again = out.get_event().await?;
+        data = event_again.data.suffix().value();
+    }
+    assert_eq!(&Value::from(3), data);
+
+    // ack message 3 only
+    harness.send_contraflow(CbAction::Ack, event_again.id.clone()).await?;
+
+    // stop harness
+    let _ = harness.stop().await?;
+
+    let offsets = get_offsets(broker.as_str(), group_id, topic).await?;
+    assert_eq!(offsets.get(&(topic.to_string(), 0)), Some(&Offset::Offset(3)));
+
+    drop(container);
+    Ok(())
+    
 }

--- a/tremor-cli/tests/integration/elastic-sink-only/assert.yaml
+++ b/tremor-cli/tests/integration/elastic-sink-only/assert.yaml
@@ -5,5 +5,3 @@ asserts:
     contains:
       - |
         All required CB events received. 
-      - |
-        Got acks: []

--- a/tremor-cli/tests/integration/elastic-sink-only/config.troy
+++ b/tremor-cli/tests/integration/elastic-sink-only/config.troy
@@ -36,6 +36,15 @@ flow
         "refresh": "wait_for",
         "retry_on_conflict": 2
       };
+      match event of
+        case %{ present num } =>
+          match event["num"] % 2 of
+            case 0 =>
+              let $elastic["_id"] = "#{event["num"]}"
+            default => null
+          end
+        default => null
+      end;
       # payload
       emit {"doc": event, "doc_as_upsert": true};
     end;
@@ -46,9 +55,12 @@ flow
     select event from add_meta/err into err;
   end;
   create pipeline elastic_meta;
+  create connector console from connectors::console;
 
   connect /connector/input to /pipeline/elastic_meta;
-  connect /pipeline/elastic_meta to /connector/elastic_sink;
+  connect /pipeline/elastic_meta/out to /connector/elastic_sink;
+  #connect /pipeline/elastic_meta/out to /connector/console/stdout;
+  connect /pipeline/elastic_meta/err to /connector/console/stderr;
 end;
 
 deploy flow elastic_sink_only;

--- a/tremor-cli/tests/integration/kafka_connectors/config.troy
+++ b/tremor-cli/tests/integration/kafka_connectors/config.troy
@@ -105,11 +105,15 @@ flow
                 "topics": [
                     "tremor_test"
                 ],
-                "retry_failed_events": false,
-                "rdkafka_options": {
-                    "enable.auto.commit": "false",
-                    "auto.offset.reset": "beginning",
-                    "debug": "consumer"
+                "mode": {
+                    "custom": {
+                        "retry_failed_events": false,
+                        "rdkafka_options": {
+                            "enable.auto.commit": "false",
+                            "auto.offset.reset": "beginning",
+                            "debug": "consumer"
+                        }
+                    }
                 }
             }
     end;


### PR DESCRIPTION
# Pull request

## Description

Currently for each event we commit the offset directly to the group-coordinator, doing a request to the broker.
During pause/resume we are also doing 1 request for getting the current assignment.

This PR fixes this by caching the current assignment and invalidating it only upon a rebalance and making use of `enable.auto.commit` and the local offset store, thus sending commits to the group coordinator in a fixed interval.

It is still possible to commit directly if this behaviour is desired.

Also the configuration interface has changed in a breaking way, by introducing a `mode` to simplify the common cases and making it possible to use them without detailed `librdkafka` knowledge. We still allow custom configurations with a `custom` mode.

This is a successor to #1837 

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

This also contains a small fix to elastic that will be ported to 0.12 branch as well.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance


