### PR TITLE
Implement a stripped down version of pulsar producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
  "http",
  "num-bigint 0.4.4",
  "once_cell",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "regex",
  "ring 0.17.5",
@@ -975,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,7 +1107,7 @@ checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
 dependencies = [
  "chrono",
  "serde",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -1504,7 +1510,7 @@ checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
  "base64 0.13.1",
- "hkdf",
+ "hkdf 0.10.0",
  "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.5",
@@ -1552,6 +1558,21 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -1704,6 +1725,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,13 +1787,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version 0.4.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1778,14 +1849,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1815,6 +1911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "data-url"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b319d1b62ffbd002e057f36bebd1f42b9f97927c9577461d855f3513c4289f"
+
+[[package]]
 name = "deadpool"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1943,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1899,6 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1989,10 +2103,48 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.8",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.7",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2019,7 +2171,7 @@ dependencies = [
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "url",
  "void",
 ]
@@ -2030,16 +2182,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "hkdf 0.12.3",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2179,6 +2352,22 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "file-mode"
@@ -2353,6 +2542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2593,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2497,8 +2693,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e3984a414cce451bd6fa931298c2b384924ddc1b6201adec3b0c0c148dabfa"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "tonic",
 ]
 
@@ -2532,7 +2728,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2666,6 +2873,15 @@ checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
  "digest 0.9.0",
  "hmac 0.10.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2917,6 +3133,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2927,6 +3144,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
+ "serde",
 ]
 
 [[package]]
@@ -3060,7 +3278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
 dependencies = [
  "base64 0.12.3",
- "pem",
+ "pem 0.8.3",
  "ring 0.16.20",
  "serde",
  "serde_json",
@@ -3123,6 +3341,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lexical"
@@ -3553,6 +3774,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3806,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3619,6 +3868,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.10",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.8",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3935,38 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openidconnect"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d6050f6a84b81f23c569f5607ad883293e57491036e318fafe6fc4895fadb1"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256 0.13.2",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with 3.4.0",
+ "sha2 0.10.8",
+ "subtle",
+ "thiserror",
+ "url",
+]
 
 [[package]]
 name = "openssl"
@@ -3741,8 +4042,32 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.7",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.7",
+ "primeorder",
  "sha2 0.10.8",
 ]
 
