### PR TITLE
Quickcheck shrinking

### DIFF
--- a/tremor-script/eqc/gen_script.erl
+++ b/tremor-script/eqc/gen_script.erl
@@ -17,7 +17,7 @@
 
 -include_lib("pbt.hrl").
 
--export([gen/1]).
+-export([pp/1]).
 
 gen_({'+', A, B}) ->
     ["(", gen_(A), " + ", gen_(B), ")"];
@@ -54,7 +54,7 @@ gen_({'+', A}) -> ["(+ ", gen_(A), ")"];
 gen_({'-', A}) -> ["(- ", gen_(A), ")"];
 gen_({'#', String1, String2, Sub}) ->
     ["(", string:trim(gen_(String1), trailing, "\""), "#{",
-     gen(Sub), "}",
+     gen_(Sub), "}",
      string:trim(gen_(String2), leading, "\""), ")"];
 gen_({array, Exprs}) ->
     ["[", [[gen_(Ele), ","] || Ele <- Exprs], "]"];
@@ -83,7 +83,7 @@ gen_(null) -> "null";
 gen_(X) when is_number(X) -> io_lib:format("~p", [X]);
 gen_(X) when is_binary(X) -> jsx:encode(X).
 
-gen(Expr) -> iolist_to_binary(gen_(Expr)).
+pp(Expr) -> iolist_to_binary(gen_(Expr)).
 
 patch_operation({merge, Value}) ->
     ["merge ", " => ", gen_(Value)];

--- a/tremor-script/eqc/model.erl
+++ b/tremor-script/eqc/model.erl
@@ -19,9 +19,6 @@
 
 -export([eval/1, eval/2]).
 
