### PR TITLE
Fix invalid scope handling for flow definition default args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+- Fix invalid scope handling for `flow` definition default arguments
 - Fix `elastic` sink not acking events handled successfully if no source is connected.
 - Fix `kafka_consumer` possibly committing earlier offsets, thus replaying events that have already been handled.
 - Fix off-by-one error in `kafka_consumer` committing offsets, thus replaying the last committed event.

--- a/tests/flows.rs
+++ b/tests/flows.rs
@@ -80,6 +80,7 @@ test_cases!(
     pipeline_args,
     pipeline_with,
     // INSERT
+    consts_as_default_args,
     args_in_create,
     chained_pipelines,
 );

--- a/tests/flows/consts_as_default_args/consts.troy
+++ b/tests/flows/consts_as_default_args/consts.troy
@@ -1,0 +1,1 @@
+const default_interval = 1;

--- a/tests/flows/consts_as_default_args/flow.troy
+++ b/tests/flows/consts_as_default_args/flow.troy
@@ -1,0 +1,55 @@
+use consts;
+
+define flow test
+args
+  interval = consts::default_interval
+flow
+  use other_consts;
+
+  define connector metronome from metronome
+  args
+    interval = other_consts::other_interval
+  with
+    config = {
+      "interval": args.interval
+    }
+  end;
+  define connector exit from exit;
+  
+
+  define pipeline identity
+  args
+    interval = other_consts::other_interval
+  pipeline
+    use inner_consts;
+
+    define script with_args
+    args
+      interval = inner_consts::inner_interval
+    script
+      args.interval
+    end;
+    create script with_args
+    with
+      interval = args.interval
+    end;
+
+    select event from in into with_args;
+    select event from with_args into out;
+  end;
+  create connector metronome
+  with
+    interval = args.interval
+  end;
+  create connector exit;
+
+  create pipeline identity
+  with
+    interval = args.interval
+  end;
+  
+  connect /connector/metronome to /pipeline/identity;
+  connect /pipeline/identity to /connector/exit;
+end;
+
+deploy flow test

--- a/tests/flows/consts_as_default_args/inner_consts.troy
+++ b/tests/flows/consts_as_default_args/inner_consts.troy
@@ -1,0 +1,1 @@
+const inner_interval = 3;

--- a/tests/flows/consts_as_default_args/other_consts.troy
+++ b/tests/flows/consts_as_default_args/other_consts.troy
@@ -1,0 +1,1 @@
+const other_interval = 2;

--- a/tremor-script/src/ast/deploy/raw.rs
+++ b/tremor-script/src/ast/deploy/raw.rs
@@ -344,8 +344,9 @@ impl<'script> Upable<'script> for FlowDefinitionRaw<'script> {
         let docs = self
             .doc
             .map(|d| d.iter().map(|l| l.trim()).collect::<Vec<_>>().join("\n"));
-        let params = self.params.up(helper)?;
         helper.leave_scope()?;
+        // we need to evaluate args in the outer scope
+        let params = self.params.up(helper)?;
 
         let flow_defn = FlowDefinition {
             mid,


### PR DESCRIPTION
# Pull request

## Description

Default arguments expressions have been wrongfully evaluated in the inner scope of the definition. This PR correctly evaluates them on the outer scope.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
Doesn't apply, this is only a compile time change.