### PR TITLE
Allow specifying kafka options for the consumer as non-strings

### DIFF
--- a/tremor-value/src/value/static.rs
+++ b/tremor-value/src/value/static.rs
@@ -16,6 +16,7 @@ use crate::value::Value;
 
 /// avoiding lifetime issues with generics
 /// See: <https://github.com/rust-lang/rust/issues/64552>
+#[derive(Debug, Clone)]
 pub struct StaticValue(Value<'static>);
 
 impl StaticValue {
@@ -24,6 +25,12 @@ impl StaticValue {
     pub fn into_value(self) -> Value<'static> {
         self.0
     }
+
+    /// get a reference to the inner value
+    #[must_use]
+    pub fn value(&self) -> &Value<'static> {
+        &self.0
+    }
 }
 impl<'de> serde::de::Deserialize<'de> for StaticValue {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -31,5 +38,11 @@ impl<'de> serde::de::Deserialize<'de> for StaticValue {
         D: serde::Deserializer<'de>,
     {
         Value::deserialize(deserializer).map(|value| StaticValue(value.into_static()))
+    }
+}
+
+impl std::fmt::Display for StaticValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wahl <matthiaswahl@m7w3.de>

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


