### PR TITLE
Select window timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixes
+
+- Fix windows based on `interval` not sending the correct event id when timing out
+
 ## [0.13.0-rc.5]
 ### Fixes
 - The Google BigQuery connector will now split requests that are longer than the allowed limit (10MB)

--- a/src/connectors/tests/mod.rs
+++ b/src/connectors/tests/mod.rs
@@ -377,9 +377,8 @@ impl TestPipeline {
         let task_rx = rx_mgmt.clone();
         task::spawn(async move {
             while let Ok(msg) = task_rx.recv().await {
-                match dbg!(msg) {
+                match msg {
                     pipeline::MgmtMsg::Stop => {
-                        dbg!();
                         break;
                     }
                     pipeline::MgmtMsg::ConnectInput { tx, .. } => {

--- a/src/system.rs
+++ b/src/system.rs
@@ -92,6 +92,11 @@ impl KillSwitch {
     pub(crate) fn dummy() -> Self {
         KillSwitch(bounded(1).0)
     }
+
+    #[cfg(test)]
+    pub(crate) fn new(sender: Sender<flow_supervisor::Msg>) -> Self {
+        KillSwitch(sender)
+    }
 }
 
 /// Tremor runtime

--- a/src/system/flow_supervisor.rs
+++ b/src/system/flow_supervisor.rs
@@ -30,6 +30,7 @@ use tremor_script::ast::DeployFlow;
 pub(crate) type Channel = Sender<Msg>;
 
 /// This is control plane
+#[derive(Debug)]
 pub(crate) enum Msg {
     /// deploy a Flow
     StartDeploy {

--- a/tremor-pipeline/src/lib.rs
+++ b/tremor-pipeline/src/lib.rs
@@ -831,6 +831,12 @@ impl EventIdGenerator {
     }
 
     #[must_use]
+    /// create a new generator for the `Operator` identified by `operator_id` with `stream_id`
+    pub fn for_operator_with_stream(operator_id: OperatorId, stream_id: u64) -> Self {
+        Self(operator_id.id(), stream_id, 0)
+    }
+
+    #[must_use]
     /// create a new generator using the given source and stream id
     pub fn new_with_stream(source_id: SourceId, stream_id: u64) -> Self {
         Self(source_id.id(), stream_id, 0)

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -248,7 +248,7 @@ pub struct Consts<'script> {
 }
 
 impl<'script> Consts<'script> {
-    /// Generates runtime borrow of the costs
+    /// Generates runtime borrow of the consts
     #[must_use]
     pub fn run(&self) -> RunConsts<'_, 'script> {
         RunConsts {


### PR DESCRIPTION
# Pull request

## Description

Fix windows based on `interval` that time out (interval elapsed) not sending the correct event id.
In effect the events that are accumulated in the window are not tracked and cannot be acked or failed.
This might show up as consumer lag in kafka if `kafka_consumer` is used as an upstream connector.

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
No significant diff between main and this branch on the benchmarks we have.

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


