### PR TITLE
Fix parsing RFC3339 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+* Fix parsing with `std::datetime::formats::RFC3339` to allow for `Z` (zulu) timezones.
+
 ### New features
 
 * Add configuration option `path_style_access` to `s3_streamer` and `s3_reader` connectors.

--- a/tremor-cli/tests/stdlib/std/all.tremor
+++ b/tremor-cli/tests/stdlib/std/all.tremor
@@ -815,8 +815,24 @@ test::suite({
       "test": test::assert("datetime::with_timezone", datetime::with_timezone({"timestamp": 0, "tz": datetime::timezones::EUROPE_LONDON}, datetime::timezones::ATLANTIC_JAN_MAYEN), {"timestamp": 0, "tz": datetime::timezones::ATLANTIC_JAN_MAYEN})
     }),
     test::test({
-      "name": "parse",
+      "name": "parse RFC3339",
       "test": test::assert("datetime::parse", datetime::parse("2022-11-09T14:46:11.499274824+01:00", datetime::formats::RFC3339), 1668001571499274824)
+    }),
+    test::test({
+      "name": "parse RFC3339 Z",
+      "test": test::assert("datetime::parse", datetime::parse("2023-04-23T13:11:37.285Z", datetime::formats::RFC3339), 1682255497285000000)
+    }),
+    test::test({
+      "name": "parse RFC2822",
+      "test": test::assert("datetime::parse", datetime::parse("Fri, 21 Nov 1997 09:55:06 -0600", datetime::formats::RFC2822), 880127706000000000)
+    }),
+    test::test({
+      "name": "format RFC2822",
+      "test": test::assert("datetime::format", datetime::format(880127706000000000, datetime::formats::RFC2822), "Fri, 21 Nov 1997 15:55:06 +0000")
+    }),
+    test::test({
+      "name": "format RFC2822 with timezone",
+      "test": test::assert("datetime::format", datetime::format(datetime::with_timezone(880127706000000000, datetime::timezones::US_CENTRAL), datetime::formats::RFC2822), "Fri, 21 Nov 1997 09:55:06 -0600")
     }),
     test::test({
       "name": "year",

--- a/tremor-script/lib/std/datetime/formats.tremor
+++ b/tremor-script/lib/std/datetime/formats.tremor
@@ -5,7 +5,7 @@
 ## Format for [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
 ##
 ## This format is also ISO8601 compatible.
-const RFC3339 = "%Y-%m-%dT%H:%M:%S%.f%:z";
+const RFC3339 = "%+";
 
 ## Format for [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-3.3)
 ##


### PR DESCRIPTION
# Pull request

## Description

Tremor wasn't able to parse RFC3339 timestamps with a zulu `Z` timezone specifier. This PR fixes this.

Example: `"2023-04-23T13:11:37.285Z"`

Reproduce:

```
use std::datetime;
let ts = "2023-04-23T13:11:37.285Z";
datetime::parse(ts, datetime::formats::RFC3339);
```

Thanks @ekarlso for reporting!

## Related

## Checklist



* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


