### PR TITLE
Bump CI action code coverage versions to fix stalled coverage uploads

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -53,7 +53,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          action: codecov/codecov-action@v4
+          action: codecov/codecov-action@v4.2.0
           attempt_limit: 6
           attempt_delay: 10000
           with: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          action: codecov/codecov-action@v4
+          action: codecov/codecov-action@v4.2.0
           attempt_limit: 6
           attempt_delay: 10000
           with: |
@@ -98,7 +98,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          action: codecov/codecov-action@v4
+          action: codecov/codecov-action@v4.2.0
           attempt_limit: 6
           attempt_delay: 10000
           with: |


### PR DESCRIPTION
## Description

Fix coverage action CI hangs on upload by bumping action version

## Note

No logic changes. This is a CI stability change.