@@ -3847,6 +4172,25 @@ dependencies = [
  "base64 0.13.1",
  "once_cell",
  "regex",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+dependencies = [
+ "base64 0.21.5",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3968,13 +4312,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.8",
+ "pkcs8 0.10.2",
+ "spki 0.7.2",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -3982,6 +4347,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "plotters"
@@ -4073,6 +4444,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.7",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +4538,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -4164,9 +4564,31 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -4185,13 +4607,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -4199,6 +4643,45 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "pulsar"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d21c6a837986cf25d22ac5b951c267d95808f3c830ff009c2879fff259a0268"
+dependencies = [
+ "async-trait",
+ "bit-vec",
+ "bytes",
+ "chrono",
+ "crc",
+ "data-url",
+ "flate2",
+ "futures",
+ "futures-io",
+ "futures-timer",
+ "log",
+ "lz4",
+ "native-tls",
+ "nom 7.1.3",
+ "oauth2",
+ "openidconnect",
+ "pem 3.0.2",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-derive 0.11.9",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "snap",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util 0.7.10",
+ "url",
+ "uuid",
+ "zstd 0.12.4",
+]
 
 [[package]]
 name = "quad-rand"
@@ -4530,9 +5013,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4597,6 +5090,26 @@ name = "route-recognizer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
+
+[[package]]
+name = "rsa"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rust-bert"
@@ -4869,10 +5382,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.8",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4972,6 +5499,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa 1.0.9",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,7 +5559,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64 0.21.5",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.4.0",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -5022,10 +5585,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -5217,6 +5792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-json"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,7 +5977,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -6109,8 +6704,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
@@ -6129,7 +6724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.9.0",
  "quote",
  "syn 1.0.109",
 ]
@@ -6402,7 +6997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6cfab2469df1b6c86199844e008f549cc6b19ca59ef0b43b68b8a62f21d63b"
 dependencies = [
  "async-channel 1.9.0",
- "prost",
+ "prost 0.9.0",
  "tonic",
  "tonic-build",
 ]
@@ -6497,8 +7092,9 @@ dependencies = [
  "port_scanner",
  "pretty_assertions",
  "proptest",
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "pulsar",
  "qwal",
  "rand 0.8.5",
  "rdkafka",
@@ -6884,6 +7480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom 0.2.10",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ indexmap = "2"
 lazy_static = "1"
 log = { version = "0.4", features = ["kv_unstable"] }
 pin-project-lite = "0.2"
+pulsar = { version = "6.1.0", features = [
+  "auth-oauth2",
+  "compression",
+  "tokio-runtime",
+], default-features = false }
 rand = "0.8.5"
 regex = "1.9"
 serde = { version = "1", features = ["derive"] }

--- a/src/connectors/impls.rs
+++ b/src/connectors/impls.rs
@@ -54,6 +54,8 @@ pub(crate) mod ws;
 /// `OpenTelemetry`
 pub(crate) mod otel;
 /// AWS S3 connectors
+pub(crate) mod pulsar;
+/// Apache Pulsar connectors
 pub(crate) mod s3;
 /// std streams connector (stdout, stderr, stdin)
 pub(crate) mod stdio;

--- a/src/connectors/impls/pulsar.rs
+++ b/src/connectors/impls/pulsar.rs
@@ -1,0 +1,77 @@
+// Copyright 2023, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::doc_markdown)]
+//! The Pulsar connectors [`pulsar_consumer`](#pulsar_consumer) and [`pulsar_producer`](#pulsar_producer) provide integration with [Apache Pulsar](https://pulsar.apache.org/) and compatible.
+//! Consuming from Pulsar and producing to Pulsar are handled by two separate connectors.
+//!
+//! ## `pulsar_producer`
+//!
+//! To produce events as pulsar messages, the a connector needs to be defined from the `pulsar_producer` connector type.
+//!
+//! ### Configuration
+//!
+//! It supports the following configuration options:
+//!
+//! | Option            | Description                                                                                                                                                      | Type                           | Required | Default Value                                               |
+//! |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|----------|-------------------------------------------------------------|
+//! | `address`         | URLs to the cluster proxy.
+//! | `topic`           | The topic to produce events to.                                                                                                                                  | string                         | yes      |                                                             |
+//!
+//! Example configuration for `pulsar_producer`:
+//!
+//! ```tremor
+//!     define connector producer from pulsar_producer
+//!     with
+//!         # Enables metrics at a 1 second interval
+//!         metrics_interval_s = 1,
+//!         # event payload is serialized to JSON
+//!         codec = "json",
+//!
+//!         # Pulsar specific producer configuration
+//!         config = {
+//!             # List of broker bootstrap servers
+//!             "address": pulsar://127.0.0.1:6650,
+//!             # the topic to send to
+//!             "topic": "persistent://default/public/tremor_test"
+//!         }
+//!     end;
+//! ```
+//!
+//! ### Event Metadata
+//!
+//! To control how the `pulsar_producer` produces events as pulsar messages, the following metadata options are available:
+//!
+//! ```tremor
+//! let $pulsar_producer = {
+//!     "key": "message_key",   # pulsar message key as string or bytes
+//!     "headers": {            # message headers  
+//!         "my_bytes_header": <<"badger"/binary>>,
+//!         "my_string_header": "string"
+//!     },
+//!     "timestamp": 12345,     # message timestamp
+//!     "partition": 3          # numeric partition id to publish message on
+//! };
+//! ```
+
+use std::time::Duration;
+
+use pulsar::TokioExecutor;
+
+mod client;
+pub(crate) mod producer;
+
+const PULSAR_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub(crate) type PulsarProducer = pulsar::Producer<TokioExecutor>;

--- a/src/connectors/impls/pulsar/client.rs
+++ b/src/connectors/impls/pulsar/client.rs
@@ -1,3 +1,17 @@
+// Copyright 2023, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use dashmap::DashMap;
 use pulsar::{Pulsar, TokioExecutor};
 use tokio::sync::Mutex;

--- a/src/connectors/impls/pulsar/client.rs
+++ b/src/connectors/impls/pulsar/client.rs
@@ -1,0 +1,27 @@
+use dashmap::DashMap;
+use pulsar::{Pulsar, TokioExecutor};
+use tokio::sync::Mutex;
+
+use crate::connectors::prelude::*;
+
+lazy_static! {
+    static ref SINGLETON_LOCK: Mutex<()> = Mutex::new(());
+    static ref PULSAR_CLIENT_SINGLETON: DashMap<String, Pulsar<TokioExecutor>> = DashMap::new();
+}
+
+// TODO: Add other possible configurations
+pub(crate) async fn get_client(url: &str) -> Result<Pulsar<TokioExecutor>> {
+    // Add some contention to unwrap errors properly and not create multiple clients to the same url.
+    let _ = SINGLETON_LOCK.lock().await;
+
+    if PULSAR_CLIENT_SINGLETON.contains_key(url) {
+        return Ok(PULSAR_CLIENT_SINGLETON
+            .get(url)
+            .unwrap_or_else(|| panic!("Client not found for {url:?}"))
+            .clone());
+    }
+
+    let client = Pulsar::builder(url, TokioExecutor).build().await?;
+    PULSAR_CLIENT_SINGLETON.insert(url.to_string(), client.clone());
+    Ok(client)
+}

--- a/src/connectors/impls/pulsar/producer.rs
+++ b/src/connectors/impls/pulsar/producer.rs
@@ -1,0 +1,205 @@
+// Copyright 2023, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! pulsar Producer Connector
+//! Sending events from tremor to a pulsar topic
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use pulsar::{Producer, TokioExecutor};
+use tokio::time::timeout;
+
+use crate::connectors::impls::pulsar::client::get_client;
+use crate::connectors::impls::pulsar::PulsarProducer;
+use crate::connectors::prelude::*;
+use crate::{connectors::impls::pulsar::PULSAR_CONNECT_TIMEOUT, utils::task_id};
+
+const PULSAR_PRODUCER_META_KEY: &str = "pulsar_producer";
+
+#[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Config {
+    /// list of brokers forming a cluster. 1 is enough
+    address: String,
+    /// the topic to send to
+    topic: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProducerConfig {
+    tremor_config: Config,
+    name: String,
+}
+
+impl tremor_config::Impl for Config {}
+
+#[derive(Default, Debug)]
+pub(crate) struct Builder {}
+
+#[async_trait::async_trait]
+impl ConnectorBuilder for Builder {
+    fn connector_type(&self) -> ConnectorType {
+        ConnectorType("pulsar_producer".into())
+    }
+
+    // TODO: Add other possible configurations and metrics
+    async fn build_cfg(
+        &self,
+        alias: &alias::Connector,
+        _config: &ConnectorConfig,
+        raw_config: &Value,
+        _kill_switch: &KillSwitch,
+    ) -> Result<Box<dyn Connector>> {
+        let tremor_config = Config::new(raw_config)?;
+
+        let tid = task_id();
+        let name = format!("tremor-{}-{alias}-{tid}", hostname());
+
+        let config = ProducerConfig {
+            tremor_config,
+            name,
+        };
+
+        Ok(Box::new(PulsarProducerConnector { config }))
+    }
+}
+
+#[derive(Clone)]
+struct PulsarProducerConnector {
+    config: ProducerConfig,
+}
+
+#[async_trait::async_trait()]
+impl Connector for PulsarProducerConnector {
+    async fn create_sink(
+        &mut self,
+        ctx: SinkContext,
+        builder: SinkManagerBuilder,
+    ) -> Result<Option<SinkAddr>> {
+        let sink = PulsarProducerSink::new(self.config.clone());
+        Ok(Some(builder.spawn(sink, ctx)))
+    }
+
+    fn codec_requirements(&self) -> CodecReq {
+        CodecReq::Required
+    }
+}
+
+struct PulsarProducerSink {
+    config: ProducerConfig,
+    producer: Option<PulsarProducer>,
+}
+
+impl PulsarProducerSink {
+    fn new(config: ProducerConfig) -> Self {
+        Self {
+            config,
+            producer: None,
+        }
+    }
+
+    async fn get_producer(&mut self) -> Result<Producer<TokioExecutor>> {
+        let client = get_client(&self.config.tremor_config.address).await?;
+        let producer = client
+            .producer()
+            .with_topic(self.config.tremor_config.topic.clone())
+            .with_name(self.config.name.clone())
+            .build()
+            .await?;
+        Ok(producer)
+    }
+}
+
+#[async_trait::async_trait]
+impl Sink for PulsarProducerSink {
+    async fn on_event(
+        &mut self,
+        _input: &str,
+        event: Event,
+        ctx: &SinkContext,
+        serializer: &mut EventSerializer,
+        _start: u64,
+    ) -> Result<SinkReply> {
+        let producer = self
+            .producer
+            .as_mut()
+            .ok_or_else(|| ErrorKind::ProducerNotAvailable(ctx.alias().to_string()))?;
+
+        let ingest_ns = event.ingest_ns;
+        for (value, meta) in event.value_meta_iter() {
+            let pulsar_meta = meta.get(PULSAR_PRODUCER_META_KEY);
+
+            for payload in serializer.serialize(value, meta, ingest_ns).await? {
+                let mut properties = HashMap::new();
+                let partition_key = pulsar_meta
+                    .get("key")
+                    .and_then(|k| k.as_str())
+                    .map(String::from);
+                if let Some(headers_obj) = pulsar_meta.get_object("headers") {
+                    for (k, v) in headers_obj {
+                        if let Some(value_str) = v.as_str() {
+                            properties.insert(k.to_string(), value_str.to_string());
+                        }
+                    }
+                }
+
+                let message = pulsar::producer::Message {
+                    partition_key,
+                    properties,
+                    payload,
+                    ..Default::default()
+                };
+                producer.send(message).await?;
+            }
+        }
+        Ok(SinkReply::ACK)
+    }
+
+    async fn connect(&mut self, ctx: &SinkContext, _attempt: &Attempt) -> Result<bool> {
+        // enforce cleaning out the previous producer
+        // We might lose some in flight messages in case of failure on the broker side
+
+        if let Some(mut old_producer) = self.producer.take() {
+            old_producer.close().await?;
+            drop(old_producer);
+        };
+
+        info!("{ctx} Connecting pulsar producer");
+        // check if we receive any error callbacks
+        match timeout(PULSAR_CONNECT_TIMEOUT, self.get_producer()).await {
+            Err(timeout) => {
+                return Err(timeout.into());
+            }
+            Ok(Err(pulsar_error)) => Err(pulsar_error.into()),
+            Ok(Ok(producer)) => {
+                self.producer = Some(producer);
+                Ok(true)
+            }
+        }
+    }
+
+    async fn on_stop(&mut self, ctx: &SinkContext) -> Result<()> {
+        if let Some(mut producer) = self.producer.take() {
+            let wait_secs = Duration::from_secs(1);
+            info!("{ctx} Flushing messages. Waiting for {wait_secs:?} seconds.");
+            timeout(wait_secs, producer.close()).await??;
+        }
+        Ok(())
+    }
+
+    fn auto_ack(&self) -> bool {
+        false
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -197,6 +197,7 @@ error_chain! {
         OneShotRecv(tokio::sync::oneshot::error::RecvError);
         ParseFloatError(std::num::ParseFloatError);
         ParseIntError(std::num::ParseIntError);
+        PulsarError(pulsar::Error);
         RegexError(regex::Error);
         ReqwestError(reqwest::Error);
         RustlsError(rustls::Error);

--- a/tremor-cli/tests/integration/pulsar/after.yaml
+++ b/tremor-cli/tests/integration/pulsar/after.yaml
@@ -1,0 +1,6 @@
+dir: "."
+cmd: "docker"
+args:
+  - "rm"
+  - "-f"
+  - "tremor-pulsar"

--- a/tremor-cli/tests/integration/pulsar/assert.yaml
+++ b/tremor-cli/tests/integration/pulsar/assert.yaml
@@ -1,0 +1,17 @@
+status: 0
+name: pulsar_connectors
+asserts:
+  - source: out.log
+    contains:
+     - |
+       {"event":{"batch":true,"number":1},"meta":{"pulsar_consumer":{"headers":{"foo":"YmFy"},"key":"badger","offset":0,"partition":0,"timestamp":null,"topic":"tremor_test"}}}
+     - |
+       {"event":{"batch":true,"number":2},"meta":{"pulsar_consumer":{"headers":null,"key":"snot","offset":0,"partition":1,"timestamp":null,"topic":"tremor_test"}}}
+     - |
+       {"event":{"batch":false,"foo":"bar"},"meta":{"pulsar_consumer":{"headers":null,"key":"snot","offset":1,"partition":1,"timestamp":null,"topic":"tremor_test"}}}
+     - |
+       {"event":{"batch":false},"meta":{"pulsar_consumer":{"headers":null,"key":"snot","offset":2,"partition":1,"timestamp":null,"topic":"tremor_test"}}}
+     - |
+       {"event":{"batch":true,"number":3},"meta":{"pulsar_consumer":{"headers":null,"key":"snot","offset":3,"partition":1,"timestamp":null,"topic":"tremor_test"}}}
+     - |
+       {"event":{"batch":true,"number":4},"meta":{"pulsar_consumer":{"headers":null,"key":"snot","offset":4,"partition":1,"timestamp":null,"topic":"tremor_test"}}}

--- a/tremor-cli/tests/integration/pulsar/before.yaml
+++ b/tremor-cli/tests/integration/pulsar/before.yaml
@@ -1,0 +1,20 @@
+- dir: "."
+  cmd: "docker"
+  args:
+    - "run"
+    - "--name"
+    - "tremor-pulsar"
+    - "-p"
+    - "6650:6650"
+    - "-p"
+    - "18080:8080"
+    - "apachepulsar/pulsar"
+    - "./bin/pulsar"
+    - "standalone"
+
+  await:
+    "port-open":
+      - "6650"
+    "http-ok":
+      - "http://127.0.0.1:18080/admin/brokers/health"
+  max-await-secs: 300

--- a/tremor-cli/tests/integration/pulsar/config.troy
+++ b/tremor-cli/tests/integration/pulsar/config.troy
@@ -1,0 +1,82 @@
+define flow pulsar_produce
+flow
+  use tremor::{connectors, pipelines};
+  use integration;
+
+  define connector producer from pulsar_producer
+  with
+    metrics_interval_s = 1,
+    reconnect = {
+      "retry": {
+        "interval_ms": 3000,
+        "max_retries": 10
+      }
+    },
+    codec = "json",
+    config = {
+      "brokers": [
+        "127.0.0.1:9092",
+      ],
+      "topic": "tremor_test",
+      "key": "snot"
+    }
+  end;
+
+  define pipeline produce
+  pipeline
+    use std::time::nanos;
+
+    define script add_pulsar_meta
+    script
+      let $pulsar_producer = event.meta;
+      emit event["event"]
+    end;
+    create script add_pulsar_meta;
+
+    define operator batch from generic::batch
+    with
+      count = 2,
+      timeout = nanos::from_seconds(1)
+    end;
+    create operator batch;
+
+    select event from in into add_pulsar_meta;
+
+
+    select event from add_pulsar_meta
+    where 
+      match event of
+        case %{ batch == true } => false
+        case _ => true
+      end
+    into out;
+    select event from add_pulsar_meta
+    where 
+      match event of 
+        case %{ batch == true } => true 
+        case _ => false 
+      end 
+    into batch;
+    select event from add_pulsar_meta/err into err;
+
+    select event from batch/err into err;
+    select event from batch into out;
+  end;
+
+
+  create connector read_file from integration::read_file;
+  create connector producer;
+  create connector stderr from connectors::console;
+
+  create pipeline passthrough from pipelines::passthrough;
+  create pipeline produce from produce;
+
+  connect /connector/read_file to /pipeline/produce;
+  connect /connector/read_file/err to /pipeline/passthrough;
+  connect /pipeline/produce/out to /connector/producer;
+  connect /pipeline/produce/err to /connector/stderr/stderr;
+  connect /pipeline/passthrough to /connector/stderr/stderr;
+
+end;
+
+deploy flow pulsar_produce;

--- a/tremor-cli/tests/integration/pulsar/in.json
+++ b/tremor-cli/tests/integration/pulsar/in.json
@@ -1,0 +1,7 @@
+{"event":{"batch": true,"number": 1},"meta": {"key": "badger","partition": 0,"headers": {"foo": "bar"},"timestamp": 123}}
+{"event":{"batch": true,"number": 2},"meta":{"headers": {}, "timestamp": 456}}
+{"event":{"batch": false,"foo": "bar"},"meta": {"key": [1,2,3],"partition": "", "timestamp": 42}}
+{"event":{"batch": false},"meta": {"timestamp":9}}
+{"event":{"batch": true,"number": 3},"meta": {"headers": {}, "timestamp":4}}
+{"event":{"batch": true,"number": 4},"meta": {"headers": {}, "timestamp":0}}
+{"event":"exit","meta":{"key":"foo"}}

--- a/tremor-cli/tests/integration/pulsar/tags.yaml
+++ b/tremor-cli/tests/integration/pulsar/tags.yaml
@@ -1,0 +1,1 @@
+["pulsar", "connector", "docker"]


### PR DESCRIPTION
# Pull request

## Description

This adds an initial support for pulsar's producer.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