-resolve(#state{locals = L}, {local, _} = K) ->
-    maps:get(K, L).
-
 combine_values(Key, null, Acc) -> maps:remove(Key, Acc);
 combine_values(Key, SpecVal = #{}, Acc) ->
     case maps:get(Key, Acc) of
@@ -212,7 +209,8 @@ ast_eval(S, false) -> {S, false};
 ast_eval(S, null) -> {S, null};
 ast_eval(S, N) when is_number(N) -> {S, N};
 ast_eval(S, B) when is_binary(B) -> {S, B};
-ast_eval(S, {local, _} = L) -> {S, resolve(S, L)};
+ast_eval(#vars{locals = Ls} = S, {local, _} = K) ->
+    {S, maps:get(K, Ls)};
 ast_eval(#vars{} = S, {emit, A}) ->
     {S1, R} = ast_eval(S, A), {S1, {emit, R}};
 ast_eval(#vars{} = S, drop) -> {S, drop}.

--- a/tremor-script/eqc/model.erl
+++ b/tremor-script/eqc/model.erl
@@ -179,13 +179,22 @@ ast_eval(#vars{} = S, {'<=', A, B}) ->
     {S2, B1} = ast_eval(S1, B),
     {S2, A1 =< B1};
 ast_eval(#vars{} = S, {'and', A, B}) ->
+    %% lazy!
     {S1, A1} = ast_eval(S, A),
-    {S2, B1} = ast_eval(S1, B),
-    {S2, A1 andalso B1};
+    case A1 of
+        true ->
+            ast_eval(S1, B);
+        false ->
+            {S1, A1}
+    end;
 ast_eval(#vars{} = S, {'or', A, B}) ->
+    %% lazy!
     {S1, A1} = ast_eval(S, A),
-    {S2, B1} = ast_eval(S1, B),
-    {S2, A1 orelse B1};
+    case A1 of
+        false -> ast_eval(S1, B);
+        true ->
+            {S1, A1}
+    end;
 ast_eval(#vars{} = S, {'not', A}) ->
     {S1, A1} = ast_eval(S, A), {S1, not A1};
 ast_eval(#vars{} = S, {'band', A, B}) ->

--- a/tremor-script/eqc/model.erl
+++ b/tremor-script/eqc/model.erl
@@ -145,7 +145,15 @@ ast_eval(#vars{} = S, {'-', A, B}) ->
 ast_eval(#vars{} = S, {'/', A, B}) ->
     {S1, A1} = ast_eval(S, A),
     {S2, B1} = ast_eval(S1, B),
-    {S2, A1 / B1};
+    case is_float(A1) orelse is_float(B1) of
+        true ->
+            %% may be fine to divide by zero
+            {S2, try A1 / B1
+                 catch _:badarith -> exit(float_arith)
+                 end};
+        false ->
+            {S2, A1 / B1}
+    end;
 ast_eval(#vars{} = S, {'*', A, B}) ->
     {S1, A1} = ast_eval(S, A),
     {S2, B1} = ast_eval(S1, B),

--- a/tremor-script/eqc/pbt.hrl
+++ b/tremor-script/eqc/pbt.hrl
@@ -14,7 +14,6 @@
 %%
 
 -include_lib("eqc/include/eqc.hrl").
--include_lib("eqc/include/eqc_component.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -record(state, {

--- a/tremor-script/eqc/spec.erl
+++ b/tremor-script/eqc/spec.erl
@@ -18,7 +18,7 @@
 -include_lib("pbt.hrl").
 
 -export([gen/1, gen_array/1, gen_bool/1, gen_float/1,
-	 gen_int/1, gen_record/1, gen_string/1, id/0, valid/1]).
+	 gen_int/1, gen_record/1, gen_string/1, id/0]).
 
 -define(SHRINKEXPR(OpGen, Gen1),
         ?LET([Op, V1], [OpGen, Gen1],
@@ -29,20 +29,6 @@
 -define(SHRINKEXPR(OpGen, Gen1, Gen2, Gen3),
         ?LET([Op, V1, V2, V3], [OpGen, Gen1, Gen2, Gen3],
              ?SHRINK({Op, V1, V2, V3}, [V1, V2, V3]))).
-
-valid(Script) ->
-    try lists:foldr(fun (AAst, {S, _}) ->
-			    model:eval(S, AAst)
-		    end,
-		    {#vars{}, null}, Script),
-	true
-    catch
-      %  for testing, A, B are errors and C is stack trace
-      %   A:B:C ->
-      %   io:format("Invalid: ~p\n~p:~p\n~p", [Script, A, B, C]),
-      %   false
-      _:_ -> false
-    end.
 
 id() ->
     ?LET(Path,

--- a/tremor-script/eqc/test_eqc.erl
+++ b/tremor-script/eqc/test_eqc.erl
@@ -20,6 +20,7 @@
 -module(test_eqc).
 
 -include_lib("pbt.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
 -compile([export_all]).
 
 

--- a/tremor-script/eqc/test_eqc.erl
+++ b/tremor-script/eqc/test_eqc.erl
@@ -58,184 +58,81 @@ expr_pre(_S, [_Script, {emit, _}]) ->
     false;
 expr_pre(_S, [_Script, drop]) ->
     false;
-expr_pre(_S, [Script, Ast]) ->
-    spec:valid([Ast | Script]).
+expr_pre(S, [Script, _Expr]) ->
+    S#state.script == Script. %% for better shrinking
 
 expr(Script, Ast) ->
     remote_eval(tremor_script_eval, [Script, Ast]).
 
-exprenqueue_post(#state{}, [Script, Ast], RustResult) ->
-    {_, ModelResult} = lists:foldr(fun(AAst, {S, _}) ->
-                                           model:eval(S, AAst)
-                                   end, {#vars{}, null}, [Ast | Script]),
-    case ModelResult =:= RustResult of
-        true -> true;
-        false ->
-            io:format("~ts", [asts_to_script([Ast | Script])]),
-            io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
-            false
-        end.
+expr_post(#state{}, [Script, Ast], RustResult) ->
+    expected([Ast | Script], RustResult).
 
 expr_next(#state{} = S, _Eval, [Script, Ast]) ->
     %% Since tremor script has no state we need to keep
     %% track of the commands exectuted so far
-    S#state{script = [Ast | Script]}.
+    case (catch model_eval([Ast | Script])) of
+        {'EXIT', _} ->
+            %% Do not add crashing operation to the script
+            %% but we test that Rust does also crash in postcondition
+            S;
+        _ ->
+            S#state{script = [Ast | Script]}
+    end.
+
+expr_features(#state{locals = Locals}, [_Script, _Ast], _Res) ->
+    [{nr_locals_in_script, maps:size(Locals)}].
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% let_int
+%% let local of type
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-let_local_int_args(#state{} = S) ->
-    [S#state.script, spec:id(), spec:gen_int(S)].
+let_local_args(#state{} = S) ->
+    [S#state.script, spec:id(), oneof([{int, spec:gen_int(S)},
+                                       {bool, spec:gen_bool(S)}
+                                       %{float, spec:gen_float(S)},
+                                       %{string, spec:gen_string(S)}
+                                      ])].
 
-let_local_int_pre(#state{}) ->
-    true.
+let_local_pre(S, [Script, _, {_Type, _Expr}]) ->
+    S#state.script == Script.
 
-let_local_int_pre(_S, [Script, _, Ast]) ->
-    spec:valid([Ast | Script]).
+let_local_adapt(S, [_Script, Id, TypedExpr]) ->
+    [S#state.script, Id, TypedExpr].
 
-let_local_int(Script, Id, Expr) ->
+let_local(Script, Id, {_Type, Expr}) ->
     remote_eval(tremor_script_eval, [Script, {'let', {local, Id}, Expr}]).
 
-let_local_int_post(#state{}, [Script, Id, Expr], RustResult) ->
-    Ast = {'let', {local, Id}, Expr},
-    {_, ModelResult} = lists:foldr(fun(AAst, {S, _}) ->
-                                           model:eval(S, AAst)
-                                   end, {#vars{}, null}, [Ast | Script]),
-    case ModelResult =:= RustResult of
-        true -> true;
-        false ->
-            io:format("\nAst:\n~p\n", [lists:reverse([Ast | Script])]),
-            io:format("Script:\n~ts\n", [asts_to_script([Ast | Script])]),
-            io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
-            false
-        end.
-
-let_local_int_next(#state{} = S, _Eval, [Script, Id, Expr]) ->
+let_local_next(#state{} = S, _Eval, [Script, Id, {Type, Expr}]) ->
     Ast = {'let', {local, Id}, Expr},
     %% Since tremor script has no state we need to keep
     %% track of the commands exectuted so far
-    S#state{
-      script = [Ast | Script],
-      locals = maps:put(Id, int, S#state.locals)
-     }.
+    case model_eval([Expr | Script]) of
+        {'EXIT', _} ->
+            S;
+        _ ->
+            S#state{
+              script = [Ast | Script],
+              locals = maps:put(Id, Type, S#state.locals)
+             }
+    end.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% let_float
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+let_local_post(#state{}, [Script, Id, {_Type, Expr}], RustResult) ->
+    expected([{'let', {local, Id}, Expr} | Script], RustResult).
 
-let_local_float_args(#state{} = S) ->
-    [S#state.script, spec:id(), spec:gen_float(S)].
-
-let_local_float_pre(#state{}) ->
-    true.
-
-let_local_float_pre(_S, [Script, _, Ast]) ->
-    spec:valid([Ast | Script]).
-
-let_local_float(Script, Id, Expr) ->
-    remote_eval(tremor_script_eval, [Script, {'let', {local, Id}, Expr}]).
-
-let_local_float_post(#state{}, [Script, Id, Expr], RustResult) ->
-    Ast = {'let', {local, Id}, Expr},
-    {_, ModelResult} = lists:foldr(fun(AAst, {S, _}) ->
-                                           model:eval(S, AAst)
-                                   end, {#vars{}, null}, [Ast | Script]),
-    case ModelResult =:= RustResult of
+expected(Script, RustResult) ->
+    ModelResult = model_eval(Script),
+    ValidExit =
+        is_exit(RustResult) andalso is_exit(ModelResult),
+    case ValidExit orelse ModelResult =:= RustResult of
         true -> true;
         false ->
-            io:format("\nAst:\n~p\n", [lists:reverse([Ast | Script])]),
-            io:format("Script:\n~ts\n", [asts_to_script([Ast | Script])]),
-            io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
-            false
-        end.
+            io:format("~ts", [asts_to_script(Script)]),
+            %% io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
+            {{model, ModelResult}, '!=', {rust, RustResult}}
+    end.
 
-let_local_float_next(#state{} = S, _Eval, [Script, Id, Expr]) ->
-    Ast = {'let', {local, Id}, Expr},
-    %% Since tremor script has no state we need to keep
-    %% track of the commands exectuted so far
-    S#state{
-      script = [Ast | Script],
-      locals = maps:put(Id, float, S#state.locals)
-     }.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% let_bool
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-let_local_bool_args(#state{} = S) ->
-    [S#state.script, spec:id(), spec:gen_bool(S)].
-
-let_local_bool_pre(#state{}) ->
-    true.
-
-let_local_bool_pre(_S, [Script, _, Ast]) ->
-    spec:valid([Ast | Script]).
-
-let_local_bool(Script, Id, Expr) ->
-    remote_eval(tremor_script_eval, [Script, {'let', {local, Id}, Expr}]).
-
-let_local_bool_post(#state{}, [Script, Id, Expr], RustResult) ->
-    Ast = {'let', {local, Id}, Expr},
-    {_, ModelResult} = lists:foldr(fun(AAst, {S, _}) ->
-                                           model:eval(S, AAst)
-                                   end, {#vars{}, null}, [Ast | Script]),
-    case ModelResult =:= RustResult of
-        true -> true;
-        false ->
-            io:format("\nAst:\n~p\n", [lists:reverse([Ast | Script])]),
-            io:format("Script:\n~ts\n", [asts_to_script([Ast | Script])]),
-            io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
-            false
-        end.
-
-let_local_bool_next(#state{} = S, _Eval, [Script, Id, Expr]) ->
-    Ast = {'let', {local, Id}, Expr},
-    %% Since tremor script has no state we need to keep
-    %% track of the commands exectuted so far
-    S#state{
-      script = [Ast | Script],
-      locals = maps:put(Id, bool, S#state.locals)
-     }.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% let_string
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-let_local_string_args(#state{} = S) ->
-    [S#state.script, spec:id(), spec:gen_string(S)].
-
-let_local_string_pre(#state{}) ->
-    true.
-
-let_local_string_pre(_S, [Script, _, Ast]) ->
-    spec:valid([Ast | Script]).
-
-let_local_string(Script, Id, Expr) ->
-    remote_eval(tremor_script_eval, [Script, {'let', {local, Id}, Expr}]).
-
-let_local_string_post(#state{}, [Script, Id, Expr], RustResult) ->
-    Ast = {'let', {local, Id}, Expr},
-    {_, ModelResult} = lists:foldr(fun(AAst, {S, _}) ->
-                                           model:eval(S, AAst)
-                                   end, {#vars{}, null}, [Ast | Script]),
-    case ModelResult =:= RustResult of
-        true -> true;
-        false ->
-            io:format("\nAst:\n~p\n", [lists:reverse([Ast | Script])]),
-            io:format("Script:\n~ts\n", [asts_to_script([Ast | Script])]),
-            io:format("model: ~p =/= tremor: ~p\n", [ModelResult, RustResult]),
-            false
-        end.
-
-let_local_string_next(#state{} = S, _Eval, [Script, Id, Expr]) ->
-    Ast = {'let', {local, Id}, Expr},
-    %% Since tremor script has no state we need to keep
-    %% track of the commands exectuted so far
-    S#state{
-      script = [Ast | Script],
-      locals = maps:put(Id, string, S#state.locals)
-     }.
 %% Given a model specification, we produce a tremor-script AST
 %% and send it via an Erlang NIF to Rust as a serialized JSON
 %% document.
@@ -262,17 +159,24 @@ tremor_script_eval(Init, Spec) ->
     ErlangResult = jsx:decode(RustResult),
     util:clamp(ErlangResult, 13).
 
+is_exit({badrpc, {'EXIT', _}}) ->
+    true;
+is_exit({'EXIT', _}) ->
+    true;
+is_exit(_) ->
+    false.
+
 -spec prop_simple_expr() -> eqc:property().
 prop_simple_expr() ->
-    ?FORALL(Params, ?SUCHTHAT(Ast, spec:gen(initial_state()), spec:valid([Ast])),
+    ?FORALL(Params, spec:gen(initial_state()),
             begin
                 RustResult = remote_eval(tremor_script_eval, [Params]),
-                { _, ModelResult } = model:eval(Params),
+                ModelResult = model_eval([Params]),
                 ?WHENFAIL(
                    io:format("SIMPLE EXPR MODEL FAILED!\n AST: ~p\n Script: ~s\n Expected Result: ~p\n Actual Result: ~p\n",
                              [Params, gen_script:pp(Params), ModelResult, RustResult]),
                              %% The real ( rust ) and model simulation ( erlang ) results should be equivalent
-                             ModelResult =:= RustResult
+                             (is_exit(RustResult) andalso is_exit(ModelResult)) orelse ModelResult =:= RustResult
                   )
             end).
 
@@ -313,3 +217,11 @@ remote_eval(Fn, Args) ->
     {ok, Client} = maybe_client(),
     rpc:call(Client, ?MODULE, Fn, Args).
 
+model_eval(Script) ->
+    try {_, ModelResult} =
+             lists:foldr(fun (AAst, {Vars, _}) -> model:eval(Vars, AAst) end,
+                         {#vars{}, null}, Script),
+         ModelResult
+    catch _:Reason ->
+            {'EXIT', Reason}
+    end.

--- a/tremor-script/eqc/test_eqc.erl
+++ b/tremor-script/eqc/test_eqc.erl
@@ -248,7 +248,7 @@ let_local_string_next(#state{} = S, _Eval, [Script, Id, Expr]) ->
 
 asts_to_script(Script) ->
     lists:foldr(fun(Ast, Result) ->
-                        Line = gen_script:gen(Ast),
+                        Line = gen_script:pp(Ast),
                         <<Result/binary, Line/binary, ";\n">>
                 end, <<>>, Script).
 
@@ -269,7 +269,7 @@ prop_simple_expr() ->
                 { _, ModelResult } = model:eval(Params),
                 ?WHENFAIL(
                    io:format("SIMPLE EXPR MODEL FAILED!\n AST: ~p\n Script: ~s\n Expected Result: ~p\n Actual Result: ~p\n",
-                             [Params, gen_script:gen(Params), ModelResult, RustResult]),
+                             [Params, gen_script:pp(Params), ModelResult, RustResult]),
                              %% The real ( rust ) and model simulation ( erlang ) results should be equivalent
                              ModelResult =:= RustResult
                   )


### PR DESCRIPTION
# Pull request

## Description

This PR improves shrinking of scripts when a test case fails. It does so by actually evaluating part of the expression in which there are no variables. It also shrinks command. sequences much better than the previous model.

There are 3 unfinished parts, discussed on discord. These 3 are cleaerly marked in the `skip` function in `test_eqc.erl`. By disabling one of these options, faults will be detected and nicely shrunk. When the specification is settled, the model can be extended to handle those cases.
(negative testing is possible, but clutters the screen so much, that it is skipped as well)

## Related

Discussion on
- division by 0.0 gives infinite in Rust
- patch and merge behaviour w.r.t. undefined keys

## Checklist

* [x ] The code is tested by running 200k tests

## Performance

This PR only affects the tests, not the system


