### PR TITLE
Allow Unicode-DFS-2016

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,22 +1,23 @@
 [licenses]
-unlicensed= "deny"
+unlicensed = "deny"
 
 #
 # License types that we explicitly allow
 #
 
 allow = [
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "ISC",
-    "MIT",
-    "Unlicense",
-    "Zlib",
-    "MPL-2.0",
-    "CC0-1.0",
-    "OpenSSL",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "ISC",
+  "MIT",
+  "Unlicense",
+  "Zlib",
+  "MPL-2.0",
+  "CC0-1.0",
+  "OpenSSL",
+  "Unicode-DFS-2016",
 ]
 
 #
@@ -29,16 +30,14 @@ name = "criterion-plot"
 expression = "MIT AND Apache-2.0"
 license-files = [
   { path = "LICENSE-APACHE", hash = 0xa577772b },
-  { path = "LICENSE-MIT", hash = 0x343f7050 }
+  { path = "LICENSE-MIT", hash = 0x343f7050 },
 ]
 
 # This is MIT, Apache, ISC tripple licensed
 [[licenses.clarify]]
 name = "hyper-rustls"
 expression = "MIT AND Apache-2.0 AND ISC"
-license-files = [
-  { path = "LICENSE", hash = 0x3154a1c7 },
-]
+license-files = [{ path = "LICENSE", hash = 0x3154a1c7 }]
 
 # ring has a rather complicated license file, and unfortunately does not
 # provide an SPDX expression in the `license` toml
@@ -52,49 +51,37 @@ name = "ring"
 # compiled into non-test libraries, is included below."
 # OpenSSL - Obviously
 expression = "ISC AND MIT AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 # This is MIT, Apache, ISC tripple licensed
 [[licenses.clarify]]
 expression = "MIT AND Apache-2.0 AND ISC"
 name = "rustls"
-license-files = [
-  { path = "LICENSE", hash = 0xe567c411 },
-]
+license-files = [{ path = "LICENSE", hash = 0xe567c411 }]
 
 # This is MIT, Apache, ISC tripple licensed
 [[licenses.clarify]]
 name = "sct"
 expression = "MIT AND Apache-2.0 AND ISC"
-license-files = [
-  { path = "LICENSE", hash = 0xb7619ae7 },
-]
+license-files = [{ path = "LICENSE", hash = 0xb7619ae7 }]
 
 # ISC style
 [[licenses.clarify]]
 name = "webpki"
 expression = "ISC"
-license-files = [
-  { path = "LICENSE", hash = 0x1c7e6c },
-]
+license-files = [{ path = "LICENSE", hash = 0x1c7e6c }]
 
 # MPL-2.0
 [[licenses.clarify]]
 name = "webpki-roots"
 expression = "MPL-2.0"
-license-files = [
-  { path = "LICENSE", hash = 0x6c919c48 },
-]
+license-files = [{ path = "LICENSE", hash = 0x6c919c48 }]
 
 # This is Zlib
 [[licenses.clarify]]
 name = "adler32"
 expression = "Zlib"
-license-files = [
-  { path = "LICENSE", hash = 0x1e225da6 },
-]
+license-files = [{ path = "LICENSE", hash = 0x1e225da6 }]
 
 
 [advisories]


### PR DESCRIPTION
# Pull request

## Description

the `syn` and `proc-macro` packages rely on the [Unicode-DFS-2016](https://spdx.org/licenses/Unicode-DFS-2016.html) license, they are build time tools and the license looks reasonable enough to allow.

## Related


## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance-/-
