### PR TITLE
Remove unused dep mapr  fixes #1925

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,16 +3047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mapr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a28a55dbc005b2f6f123c4058933d57add373d362f6fd3a76aab4fe6973500"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5789,7 +5779,6 @@ dependencies = [
  "libflate",
  "log",
  "lz4",
- "mapr",
  "matches",
  "memchr",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,6 @@ url = "2.2"
 value-trait = "0.4"
 zstd = "0.11"
 
-mapr = "0.8"
-
 # blaster / blackhole
 hdrhistogram = "7"
 xz2 = "0.1"


### PR DESCRIPTION
# Pull request

## Description

remove unused dependency `mapr`

## Related


* Related Issues: fixes #1925 


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-