### PR TITLE
Enforce "no mod.rs files" via clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 // TODO this is needed due to a false positive in clippy
 // https://github.com/rust-lang/rust/issues/83125

--- a/tremor-api/src/lib.rs
+++ b/tremor-api/src/lib.rs
@@ -21,7 +21,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 #![allow(clippy::missing_errors_doc)]
 

--- a/tremor-common/src/lib.rs
+++ b/tremor-common/src/lib.rs
@@ -19,7 +19,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 
 /// functions for async related code

--- a/tremor-influx/src/lib.rs
+++ b/tremor-influx/src/lib.rs
@@ -36,7 +36,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 // TODO: remove this when https://github.com/rust-lang/rust-clippy/issues/9076 is fixed
 #![allow(clippy::trait_duplication_in_bounds)]

--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -21,7 +21,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 
 #[macro_use]

--- a/tremor-script/src/lib.rs
+++ b/tremor-script/src/lib.rs
@@ -20,7 +20,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 // TODO: remove this when https://github.com/rust-lang/rust-clippy/issues/9076 is fixed
 #![allow(clippy::trait_duplication_in_bounds)]

--- a/tremor-value/src/lib.rs
+++ b/tremor-value/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::mod_module_files
 )]
 #![deny(missing_docs)]
 // We might want to revisit inline_always


### PR DESCRIPTION
# Pull request

## Description

Back in spring when I was working on the [ClickHouse sink][1], I had [an interesting comment][2] stating that Tremor prefers using `mod_name.rs` files instead of `mod_name/mod.rs` files.

(*In my opinion this is bad, but let's not discuss this here.*)

Once my work got merged, I started wondering if we could statically check this and make `clippy` emit an error if it sees `mod.rs` files. Turns out there's a [`mod_module_files`][3] we can `deny`. That's basically what this commit does.

The resulting compilation error is just as friendly as it needs to be:

```none
$ cargo clippy
    Checking tremor-runtime v0.12.4 (/home/ssha/git/tremor/tremor-runtime)
error: `mod.rs` files are not allowed, found `src/should_not_compile/mod.rs`
  --> src/should_not_compile/mod.rs:0:1
   |
   |
note: the lint level is defined here
  --> src/lib.rs:25:5
   |
25 |     clippy::mod_module_files
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   = help: move `src/should_not_compile/mod.rs` to `src/should_not_compile.rs`
```

I `deny`-ed this on the following crates:
  - `tremor-runtime`,
  - `tremor-api`,
  - `tremo-common`,
  - `tremor-influx`,
  - `tremor-pipeline`,
  - `tremor-script`,
  - `tremor-value`.

Feel free to request the addition of this lint elsewhere. I may have forgotten some crates :).

It turns out y'all did a great job at maintaining this at each code review, as I had no compilation error once all the lint were added.

Thank you for your work!

[1]: https://github.com/tremor-rs/tremor-runtime/pull/1538
[2]: https://github.com/tremor-rs/tremor-runtime/pull/1538#discussion_r904836976
[3]: https://rust-lang.github.io/rust-clippy/master/index.html#self_named_module_files

## Related

[#1538 (comment)](https://github.com/tremor-rs/tremor-runtime/pull/1538#discussion_r904836976)

## Checklist

* [x] The RFC, if required, has been submitted and approved (N/A)
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs (N/A)
* [x] The code is tested (N/A)
* [x] Use of unsafe code is reasoned about in a comment (N/A)
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior (N/A)
* [x] The performance impact of the change is measured (see below) (N/A)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


This should have no impact on the produced binary. I don't expect any performance improvement or regression. Similarly, I don't expect any change in coverage (other than regular flakiness).