### PR TITLE
Use codecov token to prevent CI issues

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          token: ${{ secrets.CODECOV_TOKEN }} # required because codecov is often broken
           files: ./lcov.txt # optional
           flags: cli${{ matrix.kind }} # optional
           fail_ci_if_error: ${{ github.event_name == 'pull_request' }} # only fail upon pull requests, where coverage is important

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path lcov.txt --features integration
       - uses: codecov/codecov-action@v3
         with:
-          #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          token: ${{ secrets.CODECOV_TOKEN }} # required because codecov is often broken
           files: ./lcov.txt # optional
           flags: unittests # optional
           fail_ci_if_error: ${{ github.event_name == 'pull_request' }} # only fail upon pull requests, where coverage is important


### PR DESCRIPTION
# Pull request

## Description

Use codecov token instead of automatically generated thingy as the automatic generated thingy is buggy and keeps failing the CI see: https://github.com/codecov/codecov-action/issues/837

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-