### PR TITLE
Add forgotten tremor-script-nif to dockerfiles, so shit builds again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ members = [
   "tremor-script",
   "tremor-script-nif",
   "tremor-value",
-
 ]
 
 [profile.release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,6 @@ WORKDIR /app
 
 COPY Cargo.* /app/
 
-# We change lto to 'thin' for docker builds so it
-# can be build on more moderate system
-RUN mv Cargo.toml Cargo.toml.orig && sed 's/lto = true/lto = "thin"/' Cargo.toml.orig > Cargo.toml
-
 # Main library
 COPY src /app/src
 COPY build.rs /app/build.rs
@@ -30,6 +26,7 @@ COPY .cargo /app/.cargo
 # supporting libraries
 COPY tremor-pipeline /app/tremor-pipeline
 COPY tremor-script /app/tremor-script
+COPY tremor-script-nif /app/tremor-script-nif
 COPY tremor-api /app/tremor-api
 COPY tremor-influx /app/tremor-influx
 COPY tremor-value /app/tremor-value

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -24,6 +24,7 @@ COPY src ./src
 # supporting libraries
 COPY tremor-pipeline ./tremor-pipeline
 COPY tremor-script ./tremor-script
+COPY tremor-script-nif /app/tremor-script-nif
 COPY tremor-api ./tremor-api
 COPY tremor-influx ./tremor-influx
 COPY tremor-value ./tremor-value


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


