### PR TITLE
Revert "Bump prost from 0.9.0 to 0.12.4"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e3984a414cce451bd6fa931298c2b384924ddc1b6201adec3b0c0c148dabfa"
 dependencies = [
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "tonic",
 ]
@@ -4222,17 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
-dependencies = [
- "bytes",
- "prost-derive 0.12.4",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4248,7 +4238,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "regex",
  "tempfile",
@@ -4269,26 +4259,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -6183,8 +6160,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
@@ -6548,7 +6525,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "log",
- "prost 0.12.4",
+ "prost",
  "prost-types",
  "serde",
  "simd-json",
@@ -6674,7 +6651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6cfab2469df1b6c86199844e008f549cc6b19ca59ef0b43b68b8a62f21d63b"
 dependencies = [
  "async-channel 1.9.0",
- "prost 0.9.0",
+ "prost",
  "tonic",
  "tonic-build",
 ]

--- a/tremor-connectors-gcp/Cargo.toml
+++ b/tremor-connectors-gcp/Cargo.toml
@@ -33,7 +33,7 @@ googapis = { version = "0.6", default-features = true, features = [
     "google-storage-v2",
 ] }
 gouth = { version = "0.2", default-features = true }
-prost = { version = "0.12.4", default-features = true }
+prost = { version = "0.9.0", default-features = true }
 prost-types = { version = "0.9.0", default-features = true }
 tokio = { version = "1.34", default-features = true }
 tonic = { version = "0.6.1", default-features = true, features = [


### PR DESCRIPTION
This was wrongfully merged because one of the tests was no longer mandatory (this is now fixed)