### PR TITLE
Support for writing to multiple tables in GBQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixes
 - The Google BigQuery connector will now split requests that are longer than the allowed limit (10MB)
 
+### New Features
+- The GoogleBigQuery connector now accepts `table_id` metadata, to allow setting target table per event.
+
 ## [0.13.0-rc.4]
 
 ### Fixes

--- a/src/connectors/impls/gbq/writer.rs
+++ b/src/connectors/impls/gbq/writer.rs
@@ -50,7 +50,7 @@ impl Connector for Gbq {
         sink_context: SinkContext,
         builder: SinkManagerBuilder,
     ) -> Result<Option<SinkAddr>> {
-        let sink = GbqSink::<GouthTokenProvider, _>::new(
+        let sink = GbqSink::<GouthTokenProvider, _, _>::new(
             self.config.clone(),
             Box::new(TonicChannelFactory),
         );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -346,6 +346,10 @@ error_chain! {
             description("GBQ Sink failed")
                 display("GBQ Sink failed: {}", msg)
         }
+        GbqSchemaNotProvided(table: String) {
+            description("GBQ Schema not provided")
+                display("GBQ Schema not provided for table {}", table)
+        }
         ClientNotAvailable(name: &'static str, msg: &'static str) {
             description("Client not available")
                 display("{} client not available: {}", name, msg)


### PR DESCRIPTION
Signed-off-by: Ramona Łuczkiewicz <rluczkiewicz@wayfair.com>

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/250)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


