### PR TITLE
Add back allow-non-simd feature for tremor-script

### DIFF
--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -74,5 +74,9 @@ proptest = "1.0"
 tempfile = "3"
 
 [features]
+# this is required for the erlang EQC tests of the language
 erlang-float-testing = []
+# This is required for the language server to prevent unbounded growth of the area
 arena-delete = []
+# This is required for the language server as w3e want to allow the use of it without platfor specific flags
+allow-non-simd = ["simd-json/allow-non-simd"]


### PR DESCRIPTION
# Pull request

## Description

Add back `allow-non-simd` for tremor-script

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-


