### PR TITLE
Improve performance of array::flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ## New Features
+
 * implement script enhancement RFC (initial state and port based scripts)
 * Improve dogstatsd performance
 

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -99,7 +99,15 @@ test::suite({
     }),
     test::test({
       "name": "array flatten 1",
-      "test": test::assert("array flatten 1", array::flatten([["a","b"],[1,2]]), [ "a", "b", 1, 2] )
+      "test": test::assert("array flatten 1", array::flatten([["a","b"],[1,2], [[3, 4, null, {}], [[5, 6], [[7, 8], [], 9]]]]), [ "a", "b", 1, 2, 3, 4, null, {}, 5, 6, 7, 8, 9] )
+    }),
+    test::test({
+      "name": "array flatten 2",
+      "test": test::assert("array flatten 2", array::flatten([]), [] )
+    }),
+    test::test({
+      "name": "array flatten 3",
+      "test": test::assert("array flatten 2", array::flatten([false, [], [[], [[[]], [[], [null]]]]], true), [false, null, true] )
     }),
     test::test({
       "name": "array coalesce 1",

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -80,3 +80,7 @@ erlang-float-testing = []
 arena-delete = []
 # This is required for the language server as w3e want to allow the use of it without platfor specific flags
 allow-non-simd = ["simd-json/allow-non-simd"]
+
+[[bench]]
+name = "array_flatten"
+harness = false

--- a/tremor-script/benches/array_flatten.rs
+++ b/tremor-script/benches/array_flatten.rs
@@ -1,0 +1,106 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use simd_json::ValueAccess;
+use tremor_script::ast::ImutExpr;
+use tremor_script::interpreter::{Env, LocalStack};
+
+use tremor_script::module::Manager;
+use tremor_script::prelude::ExecOpts;
+use tremor_script::Value;
+
+fn do_array_flatten<'script>(
+    bencher: &mut Bencher,
+    invoke_event: &(ImutExpr<'script>, Value<'script>),
+) {
+    let (invoke, event) = invoke_event;
+    let opts = ExecOpts {
+        result_needed: true,
+        aggr: tremor_script::AggrType::Tick,
+    };
+    let env = Env::default();
+    let local_stack = LocalStack::default();
+    bencher.iter(|| {
+        invoke
+            .run(
+                opts,
+                &env,
+                event,
+                &Value::const_null(),
+                &Value::const_null(),
+                &local_stack,
+            )
+            .expect("Expected array::flatten call to work");
+    });
+}
+
+fn array_flatten(c: &mut Criterion) {
+    let registry = tremor_script::registry();
+
+    // add the std lib dir to the PATH
+    let mut cargo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    cargo_dir = cargo_dir.canonicalize().unwrap();
+    if !cargo_dir.to_string_lossy().contains("tremor-script") {
+        cargo_dir.push("tremor-script");
+    }
+    cargo_dir.push("lib");
+    Manager::add_path(&cargo_dir.to_string_lossy()).unwrap();
+
+    let inputs: Vec<(&'static str, Value)> = vec![
+        (
+            "deeply nested",
+            tremor_script::literal!([
+                "1", "2", ["3", ["4"]], [[["5", "6"], ["7", {"foo": "bar"}, ["8", "9", "10", "11", "12", "13"]]]]
+            ]),
+        ),
+        (
+            "flat",
+            tremor_script::literal!([
+                "1", "2", ["3", "4", "5", "6"], ["7", {"foo": "bar"}, "8", "9"], ["10"], ["11", "12"], "13"
+            ]),
+        ),
+        ("one", tremor_script::literal!([["1", "2", "3"]])),
+        ("baseline", tremor_script::literal!([])),
+    ];
+    let mut group = c.benchmark_group("array::flatten");
+    for input in inputs {
+        group.throughput(Throughput::Elements(
+            input.as_array().map(Vec::len).unwrap_or_default() as u64,
+        ));
+
+        let mut script = tremor_script::script::Script::parse(
+            "use std::array; array::flatten(event)",
+            &registry,
+        )
+        .expect("Invalid script");
+        let first_expr = script.script.exprs.remove(0);
+        let invoke = first_expr.as_invoke().expect("No invoke");
+        let expr = ImutExpr::Invoke1(invoke.clone());
+        let input = (expr, input);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(&input.1),
+            &input,
+            do_array_flatten,
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, array_flatten);
+criterion_main!(benches);

--- a/tremor-script/src/ast/node_id.rs
+++ b/tremor-script/src/ast/node_id.rs
@@ -46,7 +46,7 @@ impl<'script> From<IdentRaw<'script>> for NodeId {
 impl NodeId {
     /// Create a new `NodeId` from an ID and Module list.
     #[must_use]
-    pub fn new<T: ToString>(id: &T, module: &[String]) -> Self {
+    pub fn new<T: ToString + ?Sized>(id: &T, module: &[String]) -> Self {
         Self {
             id: id.to_string(),
             module: module.to_vec(),

--- a/tremor-script/src/std_lib/array.rs
+++ b/tremor-script/src/std_lib/array.rs
@@ -102,13 +102,17 @@ pub fn load(registry: &mut Registry) {
         }));
 }
 
-//TODO this is not very nice
-fn flatten_value<'event>(v: &Value<'event>) -> Vec<Value<'event>> {
-    if let Some(a) = v.as_array() {
-        a.iter().flat_map(flatten_value).collect()
-    } else {
-        vec![v.clone()]
+fn flatten_iter<'event, 'borrow>(
+    v: &'borrow Value<'event>,
+) -> Box<dyn Iterator<Item = &'borrow Value<'event>> + 'borrow> {
+    match v.array_iter() {
+        Some(iter) => Box::new(iter.flat_map(flatten_iter)),
+        None => Box::new(std::iter::once(v)),
     }
+}
+
+pub fn flatten_value<'event>(v: &Value<'event>) -> Vec<Value<'event>> {
+    flatten_iter(v).cloned().collect()
 }
 
 #[cfg(test)]

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -20,6 +20,9 @@ mod serialize;
 /// a static value newtype workaround for rust quirks
 pub mod r#static;
 
+/// Iterator impls for Value
+pub mod iter;
+
 use crate::{Error, Result};
 use beef::Cow;
 use halfbrown::HashMap;

--- a/tremor-value/src/value/iter.rs
+++ b/tremor-value/src/value/iter.rs
@@ -1,0 +1,194 @@
+// Copyright 2022, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Value;
+use value_trait::ValueAccess;
+
+/// Iterator over value references
+pub struct ValueIter<'value, 'borrow>(Box<dyn Iterator<Item = &'borrow Value<'value>> + 'borrow>)
+where
+    'value: 'borrow;
+
+impl<'value, 'borrow> Iterator for ValueIter<'value, 'borrow> {
+    type Item = &'borrow Value<'value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.0.count()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.0.last()
+    }
+}
+
+/// Iterator over mutable references of values
+pub struct MutValueIter<'value, 'borrow>(
+    Box<dyn Iterator<Item = &'borrow mut Value<'value>> + 'borrow>,
+)
+where
+    'value: 'borrow;
+
+impl<'value, 'borrow> Iterator for MutValueIter<'value, 'borrow> {
+    type Item = &'borrow mut Value<'value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.0.count()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.0.last()
+    }
+}
+
+impl<'value> Value<'value> {
+    /// Return an iterator over array values.
+    /// For non-arrays, returns `None`.
+    pub fn array_iter<'borrow>(
+        &'borrow self,
+    ) -> Option<impl Iterator<Item = &'borrow Value<'value>>> {
+        if let Some(a) = self.as_array() {
+            Some(a.iter())
+        } else {
+            None
+        }
+    }
+}
+
+impl<'value> IntoIterator for Value<'value> {
+    type Item = Value<'value>;
+
+    type IntoIter = <Vec<Value<'value>> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Value::Array(vec) => vec.into_iter(),
+            _ => vec![self].into_iter(),
+        }
+    }
+}
+
+impl<'value, 'borrow> IntoIterator for &'borrow Value<'value> {
+    type Item = &'borrow Value<'value>;
+
+    type IntoIter = ValueIter<'value, 'borrow>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        if let Some(a) = self.as_array() {
+            ValueIter(Box::new(a.iter()))
+        } else {
+            ValueIter(Box::new(std::iter::once(self)))
+        }
+    }
+}
+
+impl<'value, 'borrow> IntoIterator for &'borrow mut Value<'value> {
+    type Item = &'borrow mut Value<'value>;
+
+    type IntoIter = MutValueIter<'value, 'borrow>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Value::Array(vec) => MutValueIter(Box::new(vec.iter_mut())),
+            s => MutValueIter(Box::new(std::iter::once(s))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use simd_json::{Value, ValueAccess};
+
+    use crate::literal;
+
+    #[test]
+    fn value_iter() {
+        let value = literal!(true);
+        assert!(value.array_iter().is_none());
+        assert!(literal!("").array_iter().is_none());
+        assert!(literal!(14.6789).array_iter().is_none());
+        assert!(literal!({}).array_iter().is_none());
+
+        let empty = literal!([]);
+        let mut iter = empty
+            .array_iter()
+            .expect("Expect an iter for an empty array");
+        assert!(iter.next().is_none());
+
+        let array = literal!([{}, null, [1, 2.5, true, "string", null], 1]);
+        let mut iter = array.array_iter().expect("Expect an iter for array value");
+        assert_eq!(Some(&literal!({})), iter.next());
+        assert_eq!(Some(&literal!(null)), iter.next());
+        assert_eq!(Some(&literal!([1, 2.5, true, "string", null])), iter.next());
+        assert_eq!(Some(&literal!(1)), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn value_into_iter() {
+        let mut value = literal!([true]);
+        for elem in &value {
+            assert_eq!(Some(true), elem.as_bool());
+        }
+        for elem in &mut value {
+            assert_eq!(Some(true), elem.as_bool());
+        }
+        for elem in value {
+            assert_eq!(Some(true), elem.as_bool());
+        }
+
+        let mut non_array = literal!({});
+        for elem in &non_array {
+            assert!(elem.is_object());
+            assert_eq!(0, elem.as_object().map(|o| o.len()).unwrap_or(1000))
+        }
+
+        for elem in &mut non_array {
+            assert!(elem.is_object());
+            assert_eq!(0, elem.as_object().map(|o| o.len()).unwrap_or(1000))
+        }
+
+        for elem in non_array {
+            assert!(elem.is_object());
+            assert_eq!(0, elem.as_object().map(|o| o.len()).unwrap_or(1000))
+        }
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

Improve performance of `array::flatten` by using iterators for recursing. This gives a performance bump of roughly 30% (depending on the array length).

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
Running the benchmark against main and this branch showed a rough 30% performance increase on my machine.

