### PR TITLE
Remove remaining print

### DIFF
--- a/src/connectors/impls/discord/handler.rs
+++ b/src/connectors/impls/discord/handler.rs
@@ -66,7 +66,7 @@ impl EventHandler for Handler {
     // We use the cache_ready event just in case some cache operation is required in whatever use
     // case you have for this.
     async fn cache_ready(&self, ctx: Context, _guilds: Vec<GuildId>) {
-        println!("Cache built successfully!");
+        info!("Cache built successfully!");
 
         if !self.is_loop_running.load(Ordering::Relaxed) {
             // We have to clone the Arc, as it gets moved into the new thread.
@@ -137,7 +137,7 @@ impl EventHandler for Handler {
     }
 
     async fn ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+        info!("{} is connected!", ready.user.name);
     }
 
     async fn typing_start(&self, _ctx: Context, e: TypingStartEvent) {

--- a/tremor-common/.gitignore
+++ b/tremor-common/.gitignore
@@ -1,0 +1,1 @@
+.a.file.that.will.get.deleted

--- a/tremor-common/Cargo.toml
+++ b/tremor-common/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.12.4"
 
 [dependencies]
-async-std = "1"
+async-std = { version = "1", features = ["attributes"] }
 rand = { version = "0.8", features = ["small_rng"] }
 beef = { version = "0.5", features = ["impl_serde"] }
 url = "2.2"


### PR DESCRIPTION
# Pull request

## Description

Remove last `println`'s from non test and non CLI code.

## Related

* Related Issues: fixes #1120

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
-/-