### PR TITLE
Short circuit boolean expressions

### DIFF
--- a/tests/queries/binary_op_short_circuit/in
+++ b/tests/queries/binary_op_short_circuit/in
@@ -1,0 +1,1 @@
+{"field_true": true, "field_false": false}

--- a/tests/queries/binary_op_short_circuit/out
+++ b/tests/queries/binary_op_short_circuit/out
@@ -1,0 +1,1 @@
+{"a": true, "b": false, "c": true, "d": false, "e": true, "f": true, "g": false}

--- a/tests/queries/binary_op_short_circuit/query.trickle
+++ b/tests/queries/binary_op_short_circuit/query.trickle
@@ -1,0 +1,9 @@
+select {
+    "a": true or event.this_field_does_not_exist,
+    "b": false and event.this_field_does_not_exist,
+    "c": false or event.field_true,
+    "d": true and event.field_false,
+    "e": true and event.field_true,
+    "f": true xor false,
+    "g": true xor true
+} from in into out;

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -89,6 +89,7 @@ macro_rules! test_cases {
 }
 
 test_cases!(
+    binary_op_short_circuit,
     default_rule,
     dimensions,
     example_rule,

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -637,6 +637,8 @@ pub enum ImutExpr<'script> {
     List(List<'script>),
     /// Binary operation
     Binary(Box<BinExpr<'script>>),
+    /// Binary operation for booleans
+    BinaryBoolean(Box<BooleanBinExpr<'script>>),
     /// Unary operation
     Unary(Box<UnaryExpr<'script>>),
     /// Patch
@@ -2056,13 +2058,6 @@ impl_expr!(StatePath);
 /// we're forced to make this pub because of lalrpop
 #[derive(Copy, Clone, Debug, PartialEq, Serialize)]
 pub enum BinOpKind {
-    /// we're forced to make this pub because of lalrpop
-    Or,
-    /// we're forced to make this pub because of lalrpop
-    Xor,
-    /// we're forced to make this pub because of lalrpop
-    And,
-
     // NOT IMPLEMENTED /// we're forced to make this pub because of lalrpop
     // BitOr,
     /// we're forced to make this pub because of lalrpop
@@ -2103,6 +2098,18 @@ pub enum BinOpKind {
     Mod,
 }
 
+// BooleanBinOpKind
+/// we're forced to make this pub because of lalrpop
+#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
+pub enum BooleanBinOpKind {
+    /// we're forced to make this pub because of lalrpop
+    Or,
+    /// we're forced to make this pub because of lalrpop
+    Xor,
+    /// we're forced to make this pub because of lalrpop
+    And,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 /// Encapsulates a binary expression form
 pub struct BinExpr<'script> {
@@ -2116,6 +2123,20 @@ pub struct BinExpr<'script> {
     pub rhs: ImutExpr<'script>,
 }
 impl_expr!(BinExpr);
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+/// Encapsulates a binary expression form
+pub struct BooleanBinExpr<'script> {
+    /// Id
+    pub(crate) mid: Box<NodeMeta>,
+    /// The operation kind
+    pub kind: BooleanBinOpKind,
+    /// The Left-hand-side operand
+    pub lhs: ImutExpr<'script>,
+    /// The Right-hand-side operand
+    pub rhs: ImutExpr<'script>,
+}
+impl_expr!(BooleanBinExpr);
 
 /// we're forced to make this pub because of lalrpop
 #[derive(Copy, Clone, Debug, PartialEq, Serialize)]

--- a/tremor-script/src/ast/base_expr.rs
+++ b/tremor-script/src/ast/base_expr.rs
@@ -181,6 +181,7 @@ impl<'script> BaseExpr for ImutExpr<'script> {
             ImutExpr::Unary(e) => e.meta(),
             ImutExpr::Bytes(e) => e.meta(),
             ImutExpr::String(e) => e.meta(),
+            ImutExpr::BinaryBoolean(e) => e.meta(),
         }
     }
 }
@@ -262,6 +263,7 @@ impl<'script> BaseExpr for ImutExprRaw<'script> {
             ImutExprRaw::String(e) => &e.mid,
             ImutExprRaw::Unary(e) => &e.mid,
             ImutExprRaw::Bytes(e) => &e.mid,
+            ImutExprRaw::BinaryBoolean(e) => &e.mid,
         }
     }
 }

--- a/tremor-script/src/ast/raw.rs
+++ b/tremor-script/src/ast/raw.rs
@@ -16,6 +16,7 @@
 // We want to keep the names here
 #![allow(clippy::module_name_repetitions)]
 
+use crate::ast::{BooleanBinExpr, BooleanBinOpKind};
 use crate::{
     ast::{
         base_expr, query, upable::Upable, visitors::ConstFolder, walkers::ExprWalker, ArrayPattern,
@@ -821,6 +822,8 @@ pub enum ImutExprRaw<'script> {
     /// we're forced to make this pub because of lalrpop
     Binary(Box<BinExprRaw<'script>>),
     /// we're forced to make this pub because of lalrpop
+    BinaryBoolean(Box<BooleanBinExprRaw<'script>>),
+    /// we're forced to make this pub because of lalrpop
     Unary(Box<UnaryExprRaw<'script>>),
     /// we're forced to make this pub because of lalrpop
     Literal(LiteralRaw<'script>),
@@ -853,6 +856,7 @@ impl<'script> Upable<'script> for ImutExprRaw<'script> {
                 ImutExpr::Recur(r.up(helper)?)
             }
             ImutExprRaw::Binary(b) => ImutExpr::Binary(Box::new(b.up(helper)?)),
+            ImutExprRaw::BinaryBoolean(b) => ImutExpr::BinaryBoolean(Box::new(b.up(helper)?)),
             ImutExprRaw::Unary(u) => ImutExpr::Unary(Box::new(u.up(helper)?)),
             ImutExprRaw::String(s) => ImutExpr::String(s.up(helper)?),
             ImutExprRaw::Record(r) => ImutExpr::Record(r.up(helper)?),
@@ -1961,6 +1965,27 @@ impl<'script> Upable<'script> for BinExprRaw<'script> {
     type Target = BinExpr<'script>;
     fn up<'registry>(self, helper: &mut Helper<'script, 'registry>) -> Result<Self::Target> {
         Ok(BinExpr {
+            mid: self.mid,
+            kind: self.kind,
+            lhs: self.lhs.up(helper)?,
+            rhs: self.rhs.up(helper)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BooleanBinExprRaw<'script> {
+    pub(crate) kind: BooleanBinOpKind,
+    pub(crate) lhs: ImutExprRaw<'script>,
+    pub(crate) rhs: ImutExprRaw<'script>,
+    pub(crate) mid: Box<NodeMeta>,
+}
+
+impl<'script> Upable<'script> for BooleanBinExprRaw<'script> {
+    type Target = BooleanBinExpr<'script>;
+
+    fn up<'registry>(self, helper: &mut Helper<'script, 'registry>) -> Result<Self::Target> {
+        Ok(BooleanBinExpr {
             mid: self.mid,
             kind: self.kind,
             lhs: self.lhs.up(helper)?,

--- a/tremor-script/src/ast/support.rs
+++ b/tremor-script/src/ast/support.rs
@@ -31,9 +31,6 @@ impl<'script> PartialEq for InvokeAggrFn<'script> {
 impl BinOpKind {
     fn operator_name(self) -> &'static str {
         match self {
-            Self::Or => "or",
-            Self::Xor => "xor",
-            Self::And => "and",
             // not implemented Self::BitOr => "|",
             Self::BitXor => "^",
             Self::BitAnd => "&",

--- a/tremor-script/src/ast/visitors/impls/const_folder.rs
+++ b/tremor-script/src/ast/visitors/impls/const_folder.rs
@@ -124,6 +124,11 @@ impl<'run, 'script: 'run> ImutExprVisitor<'script> for ConstFolder<'run, 'script
                 }
             }
 
+            ImutExpr::BinaryBoolean(b) => {
+                // FIXME: This should check for literals the same way ::Binary does!
+                ImutExpr::BinaryBoolean(b)
+            }
+
             ImutExpr::Unary(b) => {
                 if let UnaryExpr {
                     kind,

--- a/tremor-script/src/ast/visitors/impls/const_folder.rs
+++ b/tremor-script/src/ast/visitors/impls/const_folder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::super::prelude::*;
+use crate::ast::{BooleanBinExpr, BooleanBinOpKind};
 use crate::{
     ast::{base_expr::Ranged, binary::extend_bytes_from_value, NodeMeta},
     errors::{
@@ -125,8 +126,31 @@ impl<'run, 'script: 'run> ImutExprVisitor<'script> for ConstFolder<'run, 'script
             }
 
             ImutExpr::BinaryBoolean(b) => {
-                // FIXME: This should check for literals the same way ::Binary does!
-                ImutExpr::BinaryBoolean(b)
+                if let BooleanBinExpr {
+                    mid,
+                    kind,
+                    lhs: Lit(Literal { value: lhs, .. }),
+                    rhs: Lit(Literal { value: rhs, .. }),
+                } = b.as_ref()
+                {
+                    let lhs = lhs.as_bool();
+                    let rhs = rhs.as_bool();
+
+                    match (kind, lhs, rhs) {
+                        (BooleanBinOpKind::Or, Some(lhs), Some(rhs)) => {
+                            ImutExpr::literal(mid.clone(), Value::from(lhs || rhs))
+                        }
+                        (BooleanBinOpKind::Xor, Some(lhs), Some(rhs)) => {
+                            ImutExpr::literal(mid.clone(), Value::from(lhs ^ rhs))
+                        }
+                        (BooleanBinOpKind::And, Some(lhs), Some(rhs)) => {
+                            ImutExpr::literal(mid.clone(), Value::from(lhs && rhs))
+                        }
+                        _ => ImutExpr::BinaryBoolean(b),
+                    }
+                } else {
+                    ImutExpr::BinaryBoolean(b)
+                }
             }
 
             ImutExpr::Unary(b) => {

--- a/tremor-script/src/ast/visitors/imut_expr.rs
+++ b/tremor-script/src/ast/visitors/imut_expr.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ast::Const;
+use crate::ast::{BooleanBinExpr, Const};
 
 use super::prelude::*;
 use super::VisitRes;
@@ -62,12 +62,27 @@ pub trait Visitor<'script> {
     fn visit_binary(&mut self, _binary: &mut BinExpr<'script>) -> Result<VisitRes> {
         Ok(Walk)
     }
+    /// visit a binary
+    ///
+    /// # Errors
+    /// if the walker function fails
+    fn visit_binary_boolean(&mut self, _binary: &mut BooleanBinExpr<'script>) -> Result<VisitRes> {
+        Ok(Walk)
+    }
 
     /// leave a binary
     ///
     /// # Errors
     /// if the walker function fails
     fn leave_binary(&mut self, _binary: &mut BinExpr<'script>) -> Result<()> {
+        Ok(())
+    }
+
+    /// leave a binary
+    ///
+    /// # Errors
+    /// if the walker function fails
+    fn leave_binary_boolean(&mut self, _binary: &mut BooleanBinExpr<'script>) -> Result<()> {
         Ok(())
     }
 

--- a/tremor-script/src/ast/walkers/imut_expr.rs
+++ b/tremor-script/src/ast/walkers/imut_expr.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ast::Const;
+use crate::ast::{BooleanBinExpr, Const};
 
 use super::super::visitors::prelude::*;
 macro_rules! stop {
@@ -63,6 +63,20 @@ pub trait Walker<'script>: ImutExprVisitor<'script> {
         self.walk_expr(&mut binary.lhs)?;
         self.walk_expr(&mut binary.rhs)?;
         self.leave_binary(binary)
+    }
+
+    /// walk a binary
+    ///
+    /// # Errors
+    /// if the walker function fails
+    fn walk_binary_boolean(&mut self, binary: &mut BooleanBinExpr<'script>) -> Result<()> {
+        stop!(
+            self.visit_binary_boolean(binary),
+            self.leave_binary_boolean(binary)
+        );
+        self.walk_expr(&mut binary.lhs)?;
+        self.walk_expr(&mut binary.rhs)?;
+        self.leave_binary_boolean(binary)
     }
 
     /// walk a unary
@@ -695,6 +709,9 @@ pub trait Walker<'script>: ImutExprVisitor<'script> {
             }
             ImutExpr::Binary(binary) => {
                 self.walk_binary(binary.as_mut())?;
+            }
+            ImutExpr::BinaryBoolean(binary_boolean) => {
+                self.walk_binary_boolean(binary_boolean.as_mut())?;
             }
             ImutExpr::Unary(unary) => {
                 self.walk_unary(unary.as_mut())?;

--- a/tremor-script/src/grammar.lalrpop
+++ b/tremor-script/src/grammar.lalrpop
@@ -16,7 +16,7 @@ use crate::ast::raw::*;
 use crate::ast::deploy::raw::*;
 use crate::ast::query::raw::*;
 use crate::ast::module::*;
-use crate::ast::{BinOpKind, UnaryOpKind, NodeId};
+use crate::ast::{BooleanBinOpKind, BinOpKind, UnaryOpKind, NodeId};
 use crate::lexer::Token;
 use crate::pos::Location;
 use crate::Value;
@@ -592,19 +592,19 @@ ExprImut: ImutExprRaw<'input> = {
 /// Logical or
 OrExprImut: ImutExprRaw<'input> = {
     /// TODO should be OrExprImut?
-    <o:BinOp<BinOr, ExprImut, XorExprImut>> => <>,
+    <o:BooleanBinOp<BinOr, ExprImut, XorExprImut>> => <>,
     XorExprImut => <>,
 }
 
 /// Logical xor
 XorExprImut: ImutExprRaw<'input> = {
-    <o:BinOp<BinXor, XorExprImut, AndExprImut>> => <>,
+    <o:BooleanBinOp<BinXor, XorExprImut, AndExprImut>> => <>,
     AndExprImut => <>,
 }
 
 /// Logical and
 AndExprImut: ImutExprRaw<'input> = {
-    BinOp<BinAnd, AndExprImut, BitOrExprImut> => <>,
+    BooleanBinOp<BinAnd, AndExprImut, BitOrExprImut> => <>,
     BitOrExprImut => <>,
 }
 
@@ -1453,6 +1453,15 @@ BinOp<Op, Current, Next>: ImutExprRaw<'input> = {
         mid: NodeMeta::new_box(start, end)
     })),
 }
+#[inline]
+BooleanBinOp<Op, Current, Next>: ImutExprRaw<'input> = {
+    <start:@L> <lhs:(<Current>)> <op:(<Op>)> @L <rhs:Next> <end:@L> => ImutExprRaw::BinaryBoolean(Box::new(BooleanBinExprRaw {
+        kind: op,
+        lhs: lhs,
+        rhs: rhs,
+        mid: NodeMeta::new_box(start, end)
+    })),
+}
 
 
 BinCmpEq: BinOpKind = {
@@ -1460,14 +1469,14 @@ BinCmpEq: BinOpKind = {
     BinCmp => <>
 }
 
-BinOr: BinOpKind = {
-    "or" => BinOpKind::Or,
+BinOr: BooleanBinOpKind = {
+    "or" => BooleanBinOpKind::Or,
 }
-BinXor: BinOpKind = {
-    "xor" => BinOpKind::Xor,
+BinXor: BooleanBinOpKind = {
+    "xor" => BooleanBinOpKind::Xor,
 }
-BinAnd: BinOpKind = {
-    "and" => BinOpKind::And,
+BinAnd: BooleanBinOpKind = {
+    "and" => BooleanBinOpKind::And,
 }
 // BinBitOr: BinOpKind = {
 //    "|" => BinOpKind::BitOr,

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -368,7 +368,7 @@ where
 {
     // Lazy Heinz doesn't want to write that 10000 times
     // - snot badger - Darach
-    use BinOpKind::{Add, And, BitAnd, BitXor, Eq, Gt, Gte, Lt, Lte, NotEq, Or, Xor};
+    use BinOpKind::{Add, BitAnd, BitXor, Eq, Gt, Gte, Lt, Lte, NotEq};
     use StaticNode::Bool;
     use Value::{Bytes, Static, String};
     match (op, lhs, rhs) {
@@ -380,10 +380,9 @@ where
         (NotEq, l, r) => Ok(static_bool!(!val_eq(l, r))),
 
         // Bool
-        (And | BitAnd, Static(Bool(l)), Static(Bool(r))) => Ok(static_bool!(*l && *r)),
+        (BitAnd, Static(Bool(l)), Static(Bool(r))) => Ok(static_bool!(*l && *r)),
         // error_invalid_bitshift(outer, inner) missing as we don't have it implemented
-        (Or, Static(Bool(l)), Static(Bool(r))) => Ok(static_bool!(*l || *r)),
-        (Xor | BitXor, Static(Bool(l)), Static(Bool(r))) => Ok(static_bool!(*l != *r)),
+        (BitXor, Static(Bool(l)), Static(Bool(r))) => Ok(static_bool!(*l != *r)),
 
         // Binary
         (Gt, Bytes(l), Bytes(r)) => Ok(static_bool!(l > r)),

--- a/tremor-script/src/interpreter.rs
+++ b/tremor-script/src/interpreter.rs
@@ -66,6 +66,8 @@ pub const FALSE: Value<'static> = Value::Static(StaticNode::Bool(false));
 /// constant `null` value
 pub const NULL: Value<'static> = Value::Static(StaticNode::Null);
 
+#[macro_export]
+/// Static boolean `Value` from Rust `bool`
 macro_rules! static_bool {
     ($e:expr) => {
         #[allow(clippy::if_not_else)]


### PR DESCRIPTION
Signed-off-by: Ramona Łuczkiewicz <rluczkiewicz@wayfair.com>

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

* Related Issues: fixes #1794
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


