### PR TITLE
Fix interceptor finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 * fix reconnect issue in HTTP client
+* fix issue where post and preprocessors that hold state might not finalize correctly
 
 ## [0.13.0-rc.17]
 

--- a/tremor-interceptor/Cargo.toml
+++ b/tremor-interceptor/Cargo.toml
@@ -20,19 +20,49 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 byteorder = "1"
 value-trait = "0.8"
-rand = "0.8"
-bytes = "1.5.0"
 memchr = "2.6"
 anyhow = { version = "1.0", default-features = true }
 thiserror = { version = "1.0", default-features = false }
 
+#gelf
+rand = { version = "0.8", optional = true, default-features = false, features = [
+] }
+
 # Compression
-brotli = { version = "5", default-features = false, features = ["std"] }
-xz2 = "0.1"
-lz4 = "1"
-snap = "1"
-zstd = "0.13"
-libflate = "2"
+brotli = { version = "5", optional = true, default-features = false, features = [
+    "std",
+] }
+xz2 = { version = "0.1", optional = true, default-features = false, features = [
+] }
+lz4 = { version = "1", optional = true, default-features = false, features = [
+] }
+snap = { version = "1", optional = true, default-features = false, features = [
+] }
+zstd = { version = "0.13", optional = true, default-features = false, features = [
+] }
+libflate = { version = "2", optional = true, default-features = false, features = [
+    "std",
+] }
+
+# Length Prefix
+bytes = { version = "1.5.0", optional = true, default-features = false, features = [
+] }
+
 
 [dev-dependencies]
 proptest = "1.4"
+
+
+[features]
+default = ["base64", "compression", "gelf", "length-prefix"]
+length-prefix = ["dep:bytes"]
+gelf = ["dep:rand"]
+base64 = []
+compression = [
+    "dep:brotli",
+    "dep:xz2",
+    "dep:lz4",
+    "dep:snap",
+    "dep:zstd",
+    "dep:libflate",
+]

--- a/tremor-interceptor/src/postprocessor/base64.rs
+++ b/tremor-interceptor/src/postprocessor/base64.rs
@@ -14,22 +14,34 @@
 
 //! Encodes raw data into base64 encoded bytes.
 
-use super::Postprocessor;
+use super::StatelessPostprocessor;
 use tremor_common::base64;
 
 #[derive(Default)]
 pub(crate) struct Base64 {}
