### PR TITLE
Fix metronome configs

### DIFF
--- a/packaging/distribution/etc/tremor/config/main.troy.sample
+++ b/packaging/distribution/etc/tremor/config/main.troy.sample
@@ -5,9 +5,11 @@ define flow main
 flow
   use tremor::pipelines;
   use bench;
+  use std::time::nanos;
+
   define connector metronome from metronome
   with
-    config = {"interval": 500}
+    config = {"interval": nanos::from_millis(500)}
   end;
   create pipeline main from pipelines::passthrough;
   create connector metronome;

--- a/static/language/epilog/defineconnector.md
+++ b/static/language/epilog/defineconnector.md
@@ -1,9 +1,10 @@
 
 ```tremor
+use std::time::nanos;
 define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_millis(1)
     }
 end;
 ```

--- a/static/language/epilog/defineflow.md
+++ b/static/language/epilog/defineflow.md
@@ -2,10 +2,11 @@
 ```tremor
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_millis(1)
     }
   end;
   define connector exit from exit;

--- a/static/language/epilog/deploy.md
+++ b/static/language/epilog/deploy.md
@@ -2,10 +2,11 @@
 ```tremor
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_seconds(1)
     }
   end;
   define connector exit from exit;

--- a/static/language/epilog/deployflowstmt.md
+++ b/static/language/epilog/deployflowstmt.md
@@ -2,10 +2,11 @@
 ```tremor
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_millis(1)
     }
   end;
   define connector exit from exit;

--- a/tests/flows/_template/flow.troy
+++ b/tests/flows/_template/flow.troy
@@ -1,9 +1,10 @@
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_millis(1)
     }
   end;
   define connector exit from exit;

--- a/tests/flows/args_in_create/flow.troy
+++ b/tests/flows/args_in_create/flow.troy
@@ -22,8 +22,8 @@ flow
   connect /connector/metronome to /pipeline/identity;
   connect /pipeline/identity to /connector/exit;
 end;
-
+use std::time::nanos;
 deploy flow test
 with
-  ival = 1,
+  ival = nanos::from_millis(1),
 end;

--- a/tests/flows/chained_pipelines/flow.troy
+++ b/tests/flows/chained_pipelines/flow.troy
@@ -1,9 +1,10 @@
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_seconds(1)
     }
   end;
   define connector exit from exit;

--- a/tests/flows/pipeline_args/flow.troy
+++ b/tests/flows/pipeline_args/flow.troy
@@ -1,9 +1,10 @@
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_seconds(1)
     }
   end;
   define connector exit from exit;

--- a/tests/flows/pipeline_identity/flow.troy
+++ b/tests/flows/pipeline_identity/flow.troy
@@ -1,9 +1,10 @@
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_millis(1)
     }
   end;
   define connector exit from exit;

--- a/tests/flows/pipeline_with/flow.troy
+++ b/tests/flows/pipeline_with/flow.troy
@@ -1,9 +1,10 @@
 define flow test
 flow
+  use std::time::nanos;
   define connector metronome from metronome
   with
     config = {
-      "interval": 1
+      "interval": nanos::from_seconds(1)
     }
   end;
   define connector exit from exit;

--- a/tremor-cli/tests/fixtures/exit.troy
+++ b/tremor-cli/tests/fixtures/exit.troy
@@ -1,17 +1,22 @@
 define flow exit
 flow
+  use std::time::nanos;
+
   define pipeline p
   pipeline
-  select event from in into out;
+    select event from in into out;
   end;
+
   define connector e from exit;
   define connector m from metronome
   with
-    config = {"interval": 1}
+    config = {"interval": nanos::from_millis(1)}
   end;
+
   create connector e;
   create connector m;
   create pipeline p;
+
   connect /connector/m to /pipeline/p;
   connect /pipeline/p to /connector/e;
 end;

--- a/tremor-cli/tests/integration/metronome/config.troy
+++ b/tremor-cli/tests/integration/metronome/config.troy
@@ -2,10 +2,11 @@ define flow main
 flow
   use tremor::connectors;
   use integration;
+  use std::time::nanos;
 
   define connector metronome from metronome
   with
-    config = {"interval": 500}
+    config = {"interval": nanos::from_millis(500)}
   end;
   
   define pipeline main


### PR DESCRIPTION
They were assuming interval to be milliseconds, although the `interval` is interpreted as nanoseconds.

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* Related [docs PR](https://github.com/tremor-rs/tremor-www/pull/275)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


