### PR TITLE
Add support for brotli compression and decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### New features
 * add collect postprocessor
 * add support for access tokens for aws connectors
+* add support for brotli compression
 
 ### Fixes
 * fix reconnect issue in HTTP client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1101,27 @@ checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
 dependencies = [
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "brotli"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -6615,6 +6651,7 @@ name = "tremor-interceptor"
 version = "0.13.0-rc.22"
 dependencies = [
  "anyhow",
+ "brotli",
  "byteorder",
  "bytes",
  "libflate",

--- a/tremor-interceptor/Cargo.toml
+++ b/tremor-interceptor/Cargo.toml
@@ -18,11 +18,6 @@ tremor-config = { path = "../tremor-config", version = "0.13.0-rc.22" }
 tremor-common = { path = "../tremor-common", version = "0.13.0-rc.22" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-libflate = "2"
-xz2 = "0.1"
-lz4 = "1"
-snap = "1"
-zstd = "0.13"
 byteorder = "1"
 value-trait = "0.8"
 rand = "0.8"
@@ -30,6 +25,14 @@ bytes = "1.5.0"
 memchr = "2.6"
 anyhow = { version = "1.0", default-features = true }
 thiserror = { version = "1.0", default-features = false }
+
+# Compression
+brotli = { version = "5", default-features = false, features = ["std"] }
+xz2 = "0.1"
+lz4 = "1"
+snap = "1"
+zstd = "0.13"
+libflate = "2"
 
 [dev-dependencies]
 proptest = "1.4"


### PR DESCRIPTION
# Pull request

## Description

Brotli is a modern compression with a focus on HTTP, it's nice to support it. it's worth mentioning that brotli has [no magic bytes](https://github.com/google/brotli/issues/298) so we can not autodetect it.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-

