### PR TITLE
Add hygienic error for using strings in path, fixes #2337

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* hygienic errors for strings in path segements
 * axiom stdlib module
 * gcl now supports the `timestamp` metadata overwrite
 

--- a/tests/script_error.rs
+++ b/tests/script_error.rs
@@ -129,6 +129,7 @@ test_cases!(
     pp_cyclic,
     pp_nest_cyclic,
     // INSERT
+    strnig_as_ident,
     sub_overflow,
     mul_overflow,
     add_overflow,

--- a/tests/script_errors/strnig_as_ident/error.txt
+++ b/tests/script_errors/strnig_as_ident/error.txt
@@ -1,0 +1,4 @@
+Error: 
+    1 | event."@timestamp"
+      |       ^ Found the token `"` but expected `<ident>`
+      |         NOTE: Did you mean to quote an ident? If so use ` (a back tick) not " (a quote).

--- a/tests/script_errors/strnig_as_ident/script.tremor
+++ b/tests/script_errors/strnig_as_ident/script.tremor
@@ -1,0 +1,1 @@
+event."@timestamp"

--- a/tremor-script/src/errors.rs
+++ b/tremor-script/src/errors.rs
@@ -351,6 +351,7 @@ impl ErrorKind {
             UnrecognizedToken(outer, inner, t, _) if t.is_empty() && inner.start().absolute() == outer.start().absolute() => Some("It looks like a `;` is missing at the end of the script".into()),
             UnrecognizedToken(_, _, t, _) if t == "##" => Some(format!("`{t}` is as doc comment, it needs to be followed by a statement, did you want to use `#` here?")),
             UnrecognizedToken(_, _, t, _) if t == "default" || t == "case" => Some("You might have a trailing `;` in the prior statement".into()),
+            UnrecognizedToken(_, _, t, l) if t == "\"" && l.contains(&("`<ident>`".to_string())) => Some("Did you mean to quote an ident? If so use ` (a back tick) not \" (a quote).".into()),
             UnrecognizedToken(_, _, t, l) if !matches!(lexer::ident_to_token(t), lexer::Token::Ident(_, _)) && l.contains(&("`<ident>`".to_string())) => Some(format!("It looks like you tried to use '{t}' as an ident, consider quoting it as `{t}` to make it an identifier.")),
             UnrecognizedToken(_, _, t, l) if t == "-" && l.contains(&("`(`".to_string())) => Some("Try wrapping this expression in parentheses `(` ... `)`".into()),
             UnrecognizedToken(_, _, key, options) => {


### PR DESCRIPTION
## Description

Add a hygienic error for using a string as a path element instead of a quoted ident.

## Related

* Related Issues: fixes #2337
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist


* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-