### PR TITLE
Add + for records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Add `+` for `record + record`
 * hygienic errors for strings in path segements
 * axiom stdlib module
 * gcl now supports the `timestamp` metadata overwrite

--- a/static/language/prolog/binadd.md
+++ b/static/language/prolog/binadd.md
@@ -5,5 +5,4 @@ The `BinAdd` rule defines additive operations
 |`+`|Binary addition|
 |`-`|Binary subtraction|
 
-Note that the `+` binary operation is also used for string concatenation.
-
+Note that the `+` binary operation is also used for string concatenation, array concatination and for iserting/overwriting fields in a LHS record from a HRS record.

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -160,6 +160,7 @@ test_cases!(
     empty_array_pattern,
     const_in_const_lookup,
     // INSERT
+    record_add,
     nested_use_with_path,
     multi_use,
     for_comprehension_filter,

--- a/tests/scripts/record_add/in
+++ b/tests/scripts/record_add/in
@@ -1,0 +1,4 @@
+{}
+{"snot": "cake"}
+{"badger": "snot"}
+{"snot": "cake", "badger": "snot"}

--- a/tests/scripts/record_add/out
+++ b/tests/scripts/record_add/out
@@ -1,0 +1,4 @@
+{"snot":"badger"}
+{"snot":"badger"}
+{"badger":"snot","snot":"badger"}
+{"badger":"snot","snot":"badger"}

--- a/tests/scripts/record_add/script.tremor
+++ b/tests/scripts/record_add/script.tremor
@@ -1,0 +1,1 @@
+event + {"snot": "badger"}


### PR DESCRIPTION
# Pull request

## Description

This implements the `+` binary operator for records. It takes the lefthand side record and inserts all keys and values from the righthand side record into it, overwriting. existing values,

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/- net new addition