### PR TITLE
Fix http client finalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6616,6 +6616,7 @@ version = "0.13.0-rc.24"
 dependencies = [
  "anyhow",
  "async-compression",
+ "async-stream",
  "async-trait",
  "base64 0.22.1",
  "beef",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,7 +6638,6 @@ dependencies = [
  "hdrhistogram",
  "hostname 0.4.0",
  "http 1.1.0",
- "http-body 1.0.0",
  "http-body-util",
  "http-types",
  "hyper 1.3.1",

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -20,7 +20,7 @@ tremor-system = { path = "../tremor-system", version = "0.13.0-rc.24" }
 tokio = { version = "1.34", default-features = false }
 beef = { version = "0.5", default-features = false }
 value-trait = { version = "0.8", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3.30", default-features = false, features = ["std"] }
 halfbrown = { version = "0.2", default-features = false }
 simd-json = { version = "0.13", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -95,6 +95,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 ] }
 base64 = { version = "0.22", optional = true, default-features = false }
 dashmap = { version = "5.5", optional = true, default-features = false }
+async-stream = { version = "0.3", optional = true, default-features = false }
 
 # kafka
 rdkafka = { version = "0.36", optional = true, features = [
@@ -167,7 +168,7 @@ bytes = "1.0"
 tempfile = { version = "3.8", default-features = false }
 env_logger = "0.11"
 tremor-connectors-test-helpers = { path = "../tremor-connectors-test-helpers", version = "0.13.0-rc.24" }
-tide = { version = "0.16", default-features = false }      # TODO remove tide from TestHttpServer
+tide = { version = "0.16", default-features = false } # TODO remove tide from TestHttpServer
 tokio = { version = "1.34", default-features = false, features = [
     "full",
     "test-util",
@@ -231,6 +232,7 @@ http = [
     "dep:hyper",
     "dep:mime",
     "dep:reqwest",
+    "dep:async-stream",
     "hyper/http1",
     "hyper/http2",
     "tls",

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -86,7 +86,6 @@ hyper-rustls = { version = "0.27", optional = true, default-features = false, fe
     "http2",
     "ring",
 ] }
-http-body = { version = "1", optional = true, default-features = false }
 http-body-util = { version = "0.1", optional = true, default-features = false }
 mime = { version = "0.3", optional = true, default-features = false }
 reqwest = { version = "0.11", optional = true, default-features = false, features = [
@@ -225,7 +224,6 @@ http = [
     "dep:dashmap",
     "dep:gouth",
     "dep:http",
-    "dep:http-body",
     "dep:http-body-util",
     "dep:hyper-rustls",
     "dep:hyper-util",

--- a/tremor-connectors/src/impls/http.rs
+++ b/tremor-connectors/src/impls/http.rs
@@ -206,3 +206,20 @@ pub mod meta;
 pub mod server;
 /// HTTP utils
 pub(crate) mod utils;
+
+/// HTTP Connector Errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Invalid HTTP Method
+    #[error("Invalid HTTP Method")]
+    InvalidMethod,
+    /// Invalid HTTP URL
+    #[error("Invalid HTTP URL")]
+    InvalidUrl,
+    /// Request already consumed
+    #[error("Request already consumed")]
+    RequestAlreadyConsumed,
+    /// Response already consumed
+    #[error("Response already consumed")]
+    ResponseAlreadyConsumed,
+}

--- a/tremor-connectors/src/impls/http.rs
+++ b/tremor-connectors/src/impls/http.rs
@@ -196,6 +196,12 @@
 //! Setting the `$correlation` metadata on an outbound request will result in the response
 //! being tagged with the `$correlation` value set in the corresponding request.
 
+use std::{convert::Infallible, pin::Pin};
+
+use futures::Stream;
+use http_body_util::StreamBody;
+use hyper::body::{Bytes, Frame};
+
 /// HTTP auth helper
 pub mod auth;
 /// HTTP client connector
@@ -206,6 +212,10 @@ pub mod meta;
 pub mod server;
 /// HTTP utils
 pub(crate) mod utils;
+
+pub(crate) type StreamingBody = StreamBody<
+    Pin<Box<dyn Stream<Item = Result<Frame<Bytes>, Infallible>> + Send + Sync + 'static>>,
+>;
 
 /// HTTP Connector Errors
 #[derive(Debug, thiserror::Error)]

--- a/tremor-connectors/src/impls/http/client.rs
+++ b/tremor-connectors/src/impls/http/client.rs
@@ -26,14 +26,12 @@ use crate::{
     utils::{mime::MimeCodecMap, tls::TLSClientConfig},
 };
 use either::Either;
-use futures::Stream;
 use halfbrown::HashMap;
 use http::{
     header::{self, HeaderName},
     Uri,
 };
 use http_body_util::{BodyExt, StreamBody};
-use hyper::body::{Bytes, Frame};
 use hyper::{Method, Request};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::{
@@ -43,7 +41,6 @@ use hyper_util::{
 use serde::{Deserialize, Deserializer};
 use std::{
     convert::Infallible,
-    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -59,11 +56,11 @@ use tremor_config::NameWithConfig;
 use tremor_system::qsize;
 use tremor_value::prelude::*;
 
-use super::meta::{consolidate_mime, content_type, HeaderValueValue};
+use super::{
+    meta::{consolidate_mime, content_type, HeaderValueValue},
+    StreamingBody,
+};
 
-pub(crate) type StreamingBody = StreamBody<
-    Pin<Box<dyn Stream<Item = Result<Frame<Bytes>, Infallible>> + Send + Sync + 'static>>,
->;
 type StreamingRequest = Request<StreamingBody>;
 
 //  pipeline -> Sink -> http client

--- a/tremor-connectors/src/impls/http/server.rs
+++ b/tremor-connectors/src/impls/http/server.rs
@@ -709,7 +709,7 @@ impl std::fmt::Debug for RawRequestData {
             .field("data", &self.data)
             .field("request_meta", &self.request_meta)
             .field("content_type", &self.content_type)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/tremor-connectors/src/impls/http/server.rs
+++ b/tremor-connectors/src/impls/http/server.rs
@@ -673,9 +673,7 @@ impl SinkResponse {
         Ok(())
     }
 
-    pub(super) fn take_response(
-        &mut self,
-    ) -> Result<Response<BodyStream<Body>>, super::meta::Error> {
+    pub(super) fn take_response(&mut self) -> Result<Response<BodyStream<Body>>, super::Error> {
         let mut data = Vec::new();
 
         // drain the channel
@@ -686,11 +684,11 @@ impl SinkResponse {
         let builder = self
             .builder
             .take()
-            .ok_or(super::meta::Error::ResponseAlreadyConsumed)?;
+            .ok_or(super::Error::ResponseAlreadyConsumed)?;
         let body_stream = BodyStream::new(body_from_bytes(data));
         let response = builder
             .body(body_stream)
-            .map_err(|_| super::meta::Error::ResponseAlreadyConsumed)?;
+            .map_err(|_| super::Error::ResponseAlreadyConsumed)?;
         Ok(response)
     }
 

--- a/tremor-connectors/src/impls/http/utils.rs
+++ b/tremor-connectors/src/impls/http/utils.rs
@@ -13,25 +13,6 @@
 // limitations under the License.
 
 use either::Either;
-use http_body_util::Full;
-use hyper::body::Bytes;
-
-/// We re-use Full from `http_body_util` crate which is a wrapper around
-/// `hyper::body::Bytes` and implements `http_body::Body` trait. This
-/// avoids introducing our own Body type
-pub(crate) type Body = Full<Bytes>;
-
-/// An empty body
-#[must_use]
-pub(crate) fn empty_body() -> Body {
-    Full::new(Bytes::new())
-}
-
-/// Create a new body from bytes
-#[must_use]
-pub(crate) fn body_from_bytes(bytes: Vec<u8>) -> Body {
-    Full::new(Bytes::from(bytes))
-}
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(transparent)]

--- a/tremor-connectors/tests/http/client.rs
+++ b/tremor-connectors/tests/http/client.rs
@@ -717,7 +717,7 @@ async fn missing_config() -> Result<()> {
         .map(|e| e.to_string())
         .unwrap_or_default();
 
-    assert!(dbg!(res).contains("Missing Configuration"));
+    assert!(res.contains("Missing Configuration"));
 
     Ok(())
 }


### PR DESCRIPTION
# Pull request

## Description

- Fix missing finalize in http client
- move http client to streaming body 
- move http server to streaming body

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


