### PR TITLE
Remove dependency on tungstenite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6096,7 +6096,6 @@ dependencies = [
  "tremor-pipeline",
  "tremor-script",
  "tremor-value",
- "tungstenite",
  "url",
  "uuid 1.2.2",
  "value-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,6 @@ async-tungstenite = { version = "0.18.0", features = [
   "async-std-runtime",
   "async-tls",
 ] }
-tungstenite = { version = "0.17.3", features = ["rustls"] }
 
 # for tcp & ws
 async-tls = "0.11"

--- a/src/connectors/tests/ws.rs
+++ b/src/connectors/tests/ws.rs
@@ -26,7 +26,11 @@ use async_std::{
 use async_tls::TlsConnector;
 use async_tungstenite::{
     accept_async, client_async,
-    tungstenite::{stream::MaybeTlsStream, Message, WebSocket},
+    tungstenite::{
+        protocol::{frame::coding::CloseCode, CloseFrame},
+        stream::MaybeTlsStream,
+        Message, WebSocket,
+    },
     WebSocketStream,
 };
 use futures::SinkExt;
@@ -42,7 +46,6 @@ use std::{
 use tremor_common::ports::IN;
 use tremor_pipeline::{Event, EventId};
 use tremor_value::{literal, prelude::*, Value};
-use tungstenite::protocol::{frame::coding::CloseCode, CloseFrame};
 
 /// A minimal websocket test client harness
 struct TestClient<S> {


### PR DESCRIPTION
we get all we need from async_tungstenite


# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


