### PR TITLE
Fix missing disconnect in HTTP connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+
+## [Unreleased]
+
+### Fixes
+* fix reconnect issue in HTTP client
+
 ## [0.13.0-rc.17]
-
-
 
 ### New features
 * kafka schema registry codec

--- a/tremor-connectors/src/impls/http/client.rs
+++ b/tremor-connectors/src/impls/http/client.rs
@@ -448,6 +448,8 @@ impl Sink for HttpRequestSink {
                                 "Error sending fail contraflow",
                             );
                         }
+                        // We force a reconnect as otherwise the HTTP library can become stale and never progress when sending failed.
+                        task_ctx.notifier().connection_lost().await?;
                     }
                     Err(e) => {
                         error!("{task_ctx} Error sending HTTP request: {e}");
@@ -457,6 +459,7 @@ impl Sink for HttpRequestSink {
                                 "Error sending fail contraflow",
                             );
                         }
+                        // task_ctx.notifier().connection_lost().await?;
                     }
                 }
                 drop(guard);

--- a/tremor-connectors/tests/http/client.rs
+++ b/tremor-connectors/tests/http/client.rs
@@ -678,7 +678,7 @@ async fn missing_tls_config_https() -> Result<()> {
         .map(|e| e.to_string())
         .unwrap_or_default();
 
-    assert_eq!("[test::test] Invalid definition: missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config.", res);
+    assert_eq!("[harness::test] Invalid definition: missing tls config with 'https' url. Set 'tls' to 'true' or provide a full tls config.", res);
 
     Ok(())
 }

--- a/tremor-connectors/tests/kafka/consumer.rs
+++ b/tremor-connectors/tests/kafka/consumer.rs
@@ -219,7 +219,7 @@ async fn transactional_retry() -> anyhow::Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError(TapeError) at character 0 ('}')",
-            "source": "test::test",
+            "source": "harness::test",
             "stream_id": 8_589_934_592_u64,
             "pull_id": 1u64
         }),
@@ -434,7 +434,7 @@ async fn custom_no_retry() -> anyhow::Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError(TapeError) at character 0 ('}')",
-            "source": "test::test",
+            "source": "harness::test",
             "stream_id": 8_589_934_592_u64,
             "pull_id": 1u64
         }),
@@ -638,7 +638,7 @@ async fn performance() -> anyhow::Result<()> {
     assert_eq!(
         &literal!({
             "error": "SIMD JSON error: InternalError(TapeError) at character 0 ('}')",
-            "source": "test::test",
+            "source": "harness::test",
             "stream_id": 8_589_934_592_u64,
             "pull_id": 1u64
         }),


### PR DESCRIPTION
# Pull request

## Description

Fix an issue where a http client that never connected or lost the connection would become stale and never reconnect.

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-
