### PR TITLE
Fix json codec to deduplicate keys consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 * Fix `udp_client` connector connecting to IPv6 hosts.
+* Fix `json` codec to deduplicate duplicate keys by using the last key in the JSON record.
 
 ### Breaking Changes
 

--- a/src/codec/json.rs
+++ b/src/codec/json.rs
@@ -173,4 +173,43 @@ mod test {
         );
         Ok(())
     }
+
+    #[test]
+    fn duplicate_keys_unsorted() -> Result<()> {
+        let mut input = r#"{"key": 1, "key":2}"#.as_bytes().to_vec();
+        let mut codec = Json::<Unsorted>::default();
+        let res = codec.decode(input.as_mut_slice(), 0)?;
+        assert_eq!(Some(literal!({"key": 2})), res); // duplicate keys are deduplicated with last-key-wins strategy
+        let value = res.expect("No value");
+        let serialized = codec.encode(&value)?;
+        assert_eq!(r#"{"key":2}"#.as_bytes(), serialized.as_slice());
+
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_keys_sorted() -> Result<()> {
+        let mut input = r#"{"key": 1, "key":2}"#.as_bytes().to_vec();
+        let mut codec = Json::<Sorted>::default();
+        let res = codec.decode(input.as_mut_slice(), 0)?;
+        assert_eq!(Some(literal!({"key": 2})), res); // duplicate keys are deduplicated with last-key-wins strategy
+        let value = res.expect("No value");
+        let serialized = codec.encode(&value)?;
+        assert_eq!(r#"{"key":2}"#.as_bytes(), serialized.as_slice());
+
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_keys_into_static() -> Result<()> {
+        let mut input = r#"{"key": 1, "key":2}"#.as_bytes().to_vec();
+        let mut codec = Json::<Unsorted>::default();
+        let res = codec.decode(input.as_mut_slice(), 0)?;
+        assert_eq!(Some(literal!({"key": 2})), res); // duplicate keys are deduplicated with last-key-wins strategy
+        let value = res.expect("No value");
+        let serialized = codec.encode(&value)?;
+        assert_eq!(r#"{"key":2}"#.as_bytes(), serialized.as_slice());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

The following payload was preserved when read via the `json` codec:

```json
{
  "key": 1,
  "key": 2
}
```

When using the `json` extractor or assigning the resulting value to `state`, the keys were finally deduplicated. Which is wildly inconsistent behaviour.

The `json` codec was also serializing those duplicate keys, which can lead to problems with JSON parsers rejecting documents with duplicate values.

## Related

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/273)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

main:

```
Throughput   (data): 339.0 MB/s
Throughput (events): 565.1k events/s
```

this PR:

```
Throughput   (data): 331.4 MB/s
Throughput (events): 552.4k events/s
```
