### PR TITLE
Doc build fix

### DIFF
--- a/.github/workflows/doc-test.yaml
+++ b/.github/workflows/doc-test.yaml
@@ -1,0 +1,22 @@
+name: Check Docs
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1; sudo apt-get clean
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: make docs
+        run: make docs

--- a/tremor-cli/src/doc.rs
+++ b/tremor-cli/src/doc.rs
@@ -154,6 +154,7 @@ fn gen_doc(
     dest_path: Option<&str>,
     path: &Path,
 ) -> Result<()> {
+    eprintln!("Generating docs for {}", path.to_string_lossy());
     let rel_path = rel_path
         .ok_or_else(|| Error::from(format!("Bad relative path: {}", path.to_string_lossy())))?;
     let dest_path = dest_path.ok_or_else(|| Error::from("Bad destination path"))?;

--- a/tremor-script/lib/http/methods.tremor
+++ b/tremor-script/lib/http/methods.tremor
@@ -23,4 +23,4 @@ const CONNECT = "CONNECT";
 const TRACE = "TRACE";
 
 ## The PATCH HTTP method.
-const PATCH = "PATCH";ß
+const PATCH = "PATCH";

--- a/tremor-script/lib/tremor/chash.tremor
+++ b/tremor-script/lib/tremor/chash.tremor
@@ -60,4 +60,3 @@ intrinsic fn jump_with_keys(k1, k2, key, slot_count) as chash::jump_with_keys;
 ##
 ## Returns an `string`
 intrinsic fn sorted_serialize(any) as chash::sorted_serialize;
-


### PR DESCRIPTION
# Pull request

## Description

Fix invalid tremor files that break docs generation and add a CI task to check doc generation before merge

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-