### PR TITLE
Fix systemd startup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix pipeline DAG creation when pipeline has unused nodes (e.g. a stream, operator or script)
 - Fix possible hangs in `http_client`, `kv` and `dns` connectors when no pipelines is connected to their `out` port
+- Fix systemd startup script
 
 ## [0.13.0-rc.3]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,7 +39,7 @@ else
 
 
     # Load *.troy files
-    TROYS=$(find /etc/tremor/config/ -not -path '*/.*' -type f,l -name '*.troy' -print 2>/dev/null | sort)
+    TROYS=$(find /etc/tremor/config/ -not -path '*/.*' \( -type f -o -type l \) -name '*.troy' -print 2>/dev/null | sort)
     [ ! -z "$TROYS" ] && ARTEFACTS="$ARTEFACTS $TROYS"
 
     ARGS="--logger-config ${LOGGER_FILE} server run"

--- a/packaging/distribution/usr/share/tremor/tremor.sh
+++ b/packaging/distribution/usr/share/tremor/tremor.sh
@@ -33,7 +33,7 @@ else
 
 
     # Load *.troy files
-    TROYS=$(find /etc/tremor/config/ -not -path '*/.*' -type f,l -name '*.troy' -print 2>/dev/null | sort)
+    TROYS=$(find /etc/tremor/config/ -not -path '*/.*' \( -type f -o -type l \) -name '*.troy' -print 2>/dev/null | sort)
     [ ! -z "$TROYS" ] && ARTEFACTS="$ARTEFACTS $TROYS"
 
     ARGS="--logger-config ${LOGGER_FILE} server run"

--- a/packaging/distribution/usr/share/tremor/tremor.sh
+++ b/packaging/distribution/usr/share/tremor/tremor.sh
@@ -45,4 +45,4 @@ else
 fi
 
 # IMPORTANT: do not quote ARGS, no matter what shellcheck tells you
-exec /usr/bin/tini /tremor -- ${ARGS}
+exec /usr/bin/tremor ${ARGS}


### PR DESCRIPTION
It did require tini (copy-paste from docker entrypoint)

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related


## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