-impl Postprocessor for Base64 {
+impl StatelessPostprocessor for Base64 {
     fn name(&self) -> &str {
         "base64"
     }
 
-    fn process(
-        &mut self,
-        _ingres_ns: u64,
-        _egress_ns: u64,
-        data: &[u8],
-    ) -> anyhow::Result<Vec<Vec<u8>>> {
+    fn process(&self, data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
         Ok(vec![base64::encode(data).as_bytes().to_vec()])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn base64() -> anyhow::Result<()> {
+        let post = Base64 {};
+        let data: [u8; 0] = [];
+
+        assert_eq!(post.process(&data).ok(), Some(vec![vec![]]));
+
+        assert_eq!(post.process(b"\n").ok(), Some(vec![b"Cg==".to_vec()]));
+
+        assert_eq!(post.process(b"snot").ok(), Some(vec![b"c25vdA==".to_vec()]));
+        Ok(())
     }
 }

--- a/tremor-interceptor/src/postprocessor/gelf_chunking.rs
+++ b/tremor-interceptor/src/postprocessor/gelf_chunking.rs
@@ -82,10 +82,18 @@ impl Postprocessor for Gelf {
     fn process(
         &mut self,
         _ingest_ns: u64,
-        _egest_ns: u64,
+        _egress_ns: u64,
         data: &[u8],
     ) -> anyhow::Result<Vec<Vec<u8>>> {
         Ok(self.encode_gelf(data)?)
+    }
+
+    fn finish(&mut self, data: Option<&[u8]>) -> anyhow::Result<Vec<Vec<u8>>> {
+        if let Some(data) = data {
+            Ok(self.encode_gelf(data)?)
+        } else {
+            Ok(vec![])
+        }
     }
 }
 

--- a/tremor-interceptor/src/postprocessor/length_prefixed.rs
+++ b/tremor-interceptor/src/postprocessor/length_prefixed.rs
@@ -18,21 +18,16 @@ use std::io::Write;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-use super::Postprocessor;
+use super::StatelessPostprocessor;
 
 #[derive(Clone, Default)]
 pub(crate) struct LengthPrefixed {}
-impl Postprocessor for LengthPrefixed {
+impl StatelessPostprocessor for LengthPrefixed {
     fn name(&self) -> &str {
         "length-prefix"
     }
 
-    fn process(
-        &mut self,
-        _ingres_ns: u64,
-        _egress_ns: u64,
-        data: &[u8],
-    ) -> anyhow::Result<Vec<Vec<u8>>> {
+    fn process(&self, data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
         let mut res = Vec::with_capacity(data.len() + 8);
         res.write_u64::<BigEndian>(data.len() as u64)?;
         res.write_all(data)?;

--- a/tremor-interceptor/src/preprocessor/textual_length_prefixed.rs
+++ b/tremor-interceptor/src/preprocessor/textual_length_prefixed.rs
@@ -69,3 +69,142 @@ impl Preprocessor for TextualLengthPrefixed {
         Ok(res)
     }
 }
+
+#[cfg(test)]
+mod test {
+    #![allow(clippy::ignored_unit_patterns)]
+    use crate::postprocessor::{self, Postprocessor};
+
+    use super::*;
+    use proptest::prelude::*;
+
+    fn textual_prefix(len: usize) -> String {
+        format!("{len} {}", String::from_utf8_lossy(&vec![b'O'; len]))
+    }
+
+    // generate multiple chopped length-prefixed strings
+    fn multiple_textual_lengths(max_elements: usize) -> BoxedStrategy<(Vec<usize>, Vec<String>)> {
+        proptest::collection::vec(".+", 1..max_elements) // generator for Vec<String> of arbitrary strings, maximum length of vector: `max_elements`
+            .prop_map(|ss| {
+                let s: (Vec<usize>, Vec<String>) = ss
+                    .into_iter()
+                    .map(|s| (s.len(), format!("{} {s}", s.len()))) // for each string, extract the length, and create a textual length prefix
+                    .unzip();
+                s
+            })
+            .prop_map(|tuple| (tuple.0, tuple.1.join(""))) // generator for a tuple of 1. the sizes of the length prefixed strings, 2. the concatenated length prefixed strings as one giant string
+            .prop_map(|tuple| {
+                // here we chop the big string into up to 4 bits
+                let mut chopped = Vec::with_capacity(4);
+                let mut giant_string: String = tuple.1.clone();
+                while !giant_string.is_empty() && chopped.len() < 4 {
+                    // verify we are at a char boundary
+                    let mut indices = giant_string.char_indices();
+                    let num_chars = giant_string.chars().count();
+                    if let Some((index, _)) = indices.nth(num_chars / 2) {
+                        let mut splitted = giant_string.split_off(index);
+                        std::mem::swap(&mut splitted, &mut giant_string);
+                        chopped.push(splitted);
+                    } else {
+                        break;
+                    }
+                }
+                chopped.push(giant_string);
+                (tuple.0, chopped)
+            })
+            .boxed()
+    }
+
+    proptest! {
+        #[test]
+        fn textual_length_prefix_prop((lengths, datas) in multiple_textual_lengths(5)) {
+            let mut pre_p = TextualLengthPrefixed::default();
+            let mut in_ns = 0_u64;
+            let res: Vec<_> = datas.into_iter().flat_map(|data| {
+                pre_p.process(&mut in_ns, data.as_bytes(), Value::object()).unwrap_or_default()
+            }).collect();
+            assert_eq!(lengths.len(), res.len());
+            for (processed, expected_len) in res.iter().zip(lengths) {
+                assert_eq!(expected_len, processed.0.len());
+            }
+        }
+
+        #[test]
+        fn textual_length_pre_post(length in 1..100_usize) {
+            let data = vec![1_u8; length];
+            let mut pre_p = TextualLengthPrefixed::default();
+            let mut post_p = postprocessor::textual_length_prefixed::TextualLengthPrefixed::default();
+            let encoded = post_p.process(0, 0, &data).unwrap_or_default().pop().unwrap_or_default();
+            let mut in_ns = 0_u64;
+            let mut res = pre_p.process(&mut in_ns, &encoded, Value::object()).unwrap_or_default();
+            assert_eq!(1, res.len());
+            let payload = res.pop().unwrap_or_default().0;
+            assert_eq!(length, payload.len());
+        }
+    }
+
+    #[test]
+    fn textual_prefix_length_loop() {
+        let datas = vec![
+                "24 \'?\u{d617e}ѨR\u{202e}\u{f8f7c}\u{ede29}\u{ac784}36 ?{¥?MȺ\r\u{bac41}9\u{5bbbb}\r\u{1c46c}\u{4ba79}¥\u{7f}*?:\u{0}$i",
+                "60 %\u{a825a}\u{a4269}\u{39e0c}\u{b3e21}<ì\u{f6c20}ѨÛ`HW\u{9523f}V",
+                "\u{3}\u{605fe}%Fq\u{89b5e}\u{93780}Q3",
+                "¥?\u{feff}9",
+                " \'�2\u{4269b}",
+            ];
+        let lengths: Vec<usize> = vec![24, 36, 60, 9];
+        let mut pre_p = TextualLengthPrefixed::default();
+        let mut in_ns = 0_u64;
+        let res: Vec<_> = datas
+            .into_iter()
+            .flat_map(|data| {
+                pre_p
+                    .process(&mut in_ns, data.as_bytes(), Value::object())
+                    .unwrap_or_default()
+            })
+            .collect();
+        assert_eq!(lengths.len(), res.len());
+        for (processed, expected_len) in res.iter().zip(lengths) {
+            assert_eq!(expected_len, processed.0.len());
+        }
+    }
+
+    #[test]
+    fn textual_length_prefix() {
+        let mut pre_p = TextualLengthPrefixed::default();
+        let data = textual_prefix(42);
+        let mut in_ns = 0_u64;
+        let mut res = pre_p
+            .process(&mut in_ns, data.as_bytes(), Value::object())
+            .unwrap_or_default();
+        assert_eq!(1, res.len());
+        let payload = res.pop().unwrap_or_default().0;
+        assert_eq!(42, payload.len());
+    }
+
+    #[test]
+    fn empty_textual_prefix() {
+        let data = ("").as_bytes();
+        let mut pre_p = TextualLengthPrefixed::default();
+        let mut post_p = postprocessor::textual_length_prefixed::TextualLengthPrefixed::default();
+        let mut in_ns = 0_u64;
+        let res = pre_p
+            .process(&mut in_ns, data, Value::object())
+            .unwrap_or_default();
+        assert_eq!(0, res.len());
+
+        let data_empty = vec![];
+        let encoded = post_p
+            .process(42, 23, &data_empty)
+            .unwrap_or_default()
+            .pop()
+            .unwrap_or_default();
+        assert_eq!("0 ", String::from_utf8_lossy(&encoded));
+        let mut res2 = pre_p
+            .process(&mut in_ns, &encoded, Value::object())
+            .unwrap_or_default();
+        assert_eq!(1, res2.len());
+        let payload = res2.pop().unwrap_or_default().0;
+        assert_eq!(0, payload.len());
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

Fix a bug where having stateful and statless interceptors mixed could lead to loosing data during the finalisaztion step.

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

-/-