### PR TITLE
Resolve flaky test harness tests in command and integration suites

### DIFF
--- a/tremor-cli/src/test/assert/contains.txt
+++ b/tremor-cli/src/test/assert/contains.txt
@@ -1,0 +1,2 @@
+snot
+badger

--- a/tremor-cli/tests/cli/command.yml
+++ b/tremor-cli/tests/cli/command.yml
@@ -199,6 +199,17 @@ suites:
               - "Error:"
               - "3 |   emit event.baz"
               - "  |              ^^^ Trying to access a non existing event key `baz`\n\n"
+      - name: setup for tremor new creates 
+        command: rm -rf test
+        tags:
+          - run
+          - new
+        status: 0
+        expects:
+          - source: stdout
+            is_empty: true
+          - source: stderr
+            is_empty: true
       - name: tremor new creates 
         command: tremor new test
         tags:

--- a/tremor-cli/tests/integration/elastic-verify-gd/assert.yaml
+++ b/tremor-cli/tests/integration/elastic-verify-gd/assert.yaml
@@ -2,9 +2,57 @@ status: 0
 name: elastic-verify-gd
 asserts:
   - source: err.log
-    equals_file: expected_err.json
+    contains: 
+      - |
+        {"action":"index","correlation":"tons","index":"my_little_index","payload":{"action":null,"cause":"this one has a different type underneath the same key and thus will fail elastic","snot":"tons","tremor":12},"success":false}
+  - source: err.log
+    contains: 
+      - |
+        {"action":"index","correlation":"baz","index":"my_little_index","payload":{"action":null,"cause":"this one has a different type underneath the same key and thus will fail elastic","snot":"baz","tremor":12},"success":false}
   - source: ok.log
-    equals_file: expected_ok.json
+    contains:  
+      - |
+        {"action":"index","correlation":"badger","index":"my_little_index","payload":{"action":null,"snot":"badger"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"foo","index":"my_little_index","payload":{"action":null,"snot":"foo"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"racoon","index":"my_little_index","payload":{"action":null,"snot":"racoon","tremor":[true,true,true,false]},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"bar","index":"my_little_index","payload":{"action":null,"snot":"bar","tremor":[true,true,true,false]},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"delete","correlation":"badger","index":"my_little_index","payload":{"action":"delete","doc_id":"badger","snot":"badger"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"delete","correlation":"fop","index":"my_little_index","payload":{"action":"delete","doc_id":"badger","snot":"fop"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"badger","index":"my_little_index","payload":{"action":"index","doc_id":"badger","snot":"badger"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"snoop","index":"my_little_index","payload":{"action":"index","doc_id":"badger","snot":"snoop"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"update","correlation":"badger","index":"my_little_index","payload":{"action":"update","doc_id":"badger","snot":"badger"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"update","correlation":"dogg","index":"my_little_index","payload":{"action":"update","doc_id":"badger","snot":"dogg"},"success":true}
+  - source: ok.log
+    contains:  
+      - |
+        {"action":"index","correlation":"badger","index":"my_little_index","payload":{"action":null,"snot":"badger"},"success":true}
   - source: fg.err.log
     contains:
       - |


### PR DESCRIPTION
## Description

Small fixes to file based assertions ( adds is_empty, is_not_empty predicates ) and
fixes to `elastic-verify-gd` to resolve assertion failures when running the test harness
in CI mode.

## Checklist

No change to production / critical code.

## Performance

No impact

## Note

This is in part a hedge to remove any potential impact to flaky CI coverage runs. No freezes, hangs or
odd stalls when running locally as follows:

```
cargo llvm-cov run --lcov --output-path integration_lcov.txt -- test --timeout 300 integration tremor-cli/tests --report integration.json 
cargo llvm-cov run --lcov --output-path command_lcov.txt -- test --timeout 300 command tremor-cli/tests --report command.json 
cargo llvm-cov run --lcov --output-path unit_lcov.txt -- test --timeout 300 unit tremor-cli/tests --report unit.json 
```

The mystery deepens!


