### PR TITLE
implement new `std::datetime` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+* Added `std::datetime` library for parsing, formatting and working with datetimes
+
 ## [0.13.0-rc.7]
 
 ### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
- "chrono-tz-build",
+ "chrono-tz-build 0.0.3",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87b30366b6766751277791b473b674f3bf7fb75696841c784a3eb7e7fbf44ee"
+dependencies = [
+ "chrono",
+ "chrono-tz-build 0.1.0",
  "phf",
 ]
 
@@ -1171,6 +1182,17 @@ name = "chrono-tz-build"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -1310,7 +1332,7 @@ dependencies = [
  "async-std",
  "byteorder",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.6.3",
  "clickhouse-rs-cityhash-sys",
  "combine",
  "crossbeam",
@@ -5901,7 +5923,7 @@ dependencies = [
  "byteorder",
  "bytes 1.2.1",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.6.3",
  "clickhouse-rs",
  "cron",
  "csv",
@@ -5996,6 +6018,7 @@ dependencies = [
  "beef",
  "byteorder",
  "chrono",
+ "chrono-tz 0.8.0",
  "cidr-utils",
  "codespan",
  "criterion",
@@ -6029,6 +6052,7 @@ dependencies = [
  "strip-ansi-escapes",
  "tempfile",
  "termcolor",
+ "test-case",
  "tremor-common",
  "tremor-influx",
  "tremor-kv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ bimap = { version = "0.6", features = ["serde"] }
 byteorder = "1"
 bytes = "1.2"
 chrono = "0.4"
+# we have a dep on chrono-tz 0.8 in tremor-script
+# clickhouse-rs needs an upgrade to its chrono-tz dependency...
 clickhouse-chrono-tz = { version = "0.6", package = "chrono-tz" }
 
 # Once a new version of clickhouse-rs is released, we can stop using a git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ bimap = { version = "0.6", features = ["serde"] }
 byteorder = "1"
 bytes = "1.2"
 chrono = "0.4"
-chrono-tz = "0.6"
+clickhouse-chrono-tz = { version = "0.6", package = "chrono-tz" }
 
 # Once a new version of clickhouse-rs is released, we can stop using a git
 # repository as a dependency. The declaration can then be replaced with the

--- a/src/connectors/impls/clickhouse.rs
+++ b/src/connectors/impls/clickhouse.rs
@@ -319,16 +319,16 @@ impl From<&DummySqlType> for &'static SqlType {
             DummySqlType::Uuid => SqlType::Uuid,
             DummySqlType::DateTime => SqlType::DateTime(DateTimeType::DateTime32),
             DummySqlType::DateTime64Secs => {
-                SqlType::DateTime(DateTimeType::DateTime64(0, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(0, clickhouse_chrono_tz::Tz::UTC))
             }
             DummySqlType::DateTime64Millis => {
-                SqlType::DateTime(DateTimeType::DateTime64(3, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(3, clickhouse_chrono_tz::Tz::UTC))
             }
             DummySqlType::DateTime64Micros => {
-                SqlType::DateTime(DateTimeType::DateTime64(6, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(6, clickhouse_chrono_tz::Tz::UTC))
             }
             DummySqlType::DateTime64Nanos => {
-                SqlType::DateTime(DateTimeType::DateTime64(9, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(9, clickhouse_chrono_tz::Tz::UTC))
             }
         };
 
@@ -417,7 +417,7 @@ mod tests {
     }
 
     mod dummy_sql_type_into_sql_type {
-        use chrono_tz::Tz::UTC;
+        use clickhouse_chrono_tz::Tz::UTC;
 
         use super::*;
 

--- a/src/connectors/impls/clickhouse/conversion.rs
+++ b/src/connectors/impls/clickhouse/conversion.rs
@@ -18,7 +18,7 @@ use std::{
     sync::Arc,
 };
 
-use chrono_tz::Tz;
+use clickhouse_chrono_tz::Tz;
 pub(super) use clickhouse_rs::types::Value as CValue;
 use either::Either;
 use simd_json::{Value, ValueAccess};

--- a/src/connectors/tests/clickhouse/more_complex_test.rs
+++ b/src/connectors/tests/clickhouse/more_complex_test.rs
@@ -50,7 +50,7 @@ use std::{
 };
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use chrono_tz::Tz;
+use clickhouse_chrono_tz::Tz;
 use clickhouse_rs::Pool;
 use testcontainers::{clients, core::Port, images::generic::GenericImage, RunnableImage};
 use tremor_common::ports::IN;

--- a/tremor-cli/src/test/unit.rs
+++ b/tremor-cli/src/test/unit.rs
@@ -93,8 +93,16 @@ fn eval_suite_tests(
 
     let ll = suite_spec.exprs.len();
     for (idx, item) in suite_spec.exprs.iter().enumerate() {
-        if let ImutExpr::Invoke1(Invoke { node_id, args, .. }) = item {
-            if node_id.module() != ["test"] || node_id.id() != "test" {
+        if let ImutExpr::Invoke1(Invoke {
+            node_id,
+            args,
+            invocable,
+            ..
+        }) = item
+        {
+            if (node_id.module() != ["test"] || node_id.id() != "test")
+                && invocable.name() == "test"
+            {
                 continue;
             }
             let spec = args
@@ -239,7 +247,9 @@ pub(crate) fn run_suite(
 
                 let Invoke { node_id, args, .. } = expr;
 
-                if node_id.module() == ["test"] || node_id.id() == "test" {
+                if (node_id.module() == ["test"] || node_id.id() == "test")
+                    && expr.invocable.name() == "suite"
+                {
                     // A Test suite
                     let spec = args
                         .first()

--- a/tremor-cli/src/test/unit.rs
+++ b/tremor-cli/src/test/unit.rs
@@ -81,6 +81,7 @@ fn eval(expr: &ImutExpr, env: &Env, local: &LocalStack) -> Result<Value<'static>
         .into_static())
 }
 
+#[allow(clippy::too_many_lines)]
 fn eval_suite_tests(
     env: &Env,
     local: &LocalStack,

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -806,7 +806,7 @@ test::suite({
     }),
     test::test({
       "name": "parse",
-      "test": test::assert("datetime::parse", datetime::parse("2022-11-09 14:46:11.499274824+01:00", datetime::formats::RFC3339), 1668001571499274824)
+      "test": test::assert("datetime::parse", datetime::parse("2022-11-09T14:46:11.499274824+01:00", datetime::formats::RFC3339), 1668001571499274824)
     }),
     test::test({
       "name": "year",

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -778,7 +778,7 @@ test::suite({
     }),
     test::test({
       "name": "rfc3339 Z",
-      "test": test::assert("datetime::rfc3339 Z", datetime::rfc3339(1_559_655_782_000_000_000), "2019-06-04T13:43:02Z")
+      "test": test::assert("datetime::rfc3339 Z", datetime::rfc3339(1_559_655_782_000_000_000), "2019-06-04T13:43:02+00:00")
     }),
     test::test({
       "name": "format timestamp",
@@ -822,11 +822,11 @@ test::suite({
     }),
     test::test({
       "name": "day_of_month",
-      "test": test::assert("datetime::day_of_month", datetime::day_of_month(nanos::from_days(40)), 9)
+      "test": test::assert("datetime::day_of_month", datetime::day_of_month(nanos::from_days(40)), 10)
     }),
     test::test({
       "name": "day_of_year",
-      "test": test::assert("datetime::day_of_year", datetime::day_of_year(nanos::from_days(40)), 40)
+      "test": test::assert("datetime::day_of_year", datetime::day_of_year(nanos::from_days(40)), 41)
     }),
     test::test({
       "name": "hour",
@@ -842,15 +842,15 @@ test::suite({
     }),
     test::test({
       "name": "subsecond_millis",
-      "test": test::assert("datetime::subsecond_millis", datetime::subsecond_millis(1668001571499274824), 0)
+      "test": test::assert("datetime::subsecond_millis", datetime::subsecond_millis(1668001571499274824), 499)
     }),
     test::test({
       "name": "subsecond_micros",
-      "test": test::assert("datetime::subsecond_micros", datetime::subsecond_micros(1668001571499274824), 0)
+      "test": test::assert("datetime::subsecond_micros", datetime::subsecond_micros(1668001571499274824), 499274)
     }),
     test::test({
       "name": "subsecond_nanos",
-      "test": test::assert("datetime::subsecond_nanos", datetime::subsecond_nanos(1668001571499274824), 0)
+      "test": test::assert("datetime::subsecond_nanos", datetime::subsecond_nanos(1668001571499274824), 499274824)
     }),
   ]
 });

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -1,6 +1,7 @@
 use std::array;
 use std::base64;
 use std::binary;
+use std::datetime;
 use std::float;
 use std::integer;
 use std::json;
@@ -731,6 +732,125 @@ test::suite({
     test::test({
       "name": "from_micros",
       "test": test::assert("time::nanos::from_micros", nanos::to_micros(nanos::from_micros(42)), 42)
+    }),
+    test::test({
+      "name": "truncate_micros",
+      "test": test::assert("time::nanos::truncate_micros", nanos::truncate_micros(9_999), 9_000)
+    }),
+    test::test({
+      "name": "truncate_millis",
+      "test": test::assert("time::nanos::truncate_millis", nanos::truncate_millis(9_999_999), 9_000_000)
+    }),
+    test::test({
+      "name": "truncate_seconds",
+      "test": test::assert("time::nanos::truncate_seconds", nanos::truncate_seconds(9_999_999_999), 9_000_000_000)
+    }),
+    test::test({
+      "name": "truncate_minutes",
+      "test": test::assert("time::nanos::truncate_minutes", nanos::truncate_minutes(69_999_999_999), 60_000_000_000)
+    }),
+    test::test({
+      "name": "truncate_hours",
+      "test": test::assert("time::nanos::truncate_hours", nanos::truncate_hours(3_699_999_999_999), 3_600_000_000_000)
+    }),
+    test::test({
+      "name": "truncate_hours_negative",
+      "test": test::assert("time::nanos::truncate_hours", nanos::truncate_hours(-1), -3_600_000_000_000)
+    }),
+    test::test({
+      "name": "truncate_days",
+      "test": test::assert("time::nanos::truncate_days", nanos::truncate_days(86_499_999_999_999), 86_400_000_000_000)
+    }),
+  ]
+});
+
+test::suite({
+  "name": "datetime",
+  "tags": ["datetime"],
+  "tests": [
+    test::test({
+      "name": "rfc3339",
+      "test": test::assert("datetime::rfc3339", datetime::rfc3339(0), "1970-01-01T00:00:00+00:00")
+    }),
+    test::test({
+      "name": "rfc3339",
+      "test": test::assert("datetime::rfc2282", datetime::rfc2822(0), "Thu, 01 Jan 1970 00:00:00 +0000")
+    }),
+    test::test({
+      "name": "rfc3339 Z",
+      "test": test::assert("datetime::rfc3339 Z", datetime::rfc3339(1_559_655_782_000_000_000), "2019-06-04T13:43:02Z")
+    }),
+    test::test({
+      "name": "format timestamp",
+      "test": test::assert("datetime::format", datetime::format(1667998614978835761, datetime::formats::RFC2822), "Wed, 09 Nov 2022 12:56:54 +0000")
+    }),
+    test::test({
+      "name": "format with timezone",
+      "test": test::assert("datetime::format", datetime::format(datetime::with_timezone(123, datetime::timezones::EUROPE_BERLIN), "%Y-%m-%dT%H:%M:%S.%f%:z"), "1970-01-01T01:00:00.000000123+01:00")
+    }),
+    test::test({
+      "name": "with_timezone attach",
+      "test": test::assert("datetime::with_timezone", datetime::with_timezone(0, datetime::timezones::EUROPE_LONDON), {"timestamp": 0, "tz": datetime::timezones::EUROPE_LONDON})
+    }),
+    test::test({
+      "name": "with_timezone name",
+      "test": test::assert("datetime::with_timezone", datetime::with_timezone(0, "Europe/London"), {"timestamp": 0, "tz": "Europe/London"})
+    }),
+    test::test({
+      "name": "with_timezone offset",
+      "test": test::assert("datetime::with_timezone", datetime::with_timezone(0, "-0200"), {"timestamp": 0, "tz": "-0200"})
+    }),
+    test::test({
+      "name": "with_timezone update",
+      "test": test::assert("datetime::with_timezone", datetime::with_timezone({"timestamp": 0, "tz": datetime::timezones::EUROPE_LONDON}, datetime::timezones::ATLANTIC_JAN_MAYEN), {"timestamp": 0, "tz": datetime::timezones::ATLANTIC_JAN_MAYEN})
+    }),
+    test::test({
+      "name": "parse",
+      "test": test::assert("datetime::parse", datetime::parse("2022-11-09 14:46:11.499274824+01:00", datetime::formats::RFC3339), 1668001571499274824)
+    }),
+    test::test({
+      "name": "year",
+      "test": test::assert("datetime::year", datetime::year(0), 1970)
+    }),
+    test::test({
+      "name": "month",
+      "test": test::assert("datetime::month", datetime::month(0), 1)
+    }),
+    test::test({
+      "name": "iso_week",
+      "test": test::assert("datetime::iso_week", datetime::iso_week(1668001571499274824), 45)
+    }),
+    test::test({
+      "name": "day_of_month",
+      "test": test::assert("datetime::day_of_month", datetime::day_of_month(nanos::from_days(40)), 9)
+    }),
+    test::test({
+      "name": "day_of_year",
+      "test": test::assert("datetime::day_of_year", datetime::day_of_year(nanos::from_days(40)), 40)
+    }),
+    test::test({
+      "name": "hour",
+      "test": test::assert("datetime::hour", datetime::hour({"timestamp": 0, "tz": "+01:00"}), 1)
+    }),
+    test::test({
+      "name": "minute",
+      "test": test::assert("datetime::minute", datetime::minute({"timestamp": 0, "tz": "+01:02"}), 2)
+    }),
+    test::test({
+      "name": "second",
+      "test": test::assert("datetime::second", datetime::second(0), 0)
+    }),
+    test::test({
+      "name": "subsecond_millis",
+      "test": test::assert("datetime::subsecond_millis", datetime::subsecond_millis(1668001571499274824), 0)
+    }),
+    test::test({
+      "name": "subsecond_micros",
+      "test": test::assert("datetime::subsecond_micros", datetime::subsecond_micros(1668001571499274824), 0)
+    }),
+    test::test({
+      "name": "subsecond_nanos",
+      "test": test::assert("datetime::subsecond_nanos", datetime::subsecond_nanos(1668001571499274824), 0)
     }),
   ]
 });

--- a/tremor-script/.gitignore
+++ b/tremor-script/.gitignore
@@ -19,3 +19,4 @@ rebar3.crashdump
 priv
 eqc/.rebar3
 proptest-regressions/
+/lib/std/datetime/timezones.tremor

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.13"
 beef = { version = "0.5", features = ["impl_serde"] }
 byteorder = "1.4"
 chrono = "0.4"
+chrono-tz = "0.8"
 cidr-utils = "0.5"
 codespan = "0.11"
 dissect = "0.5"
@@ -64,6 +65,7 @@ xz2 = "0.1"
 
 [build-dependencies]
 lalrpop = "0.19"
+chrono-tz = "0.8"
 
 [dev-dependencies]
 criterion = "0.4"
@@ -72,6 +74,7 @@ matches = "0.1"
 pretty_assertions = "1.3.0"
 proptest = "1.0"
 tempfile = "3"
+test-case = "2.2"
 
 [features]
 # this is required for the erlang EQC tests of the language

--- a/tremor-script/build.rs
+++ b/tremor-script/build.rs
@@ -13,6 +13,47 @@
 // limitations under the License.
 
 extern crate lalrpop;
+use chrono_tz::TZ_VARIANTS;
+use std::{io::Write, path::PathBuf};
+
+const TIMEZONE_DOCS: &'static str = r#"### Timezones extracted from TZ data
+### Never use the actual values, they are going to change.
+###
+### Usage:
+###
+### ```tremor
+### use std::datetime;
+### let date_str = datetime::format(datetime::with_timezone(0, datetime::timezones::EUROPE_BERLIN), datetime::formats::RFC3339);
+### ```
+"#;
+
+fn create_timezones_tremor() {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.push("lib");
+    dir.push("std");
+    dir.push("datetime");
+    dir.push("timezones.tremor");
+    let mut file = std::fs::File::create(&dir).expect("Unable to create file timezones.tremor");
+    file.write_all(TIMEZONE_DOCS.as_bytes()).unwrap();
+
+    for (index, tz) in TZ_VARIANTS.iter().enumerate() {
+        let name = tz.name();
+        let ident_name = tz
+            .name()
+            .replace("GMT+", "GMT_PLUS_")
+            .replace("GMT-", "GMT_MINUS_")
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '_' })
+            .map(|c| c.to_ascii_uppercase())
+            .collect::<String>();
+        let docstring = format!("## Timezone name constant for {name}\n");
+        let line = format!("const {ident_name} = {index};\n");
+        file.write_all(docstring.as_bytes())
+            .expect("expected writing to timezones.tremor to succeed");
+        file.write_all(line.as_bytes())
+            .expect("expected writing to timezones.tremor to succeed");
+    }
+}
 
 fn main() {
     lalrpop::Configuration::new()
@@ -22,4 +63,6 @@ fn main() {
 
     println!("cargo:rustc-cfg=can_join_spans");
     println!("cargo:rustc-cfg=can_show_location_of_runtime_parse_error");
+
+    create_timezones_tremor();
 }

--- a/tremor-script/build.rs
+++ b/tremor-script/build.rs
@@ -16,7 +16,7 @@ extern crate lalrpop;
 use chrono_tz::TZ_VARIANTS;
 use std::{io::Write, path::PathBuf};
 
-const TIMEZONE_DOCS: &'static str = r#"### Timezones extracted from TZ data
+const TIMEZONE_DOCS: &str = r#"### Timezones extracted from TZ data
 ### Never use the actual values, they are going to change.
 ###
 ### Usage:

--- a/tremor-script/lib/std.tremor
+++ b/tremor-script/lib/std.tremor
@@ -3,6 +3,7 @@
 ### * [array](array.md) - functions to deal with arrays (`[]`)
 ### * [base64](base64.md) - functions for base64 en and decoding
 ### * [binary](base64.md) - functions to deal with binary data (`<< 1, 2, 3 >>`)
+### * [datetime](datetime.md) - functions and constants to deal with timestamp and datetimes
 ### * [float](float.md) - functions to deal with floating point numbers
 ### * [integer](integer/index.md) - functions to deal with integer numbers
 ### * [json](json.md) - functions to deal with JSON
@@ -22,6 +23,7 @@
 use std::array;
 use std::base64;
 use std::binary;
+use std::datetime;
 use std::float;
 use std::integer;
 use std::json;

--- a/tremor-script/lib/std.tremor
+++ b/tremor-script/lib/std.tremor
@@ -3,7 +3,7 @@
 ### * [array](array.md) - functions to deal with arrays (`[]`)
 ### * [base64](base64.md) - functions for base64 en and decoding
 ### * [binary](base64.md) - functions to deal with binary data (`<< 1, 2, 3 >>`)
-### * [datetime](datetime.md) - functions and constants to deal with timestamp and datetimes
+### * [datetime](datetime/index.md) - functions and constants to deal with timestamp and datetimes
 ### * [float](float.md) - functions to deal with floating point numbers
 ### * [integer](integer/index.md) - functions to deal with integer numbers
 ### * [json](json.md) - functions to deal with JSON

--- a/tremor-script/lib/std/datetime.tremor
+++ b/tremor-script/lib/std/datetime.tremor
@@ -1,0 +1,172 @@
+### Support for parsing date strings to nanosecond timestamps and formatting nanosecond timestamps into strings and more.
+### 
+### The submodule [timezones](datetime/timezones.md) contains constants for each existing timezone in the IANA timezone database.
+### The submodule [formats](datetime/formats.md) contains constants commonly used formats.
+###
+### In this module we introduce a type called `datetime`.
+###
+### It is either:
+###  * a simple integer timestamp which is interpreted as *UTC nanosecond precision timestamp since epoch* or
+###  * a record with the following fields:
+###    * `timestamp`: a *UTC nanosecond precision timestamp since epoch*
+###    * `tz`: a timezone identifier from the [`std::datetime::timezones`](datetime/timezones.md) module or a string with a timezone name or a fixed offset
+###
+### It can be conveniently created and adapted with the [`with_timezone`](#with_timezoneutc_nanos-timezone) function.
+###
+use std::datetime::timezones;
+use std::datetime::formats;
+
+## Formats the given datetime according to [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+##
+## Returns a string.
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::rfc3339(1667997961)
+intrinsic fn rfc3339(datetime) as datetime::rfc3339;
+
+## Formats the given datetime according to [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-3.3)
+##
+## Returns a string.
+intrinsic fn rfc2822(datetime) as datetime::rfc2822;
+
+## Formats the given nanosecond timestamp or datetime struct (created with `datetime::with_timezone`) 
+## according to the given format.
+##
+## Check [this documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) from the Rust chrone datetime library
+## on supported format specifiers. It is also possible to chose formats from the `std::datetime::formats` module.
+##
+## > ```tremor
+## > datetime::format(datetime::with_timezone(123, datetime::timezones::EUROPE_BERLIN), "%Y-%m-%dT%H:%M:%S%:z") == "1970-01-01T01:00:00:+01:00"
+## > ```
+intrinsic fn format(datetime, format) as datetime::format;
+
+## Turn the given `utc_nanos` into a full datetime with the given `timezone`. For use in other functions of this module.
+## 
+## Provide a const timezone identifier from the `std::datetime::timezones` module 
+## or a string with timezone name or fixed offset
+## 
+## Returns a record with `timestamp` and `tz` fields.
+## This function errors if the timezone is invalid.
+intrinsic fn with_timezone(utc_nanos, timezone) as datetime::with_timezone;
+
+## Parse the given datetime string according to the given format into a nanosecond timestamp since epoch UTC
+##
+## Check [this documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) from the Rust chrone datetime library
+## on supported format specifiers. It is also possible to chose formats from the `std::datetime::formats` module.
+##
+## This function errors if the given string cannot be parsed according to the given format.
+## If successful this function returns a 64-bit integer.
+##
+## Usage:
+## 
+## > ```tremor
+## > let nanos = datetime::parse(event.datetime, datetime::formats::RFC3339);
+## > ```
+intrinsic fn parse(string, format) as datetime::parse;
+
+## Extract the year number in in the calendar date
+## according to the proleptic Gregorian calendar.
+## 
+## > ```tremor
+## > use std::datetime;
+## > datetime::year(0)  == 1970
+## >```
+intrinsic fn year(datetime) as datetime::year;
+
+## Extract the month number starting from 1
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::month(0) == 1
+## > ```
+intrinsic fn month(datetime) as datetime::month;
+
+## Extract the ISO week number starting from 1
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::iso_week(0) == 1
+## > ```
+intrinsic fn iso_week(datetime) as datetime::iso_week;
+
+## Extract the day of the month starting from 1
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::day_of_month(0) == 1
+## > ```
+intrinsic fn day_of_month(datetime) as datetime::day_of_month;
+## Extract the day of the year starting from 1
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::day_of_year(0) == 1
+## > ```
+intrinsic fn day_of_year(datetime) as datetime::day_of_year;
+
+## Extract the hour number of the day starting from 0
+##
+## Returns an integer in the range of 0 to 23
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::hour(0) == 0
+## > ```
+intrinsic fn hour(datetime) as datetime::hour;
+
+## Extract the minute number of the day starting from 0
+##
+## Returns an integer in the range of 0 to 59
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::minute(0) == 0
+## > ```
+intrinsic fn minute(datetime) as datetime::minute;
+
+## Extract the second number of the day starting from 0
+##
+## Returns an integer in the range of 0 to 59
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::second(0) == 0
+## > ```
+intrinsic fn second(datetime) as datetime::second;
+
+## Extract the number of milliseconds since the last full second.
+##
+## For turning a timestamp into milliseconds use [`std::time::nanos::to_millis`](../time/nanos.md#to_millisnanos).
+##
+## Returns an integer
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::subsecond_millis(1_000_000) == 1
+## > ```
+intrinsic fn subsecond_millis(datetime) as datetime::subsecond_millis;
+
+## Extract the number of microseconds since the last full second
+##
+## For turning a timestamp into microseconds use [`std::time::nanos::to_micros`](../time/nanos.md#to_microsnanos).
+##
+## Returns an integer
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::subsecond_micros(1_000_000) == 1_000
+## > ```
+intrinsic fn subsecond_micros(datetime) as datetime::subsecond_micros;
+
+## Extract the number of nanoseconds since the last full second
+##
+## This is not the number of milliseconds since epoch.
+##
+## Returns an integer
+##
+## > ```tremor
+## > use std::datetime;
+## > datetime::subsecond_nanos(1_000_000) == 1_000_000
+## > ```
+intrinsic fn subsecond_nanos(datetime) as datetime::subsecond_nanos;

--- a/tremor-script/lib/std/datetime.tremor
+++ b/tremor-script/lib/std/datetime.tremor
@@ -1,7 +1,7 @@
 ### Support for parsing date strings to nanosecond timestamps and formatting nanosecond timestamps into strings and more.
 ### 
-### The submodule [timezones](datetime/timezones.md) contains constants for each existing timezone in the IANA timezone database.
-### The submodule [formats](datetime/formats.md) contains constants commonly used formats.
+### The submodule [timezones](timezones.md) contains constants for each existing timezone in the IANA timezone database.
+### The submodule [formats](formats.md) contains constants commonly used formats.
 ###
 ### In this module we introduce a type called `datetime`.
 ###
@@ -9,7 +9,7 @@
 ###  * a simple integer timestamp which is interpreted as *UTC nanosecond precision timestamp since epoch* or
 ###  * a record with the following fields:
 ###    * `timestamp`: a *UTC nanosecond precision timestamp since epoch*
-###    * `tz`: a timezone identifier from the [`std::datetime::timezones`](datetime/timezones.md) module or a string with a timezone name or a fixed offset
+###    * `tz`: a timezone identifier from the [`std::datetime::timezones`](timezones.md) module or a string with a timezone name or a fixed offset
 ###
 ### It can be conveniently created and adapted with the [`with_timezone`](#with_timezoneutc_nanos-timezone) function.
 ###

--- a/tremor-script/lib/std/datetime.tremor
+++ b/tremor-script/lib/std/datetime.tremor
@@ -23,6 +23,7 @@ use std::datetime::formats;
 ## > ```tremor
 ## > use std::datetime;
 ## > datetime::rfc3339(1667997961)
+## > ```
 intrinsic fn rfc3339(datetime) as datetime::rfc3339;
 
 ## Formats the given datetime according to [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-3.3)

--- a/tremor-script/lib/std/datetime/formats.tremor
+++ b/tremor-script/lib/std/datetime/formats.tremor
@@ -1,0 +1,18 @@
+### Common formats for formatting datetimes
+###
+### To be used with `std::datetime::format` or `std::datetime::parse`
+
+## Format for [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
+##
+## This format is also ISO8601 compatible.
+const RFC3339 = "%Y-%m-%dT%H:%M:%S%.f%:z";
+
+## Format for [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-3.3)
+##
+## Same as [RFC5322](#rfc5322)
+const RFC2822 = "%a, %d %b %Y %H:%M:%S %z";
+
+## Format for [RFC 5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.3)
+##
+## Same as [RFC2822](#rfc2822)
+const RFC5322 = RFC2822;

--- a/tremor-script/lib/std/test.tremor
+++ b/tremor-script/lib/std/test.tremor
@@ -10,7 +10,7 @@
 ## > assert("one equals one", 1, 2); # errors
 ## > ```
 ##
-## Returns an `bool`.
+## Returns a `bool`.
 intrinsic fn assert(name, expected, got) as test::assert;
 
 ## The `suite` function is an entrypoint into tremor's

--- a/tremor-script/lib/std/time/nanos.tremor
+++ b/tremor-script/lib/std/time/nanos.tremor
@@ -154,3 +154,103 @@ end;
 fn to_micros(nanos) with
   nanos / NANOS_PER_MICROSECOND
 end;
+
+
+## Truncate down to the next microsecond.
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_micros(9999) 
+## > # result: 9000
+## > ```
+fn truncate_micros(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_MICROSECOND) - (nanos % NANOS_PER_MICROSECOND)
+    default => nanos - (nanos % NANOS_PER_MICROSECOND)
+  end
+end;
+
+## Truncate down to the next millisecond
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_millis(9_999_999) 
+## > # result: 9_000_000
+## > ```
+fn truncate_millis(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_MILLISECOND) - (nanos % NANOS_PER_MILLISECOND)
+    default => nanos - (nanos % NANOS_PER_MILLISECOND)
+  end
+end;
+
+## Truncate down to the next second
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_seconds(9_999_999_999) 
+## > # result: 9_000_000_000
+## > ```
+fn truncate_seconds(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_SECOND) - (nanos % NANOS_PER_SECOND)
+    default => nanos - (nanos % NANOS_PER_SECOND)
+  end
+end;
+
+## Truncate down to the next minute
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_minutes(69_999_999_999) 
+## > # result: 60_000_000_000
+## > ```
+fn truncate_minutes(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_MINUTE) - (nanos % NANOS_PER_MINUTE)
+    default => nanos - (nanos % NANOS_PER_MINUTE)
+  end
+end;
+
+## Truncate down to the next hour
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_hours(3_699_999_999_999) 
+## > # result: 3_600_000_000_000
+## > ```
+fn truncate_hours(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_HOUR) - (nanos % NANOS_PER_HOUR)
+    default => nanos - (nanos % NANOS_PER_HOUR)
+  end
+end;
+
+## Truncate down to the next day
+##
+## This function does not take leap-seconds or any other datetime fanciness into account. This is plain timestamp math.
+##
+## > ```tremor
+## > use std::time::nanos;
+## > nanos::truncate_days(86_499_999_999_999) 
+## > # result: 86_400_000_000_000
+## > ```
+fn truncate_days(nanos) with
+  match nanos < 0 of
+    case true => (nanos - NANOS_PER_DAY) - (nanos % NANOS_PER_DAY)
+    default => nanos - (nanos % NANOS_PER_DAY)
+  end
+end;
+
+# We don't know when a full week started so we cannot easily truncate down to a week
+# So we skipped the `truncate_weeks` function

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -923,6 +923,13 @@ pub enum Invocable<'script> {
 }
 
 impl<'script> Invocable<'script> {
+    /// name of the invocable (without module)
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Intrinsic(wrapper) => wrapper.name(),
+            Self::Tremor(custom) => custom.name.as_str(),
+        }
+    }
     fn inline(self, args: ImutExprs<'script>, mid: Box<NodeMeta>) -> Result<ImutExpr<'script>> {
         match self {
             Invocable::Intrinsic(_f) => Err("can't inline intrinsic".into()),

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -924,7 +924,7 @@ pub enum Invocable<'script> {
 
 impl<'script> Invocable<'script> {
     /// name of the invocable (without module)
-    pub fn name(&self) -> &str {
+    #[must_use] pub fn name(&self) -> &str {
         match self {
             Self::Intrinsic(wrapper) => wrapper.name(),
             Self::Tremor(custom) => custom.name.as_str(),

--- a/tremor-script/src/ast.rs
+++ b/tremor-script/src/ast.rs
@@ -924,7 +924,8 @@ pub enum Invocable<'script> {
 
 impl<'script> Invocable<'script> {
     /// name of the invocable (without module)
-    #[must_use] pub fn name(&self) -> &str {
+    #[must_use]
+    pub fn name(&self) -> &str {
         match self {
             Self::Intrinsic(wrapper) => wrapper.name(),
             Self::Tremor(custom) => custom.name.as_str(),

--- a/tremor-script/src/ast/helper.rs
+++ b/tremor-script/src/ast/helper.rs
@@ -61,7 +61,7 @@ impl Warning {
 #[derive(Default, Debug, Clone, Serialize, PartialEq)]
 pub struct Scope<'script> {
     /// Module of the scope
-    pub(crate) modules: std::collections::HashMap<String, module::Index>,
+    pub(crate) modules: std::collections::BTreeMap<String, module::Index>,
     /// Content of the scope
     pub content: Content<'script>,
     pub(crate) parent: Option<Box<Scope<'script>>>,

--- a/tremor-script/src/ast/module.rs
+++ b/tremor-script/src/ast/module.rs
@@ -35,8 +35,8 @@ use crate::{
 };
 use beef::Cow;
 use sha2::Digest;
-use std::collections::hash_map::Entry;
-use std::{collections::HashMap, fmt::Debug};
+use std::collections::btree_map::Entry;
+use std::{collections::BTreeMap, fmt::Debug};
 
 use std::sync::RwLock;
 lazy_static::lazy_static! {
@@ -96,7 +96,7 @@ impl_expr!(ModuleRaw);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Id(Vec<u8>);
 
-type NamedEnteties<T> = HashMap<String, T>;
+type NamedEnteties<T> = BTreeMap<String, T>;
 
 /// Content of a module
 #[derive(Default, Clone, Serialize, PartialEq)]
@@ -221,7 +221,7 @@ pub struct Module {
     /// module contents
     pub content: Content<'static>,
     /// additionally loaded modules
-    pub modules: HashMap<String, Index>,
+    pub modules: BTreeMap<String, Index>,
 }
 
 impl From<&[u8]> for Id {

--- a/tremor-script/src/ast/test.rs
+++ b/tremor-script/src/ast/test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 #![allow(clippy::unwrap_used)]
 use super::*;
-use crate::{CustomFn, NodeMeta};
+use crate::{registry, CustomFn, NodeMeta};
 use matches::assert_matches;
 
 fn v(s: &'static str) -> ImutExpr<'static> {
@@ -87,6 +87,14 @@ fn as_invoke() {
         is_const: false,
         inline: false,
     });
+    assert_eq!("f", invocable.name());
+    let invocable2 = Invocable::Intrinsic(
+        registry()
+            .find("array", "reverse")
+            .expect("Expected array::reverse to exist")
+            .clone(),
+    );
+    assert_eq!("reverse", invocable2.name());
     let i = Invoke {
         mid: NodeMeta::dummy(),
         node_id: NodeId {
@@ -104,6 +112,25 @@ fn as_invoke() {
     let e = ImutExpr::Invoke2(i.clone());
     assert!(Expr::Imut(e).as_invoke().is_some());
     let e = ImutExpr::Invoke3(i.clone());
+    assert!(Expr::Imut(e).as_invoke().is_some());
+
+    let i2 = Invoke {
+        mid: NodeMeta::dummy(),
+        node_id: NodeId {
+            module: Vec::new(),
+            id: "fun".to_string(),
+        },
+        invocable: invocable2,
+        args: Vec::new(),
+    };
+    assert!(Expr::Imut(v("snut")).as_invoke().is_none());
+    let e = ImutExpr::Invoke(i2.clone());
+    assert!(Expr::Imut(e).as_invoke().is_some());
+    let e = ImutExpr::Invoke1(i2.clone());
+    assert!(Expr::Imut(e).as_invoke().is_some());
+    let e = ImutExpr::Invoke2(i2.clone());
+    assert!(Expr::Imut(e).as_invoke().is_some());
+    let e = ImutExpr::Invoke3(i2.clone());
     assert!(Expr::Imut(e).as_invoke().is_some());
 }
 

--- a/tremor-script/src/registry.rs
+++ b/tremor-script/src/registry.rs
@@ -310,6 +310,11 @@ pub struct TremorFnWrapper {
 }
 
 impl TremorFnWrapper {
+    /// name of the function (without module)
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
     /// Creates a new wrapper
     #[must_use]
     pub fn new(module: String, name: String, fun: Box<dyn TremorFn>) -> Self {

--- a/tremor-script/src/std_lib/datetime.rs
+++ b/tremor-script/src/std_lib/datetime.rs
@@ -297,7 +297,7 @@ mod tests {
             |e: crate::errors::Error| to_runtime_error(Mfa::new("datetime", "with_timezone", 2), e);
 
         for input in 0_usize..chrono_tz::TZ_VARIANTS.len() {
-            let res = (|| with_timezone!(Value::from(input), tz, fnork, { Ok(()) }))();
+            let res = (|| with_timezone!(Value::from(input), _tz, fnork, { Ok(()) }))();
             assert!(
                 res.is_ok(),
                 "{}: Expected Ok(()), got: {res:?}",

--- a/tremor-script/src/std_lib/datetime.rs
+++ b/tremor-script/src/std_lib/datetime.rs
@@ -187,7 +187,7 @@ pub fn load(registry: &mut Registry) {
         .insert(tremor_const_fn!(datetime|with_timezone(_context, _timestamp, _timezone) {
             // this macro ensures we have a valid timezone
             with_timezone!(_timezone, _tz, to_runtime_error, {
-                to_timezone_object(*_timestamp, *_timezone, this_mfa)
+                to_timezone_object(_timestamp, _timezone, this_mfa)
             })
         }))
         .insert(datetime_fn!(year, datetime, datetime.year()))

--- a/tremor-script/src/std_lib/datetime.rs
+++ b/tremor-script/src/std_lib/datetime.rs
@@ -165,7 +165,7 @@ pub fn load(registry: &mut Registry) {
              let res = _parse(_input, _input_fmt, has_tz(_input_fmt));
              match res {
                  Ok(x) => Ok(Value::from(x)),
-                 Err(e)=> Err(FunctionError::RuntimeError { mfa: mfa( "datetime",  "parse", 1), error: format!("Cannot Parse {e} to valid timestamp") })
+                 Err(e)=> Err(FunctionError::RuntimeError { mfa: mfa( "datetime",  "parse", 1), error: e.to_string() })
         }}))
         .insert(tremor_const_fn!(datetime|format(_context, _datetime, _format) {
             let format = _format.as_str().ok_or_else(||FunctionError::BadType {mfa: this_mfa()})?;


### PR DESCRIPTION
# Pull request



## Description

Implement the new `std::datetime` library.

And add `truncate_*` functions to `std::time::nanos`.

## Related


* Related [TBD](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

Doesn't really apply as those changes are net new. (A benchmark for some function would still be nice though.)
