### PR TITLE
Split too large requests to GBQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixes
+- The Google BigQuery connector will now split requests that are longer than the allowed limit (10MB)
+
 ## [0.13.0-rc.4]
 
 ### Fixes

--- a/src/connectors/impls/gbq/writer.rs
+++ b/src/connectors/impls/gbq/writer.rs
@@ -26,8 +26,15 @@ pub(crate) struct Config {
     pub table_id: String,
     pub connect_timeout: u64,
     pub request_timeout: u64,
+    #[serde(default = "default_request_size_limit")]
+    pub request_size_limit: usize,
 }
 impl ConfigImpl for Config {}
+
+fn default_request_size_limit() -> usize {
+    // 10MB
+    10 * 1024 * 1024
+}
 
 #[derive(Debug, Default)]
 pub(crate) struct Builder {}
@@ -88,6 +95,7 @@ mod tests {
                 table_id: "test".into(),
                 connect_timeout: 1,
                 request_timeout: 1,
+                request_size_limit: 10 * 1024 * 1024,
             },
         };
 

--- a/src/connectors/impls/gbq/writer/sink.rs
+++ b/src/connectors/impls/gbq/writer/sink.rs
@@ -388,7 +388,7 @@ where
         request_data.push(serialized_rows);
 
         if request_data.len() > 1 {
-            warn!("The batch is too large to be sent in a single request, splitting it into {} requests. Consider lowering the batch size.", request_data.len());
+            warn!("{ctx} The batch is too large to be sent in a single request, splitting it into {} requests. Consider lowering the batch size.", request_data.len());
         }
 
         for serialized_rows in request_data {

--- a/src/connectors/impls/gbq/writer/sink.rs
+++ b/src/connectors/impls/gbq/writer/sink.rs
@@ -407,7 +407,11 @@ where
                 };
             }
 
-            match request.rows.as_mut().ok_or(ErrorKind::GbqSinkFailed("No rows in request"))? {
+            match request
+                .rows
+                .as_mut()
+                .ok_or(ErrorKind::GbqSinkFailed("No rows in request"))?
+            {
                 Rows::ProtoRows(ref mut x) => x
                     .rows
                     .as_mut()


### PR DESCRIPTION
Signed-off-by: Ramona Łuczkiewicz <rluczkiewicz@wayfair.com>

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/244)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


