### PR TITLE
Fix invalid `macro_export` usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub async fn load_troy_file(world: &World, file_name: &str) -> Result<usize> {
 }
 
 /// Logs but ignores an error
-#[macro_export(log_error)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! log_error {
     ($maybe_error:expr,  $($args:tt)+) => (


### PR DESCRIPTION
# Pull request

## Description

This fixes build failure with Rust 1.69+. According to [^1], "the only valid argument is `#[macro_export(local_inner_macros)]` or no argument (`#[macro_export]`)".

The check for invalid `#[macro_export]` arguments was added in rust-lang/rust#107911 and first released in Rust 1.69.0.

[^1]: https://github.com/rust-lang/rust/blob/1.69.0/compiler/rustc_lint_defs/src/builtin.rs#L4129

## Related

* Related Issues: rust-lang/rust#107911

## Checklist

(Please let me know if this needs to be documented in CHANGELOG.)

* [ ] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested (https://github.com/Homebrew/homebrew-core/pull/129863)
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

Not applicable.

