### PR TITLE
Bump testcontainers dep version for connectors tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,13 +1092,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.42.0-rc.3"
+name = "bollard"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-named-pipe",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "hyperlocal-next",
+ "log",
+ "pin-project-lite 0.2.14",
+ "rustls 0.22.4",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded 0.7.1",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.11",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.44.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
 dependencies = [
  "serde",
- "serde_with",
+ "serde_repr",
+ "serde_with 3.8.1",
 ]
 
 [[package]]
@@ -1236,6 +1276,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
@@ -1769,8 +1810,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -1788,14 +1839,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core 0.20.8",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1913,7 +1989,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1935,6 +2020,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1968,6 +2065,29 @@ name = "distance"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9d8664cf849d7d0f3114a3a387d2f5e4303176d746d5a951aaddc66dfe9240"
+
+[[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.5.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -2023,7 +2143,7 @@ dependencies = [
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "url",
  "void",
 ]
@@ -2957,6 +3077,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite 0.2.14",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,7 +3117,9 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
+ "log",
  "rustls 0.22.4",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -3050,6 +3187,21 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite 0.2.14",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3125,6 +3277,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3135,6 +3288,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -3932,6 +4086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,6 +4178,31 @@ dependencies = [
  "redox_syscall 0.5.1",
  "smallvec",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06af5f9333eb47bd9ba8462d612e37a8328a5cb80b13f0af4de4c3b89f52dee5"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9252f259500ee570c75adcc4e317fa6f57a1e47747d622e0bf838002a7b790"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4854,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8792cccdf842159ef04a35f247df68ccc42192e9a67e389e6cd0f1a83970a6a0"
 dependencies = [
  "cached-path",
- "dirs",
+ "dirs 4.0.0",
  "half",
  "lazy_static",
  "ordered-float 3.9.2",
@@ -5316,6 +5501,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,7 +5542,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.8.1",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -5355,10 +5569,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling 0.20.8",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5806,6 +6032,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6092,19 +6341,25 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.15.0"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
+checksum = "69d47265a44d1035a322691cf0a6cc227d79b62ef86ffb0dbc204b394fee3d07"
 dependencies = [
+ "async-trait",
+ "bollard",
  "bollard-stubs",
+ "dirs 5.0.1",
+ "dns-lookup",
+ "docker_credential",
  "futures",
- "hex",
- "hmac 0.12.1",
  "log",
- "rand 0.8.5",
+ "parse-display",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "serde_with 3.8.1",
+ "tokio",
+ "tokio-util 0.7.11",
+ "url",
 ]
 
 [[package]]

--- a/tremor-connectors-aws/Cargo.toml
+++ b/tremor-connectors-aws/Cargo.toml
@@ -38,7 +38,7 @@ aws-credential-types = { version = "1", default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false }
-testcontainers = { version = "0.15", default-features = false }
+testcontainers = { version = "0.16", default-features = false }
 serial_test = { version = "3.0", default-features = false }
 bytes = { version = "1.1", default-features = true }
 tremor-connectors-test-helpers = { path = "../tremor-connectors-test-helpers", version = "0.13.0-rc.25" }

--- a/tremor-connectors-aws/tests/aws.rs
+++ b/tremor-connectors-aws/tests/aws.rs
@@ -26,7 +26,7 @@ use std::{
     collections::{HashMap, HashSet},
     time::{Duration, Instant},
 };
-use testcontainers::{clients::Cli, Container, GenericImage, RunnableImage};
+use testcontainers::{Cli, Container, GenericImage, RunnableImage};
 use tremor_connectors_test_helpers::free_port::find_free_tcp_port;
 
 const IMAGE: &str = "minio/minio";

--- a/tremor-connectors-aws/tests/aws/reader.rs
+++ b/tremor-connectors-aws/tests/aws/reader.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 use aws_sdk_s3::{primitives::ByteStream, Client};
 use serial_test::serial;
-use testcontainers::clients;
 use tremor_connectors::harness::Harness;
 use tremor_connectors_aws::s3;
 use tremor_value::{literal, Value};

--- a/tremor-connectors-aws/tests/aws/reader.rs
+++ b/tremor-connectors-aws/tests/aws/reader.rs
@@ -50,8 +50,7 @@ async fn connector_s3_no_connection() -> anyhow::Result<()> {
 async fn connector_s3_no_credentials() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-credentials");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     // ensure that we can create the bucket
     let mut env = EnvHelper::new();
@@ -85,8 +84,7 @@ async fn connector_s3_no_credentials() -> anyhow::Result<()> {
 async fn connector_s3_no_region() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-region");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
     create_bucket(&bucket_name, http_port).await?;
@@ -118,8 +116,7 @@ async fn connector_s3_no_region() -> anyhow::Result<()> {
 async fn connector_s3_no_bucket() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-bucket");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
 
@@ -149,8 +146,7 @@ async fn connector_s3_reader() -> anyhow::Result<()> {
     static HUGE_FILE: [u8; 4096] = [b'Z'; 4096];
     let bucket_name = random_bucket_name("tremor");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
     create_bucket(&bucket_name, http_port).await?;

--- a/tremor-connectors-aws/tests/aws/streamer.rs
+++ b/tremor-connectors-aws/tests/aws/streamer.rs
@@ -22,7 +22,6 @@ use rand::{distributions::Alphanumeric, Rng};
 use serial_test::serial;
 use std::io::Read;
 use std::time::Duration;
-use testcontainers::clients;
 use tokio::time::timeout;
 use tremor_common::ports::IN;
 use tremor_connectors::harness::Harness;

--- a/tremor-connectors-aws/tests/aws/streamer.rs
+++ b/tremor-connectors-aws/tests/aws/streamer.rs
@@ -62,8 +62,7 @@ async fn no_connection() -> anyhow::Result<()> {
 async fn no_credentials() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-credentials");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
     create_bucket(&bucket_name, http_port).await?;
@@ -95,8 +94,7 @@ async fn no_credentials() -> anyhow::Result<()> {
 async fn no_region() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-region");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
     create_bucket(&bucket_name, http_port).await?;
@@ -129,8 +127,7 @@ async fn no_region() -> anyhow::Result<()> {
 async fn no_bucket() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("no-bucket");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
 
@@ -159,8 +156,7 @@ async fn no_bucket() -> anyhow::Result<()> {
 async fn connector_s3_consistent() -> anyhow::Result<()> {
     let bucket_name = random_bucket_name("tremor");
 
-    let docker = clients::Cli::default();
-    let (_container, http_port) = spawn_docker(&docker).await;
+    let (_container, http_port) = spawn_docker().await;
 
     wait_for_s3(http_port).await?;
     create_bucket(&bucket_name, http_port).await?;

--- a/tremor-connectors-gcp/Cargo.toml
+++ b/tremor-connectors-gcp/Cargo.toml
@@ -59,7 +59,7 @@ simd-json-derive = { version = "0.13", default-features = true }
 simd-json = { version = "0.13", default-features = true }
 
 [dev-dependencies]
-testcontainers = { version = "0.15", default-features = true }
+testcontainers = { version = "0.16", default-features = true }
 hyper = { version = "0.14", default-features = true, features = [
     "server",
     "http1",

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -156,7 +156,7 @@ socket2 = { version = "0.5", optional = true, default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 test-case = "3.3"
 proptest = "1.4"
-testcontainers = "0.15"
+testcontainers = "0.16"
 serial_test = "3.0"
 http-types = "2.0"
 bytes = "1.0"

--- a/tremor-connectors/tests/clickhouse/more_complex_test.rs
+++ b/tremor-connectors/tests/clickhouse/more_complex_test.rs
@@ -55,7 +55,7 @@ use chrono::DateTime;
 use chrono_tz::Tz;
 use clickhouse_rs::Pool;
 use log::error;
-use testcontainers::{clients, core::Port, GenericImage, RunnableImage};
+use testcontainers::{GenericImage, RunnableImage};
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::clickhouse};
 use tremor_connectors_test_helpers::free_port;

--- a/tremor-connectors/tests/clickhouse/simple_test.rs
+++ b/tremor-connectors/tests/clickhouse/simple_test.rs
@@ -19,7 +19,7 @@ use super::utils;
 use clickhouse_rs::Pool;
 use log::error;
 use std::time::{Duration, Instant};
-use testcontainers::{clients, core::Port, GenericImage, RunnableImage};
+use testcontainers::{GenericImage, RunnableImage};
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::clickhouse};
 use tremor_connectors_test_helpers::free_port;

--- a/tremor-connectors/tests/clickhouse/simple_test.rs
+++ b/tremor-connectors/tests/clickhouse/simple_test.rs
@@ -19,6 +19,7 @@ use super::utils;
 use clickhouse_rs::Pool;
 use log::error;
 use std::time::{Duration, Instant};
+use testcontainers::runners::AsyncRunner;
 use testcontainers::{GenericImage, RunnableImage};
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::clickhouse};
@@ -35,8 +36,6 @@ use tremor_value::literal;
 // ensure that all the data was actually written.
 #[tokio::test(flavor = "multi_thread")]
 async fn simple_insertion() -> anyhow::Result<()> {
-    let docker = clients::Cli::default();
-
     // The following lines spin up a regular ClickHouse container and wait for
     // the database to be up and running.
 
@@ -44,13 +43,10 @@ async fn simple_insertion() -> anyhow::Result<()> {
     // We want to access the container from the host, so we need to make the
     // corresponding port available.
     let local = free_port::find_free_tcp_port().await?;
-    let port_to_expose = Port {
-        internal: utils::SERVER_PORT,
-        local,
-    };
+    let port_to_expose = (local, utils::SERVER_PORT);
     let image = RunnableImage::from(image).with_mapped_port(port_to_expose);
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(9000);
+    let container = image.start().await;
+    let port = container.get_host_port_ipv4(9000).await;
     utils::wait_for_ok(port).await?;
 
     // Once the database is available, we use the regular client to create the
@@ -174,7 +170,7 @@ async fn simple_insertion() -> anyhow::Result<()> {
 
     assert_eq!(ages, [42, 101]);
 
-    container.stop();
+    container.stop().await;
 
     Ok(())
 }

--- a/tremor-connectors/tests/elastic.rs
+++ b/tremor-connectors/tests/elastic.rs
@@ -29,7 +29,7 @@ use log::error;
 use serial_test::serial;
 use std::path::Path;
 use std::time::{Duration, Instant};
-use testcontainers::{clients, core::WaitFor, GenericImage, RunnableImage};
+use testcontainers::{core::WaitFor, GenericImage, RunnableImage};
 use tokio::process;
 use tremor_common::ports::IN;
 use tremor_connectors::{

--- a/tremor-connectors/tests/kafka.rs
+++ b/tremor-connectors/tests/kafka.rs
@@ -19,14 +19,15 @@ mod kafka {
     mod producer;
 }
 use std::time::Duration;
-use testcontainers::{core::WaitFor, Cli as DockerCli, GenericImage, RunnableImage};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{core::WaitFor, ContainerAsync, GenericImage, RunnableImage};
 use tremor_connectors_test_helpers::free_port::find_free_tcp_port;
 
 const IMAGE: &str = "vectorized/redpanda";
 const VERSION: &str = "v22.1.7";
 pub(crate) const PRODUCE_TIMEOUT: Duration = Duration::from_secs(5);
 
-async fn redpanda_container(docker: &DockerCli) -> anyhow::Result<Container<GenericImage>> {
+async fn redpanda_container() -> anyhow::Result<ContainerAsync<GenericImage>> {
     let kafka_port = find_free_tcp_port().await?;
     let args = vec![
         "redpanda",
@@ -59,5 +60,5 @@ async fn redpanda_container(docker: &DockerCli) -> anyhow::Result<Container<Gene
         // .with_mapped_port((free_port::find_free_tcp_port().await?, 8081_u16))
         // .with_mapped_port((free_port::find_free_tcp_port().await?, 8082_u16))
         .with_mapped_port((kafka_port, 9092_u16));
-    Ok(docker.run(image))
+    Ok(image.start().await)
 }

--- a/tremor-connectors/tests/kafka.rs
+++ b/tremor-connectors/tests/kafka.rs
@@ -19,9 +19,7 @@ mod kafka {
     mod producer;
 }
 use std::time::Duration;
-use testcontainers::{
-    clients::Cli as DockerCli, core::WaitFor, Container, GenericImage, RunnableImage,
-};
+use testcontainers::{core::WaitFor, Cli as DockerCli, GenericImage, RunnableImage};
 use tremor_connectors_test_helpers::free_port::find_free_tcp_port;
 
 const IMAGE: &str = "vectorized/redpanda";

--- a/tremor-connectors/tests/kafka/consumer.rs
+++ b/tremor-connectors/tests/kafka/consumer.rs
@@ -27,7 +27,7 @@ use rdkafka::{
 use serial_test::serial;
 use std::collections::HashMap;
 use std::time::Duration;
-use testcontainers::clients::Cli as DockerCli;
+use testcontainers::Cli as DockerCli;
 use tokio::time::timeout;
 use tremor_connectors::{harness::Harness, impls::kafka};
 use tremor_connectors_test_helpers::free_port;

--- a/tremor-connectors/tests/kafka/consumer.rs
+++ b/tremor-connectors/tests/kafka/consumer.rs
@@ -27,7 +27,6 @@ use rdkafka::{
 use serial_test::serial;
 use std::collections::HashMap;
 use std::time::Duration;
-use testcontainers::Cli as DockerCli;
 use tokio::time::timeout;
 use tremor_connectors::{harness::Harness, impls::kafka};
 use tremor_connectors_test_helpers::free_port;
@@ -40,10 +39,9 @@ use crate::{redpanda_container, PRODUCE_TIMEOUT};
 #[tokio::test(flavor = "multi_thread")]
 // #[serial(kafka)]
 async fn transactional_retry() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092);
+    let port = container.get_host_port_ipv4(9092).await;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test";
     let group_id = "transactional_retry";
@@ -266,10 +264,9 @@ async fn transactional_retry() -> anyhow::Result<()> {
 #[serial(kafka)]
 
 async fn custom_no_retry() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092);
+    let port = container.get_host_port_ipv4(9092).await;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_no_retry";
     let group_id = "test1";
@@ -476,10 +473,9 @@ async fn custom_no_retry() -> anyhow::Result<()> {
 #[serial(kafka)]
 
 async fn performance() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
+    let port = container.get_host_port_ipv4(9092).await;
 
-    let port = container.get_host_port_ipv4(9092);
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_no_retry";
     let group_id = "group123";
@@ -767,10 +763,9 @@ async fn invalid_rdkafka_options() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(kafka)]
 async fn connector_kafka_consumer_pause_resume() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092);
+    let port = container.get_host_port_ipv4(9092).await;
 
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_pause_resume";
@@ -861,10 +856,9 @@ async fn connector_kafka_consumer_pause_resume() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(kafka)]
 async fn transactional_store_offset_handling() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092);
+    let port = container.get_host_port_ipv4(9092).await;
 
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_store_offsets";
@@ -1062,10 +1056,9 @@ async fn transactional_store_offset_handling() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(kafka)]
 async fn transactional_commit_offset_handling() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092);
+    let port = container.get_host_port_ipv4(9092).await;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_commit_offset";
     let group_id = "group_commit_offset";

--- a/tremor-connectors/tests/kafka/producer.rs
+++ b/tremor-connectors/tests/kafka/producer.rs
@@ -25,7 +25,7 @@ use rdkafka::{
 };
 use serial_test::serial;
 use std::time::Duration;
-use testcontainers::clients::Cli as DockerCli;
+use testcontainers::Cli as DockerCli;
 use tokio::time::timeout;
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::kafka};

--- a/tremor-connectors/tests/kafka/producer.rs
+++ b/tremor-connectors/tests/kafka/producer.rs
@@ -25,7 +25,6 @@ use rdkafka::{
 };
 use serial_test::serial;
 use std::time::Duration;
-use testcontainers::Cli as DockerCli;
 use tokio::time::timeout;
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::kafka};
@@ -37,10 +36,9 @@ use tremor_value::literal;
 #[tokio::test(flavor = "multi_thread")]
 #[serial(kafka)]
 async fn connector_kafka_producer() -> anyhow::Result<()> {
-    let docker = DockerCli::default();
-    let container = redpanda_container(&docker).await?;
+    let container = redpanda_container().await?;
+    let port = container.get_host_port_ipv4(9092).await;
 
-    let port = container.get_host_port_ipv4(9092);
     let mut admin_config = ClientConfig::new();
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test";


### PR DESCRIPTION
# Pull request

## Description

Bump testcontainers crate dependency to to 0.16

## Related

* Related Issues: closes #2526

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

No impact on performance