### PR TITLE
Update workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,39 +4483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustler"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61e8ddf75de20513455d7b6f17241a595abbb01b53a6340cecc798a1b13422d"
-dependencies = [
- "lazy_static",
- "rustler_codegen",
- "rustler_sys",
-]
-
-[[package]]
-name = "rustler_codegen"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa2e45c0165272070f80ce93bcd7dd5407a3c84a1ef73ab9900e00f00ef3d36"
-dependencies = [
- "heck 0.4.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "rustler_sys"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff26a42e62d538f82913dd34f60105ecfdffbdb25abdc3c3580b0c622285332"
-dependencies = [
- "regex",
- "unreachable",
-]
-
-[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,14 +6125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tremor-script-nif"
-version = "0.13.0-rc.10"
-dependencies = [
- "rustler",
- "tremor-script",
-]
-
-[[package]]
 name = "tremor-value"
 version = "0.13.0-rc.10"
 dependencies = [
@@ -6347,15 +6306,6 @@ checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ members = [
   "tremor-influx",
   "tremor-pipeline",
   "tremor-script",
-  "tremor-script-nif",
   "tremor-value",
 ]
+default-members = ["tremor-cli"]
+exclude = ["tremor-script-nif"]
 
 [profile.release]
 debug = true

--- a/tremor-script-nif/.gitignore
+++ b/tremor-script-nif/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tremor-script-nif/build.rs
+++ b/tremor-script-nif/build.rs
@@ -34,7 +34,7 @@ fn main() {
 
     // Location of libtremor
 
-    let mut libpath = Path::new(&here).join("..").join("target");
+    let mut libpath = Path::new(&here).join("target");
     if host_triple != target_triple {
         libpath = libpath.join(&target_triple);
     }

--- a/tremor-script/rebar.config
+++ b/tremor-script/rebar.config
@@ -6,7 +6,7 @@
 
 {pre_hooks, [
   {"(linux|darwin|solaris|freebsd)", compile,
-        "sh -c \"cd .. && cargo build -p tremor-script-nif --features erlang-float-testing  && cp \\$(cat tremor-script-nif/libpath) tremor-script/priv\""}
+        "sh -c \"cd ../tremor-script-nif && cargo build --features erlang-float-testing && cp \\$(cat libpath) ../tremor-script/priv\""}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
# Pull request

## Description

This updates the workspace in two ways:

1) it sets the default project to `tremor-cli`, so `cargo` run w/o arguments specifying which project to build, will build the CLI (executable) not just the runtime
2) it excludes `tremor-script-nif` from the workspace and instead builds it separately for EQC testing removing the requirement for erlang during normal builds

## Related

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance
-/-