### PR TITLE
Bump chrono-tz except for clickhouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
- "chrono-tz-build",
+ "chrono-tz-build 0.2.1",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build 0.3.0",
  "phf",
 ]
 
@@ -1297,6 +1308,17 @@ name = "chrono-tz-build"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -1423,7 +1445,7 @@ checksum = "802fe62a5480415bcdbb5217b3ea029d748c9a3ce3b884767cf58888e33e7f65"
 dependencies = [
  "byteorder",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.8.6",
  "clickhouse-rs-cityhash-sys",
  "combine",
  "crossbeam",
@@ -6961,7 +6983,7 @@ dependencies = [
  "bimap",
  "bytes",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.8.6",
  "clickhouse-rs",
  "cron",
  "dashmap",
@@ -7289,7 +7311,7 @@ dependencies = [
  "beef",
  "byteorder",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.9.0",
  "cidr-utils",
  "codespan",
  "criterion",

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -142,7 +142,8 @@ clickhouse-rs = { version = "1.1.0-alpha.1", optional = true, default-features =
     "tokio_io",
     "tls",
 ] }
-chrono-tz = { version = "0.8", optional = true, default-features = false }
+# Clickhouse chrono-tz is out of date so we ringfence it here. Hopefully a new version will be released soon...
+clickhouse-chrono-tz = { package = "chrono-tz", version = "0.8", optional = true, default-features = false }
 
 # crononome
 serde_yaml = { version = "0.9", optional = true, default-features = false }
@@ -208,12 +209,7 @@ tls = [
 ]
 
 dns = ["dep:trust-dns-resolver"]
-elasticsearch = [
-    "dep:elasticsearch",
-    "dep:serde_yaml",
-    "tls",
-    "http",
-]
+elasticsearch = ["dep:elasticsearch", "dep:serde_yaml", "tls", "http"]
 http = [
     "dep:base64",
     "dep:dashmap",
@@ -239,7 +235,7 @@ file = ["dep:file-mode", "dep:async-compression"]
 kv = ["dep:sled"]
 wal = ["dep:qwal", "dep:simd-json-derive"]
 bench = ["dep:xz2", "dep:hdrhistogram"]
-clickhouse = ["dep:clickhouse-rs", "dep:chrono-tz", "dep:uuid"]
+clickhouse = ["dep:clickhouse-rs", "dep:clickhouse-chrono-tz", "dep:uuid"]
 crononome = ["dep:serde_yaml", "dep:chrono", "dep:cron"]
 stdio = []
 metronome = []

--- a/tremor-connectors/src/impls/clickhouse.rs
+++ b/tremor-connectors/src/impls/clickhouse.rs
@@ -283,6 +283,7 @@
 mod conversion;
 
 use crate::sink::prelude::*;
+use clickhouse_chrono_tz::Tz;
 use clickhouse_rs::{
     errors::Error as CError,
     types::{DateTimeType, SqlType},
@@ -598,17 +599,15 @@ impl From<&DummySqlType> for &'static SqlType {
             DummySqlType::Ipv6 => SqlType::Ipv6,
             DummySqlType::Uuid => SqlType::Uuid,
             DummySqlType::DateTime => SqlType::DateTime(DateTimeType::DateTime32),
-            DummySqlType::DateTime64Secs => {
-                SqlType::DateTime(DateTimeType::DateTime64(0, chrono_tz::Tz::UTC))
-            }
+            DummySqlType::DateTime64Secs => SqlType::DateTime(DateTimeType::DateTime64(0, Tz::UTC)),
             DummySqlType::DateTime64Millis => {
-                SqlType::DateTime(DateTimeType::DateTime64(3, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(3, Tz::UTC))
             }
             DummySqlType::DateTime64Micros => {
-                SqlType::DateTime(DateTimeType::DateTime64(6, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(6, Tz::UTC))
             }
             DummySqlType::DateTime64Nanos => {
-                SqlType::DateTime(DateTimeType::DateTime64(9, chrono_tz::Tz::UTC))
+                SqlType::DateTime(DateTimeType::DateTime64(9, Tz::UTC))
             }
         };
 
@@ -697,7 +696,7 @@ mod tests {
     }
 
     mod dummy_sql_type_into_sql_type {
-        use chrono_tz::Tz::UTC;
+        use Tz::UTC;
 
         use super::*;
 

--- a/tremor-connectors/src/impls/clickhouse/conversion.rs
+++ b/tremor-connectors/src/impls/clickhouse/conversion.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::DummySqlType;
-use chrono_tz::Tz;
+use clickhouse_chrono_tz::Tz;
 pub(super) use clickhouse_rs::types::Value as CValue;
 use either::Either;
 use std::{

--- a/tremor-connectors/tests/clickhouse/more_complex_test.rs
+++ b/tremor-connectors/tests/clickhouse/more_complex_test.rs
@@ -52,7 +52,7 @@ use std::{
 use super::utils;
 use anyhow::{bail, Ok, Result};
 use chrono::DateTime;
-use chrono_tz::Tz;
+use clickhouse_chrono_tz::Tz;
 use clickhouse_rs::Pool;
 use log::error;
 use testcontainers::runners::AsyncRunner;

--- a/tremor-script/Cargo.toml
+++ b/tremor-script/Cargo.toml
@@ -25,7 +25,7 @@ atty = "0.2"
 beef = { version = "0.5", features = ["impl_serde"] }
 byteorder = "1"
 chrono = "0.4"
-chrono-tz = "0.8"
+chrono-tz = "0.9"
 cidr-utils = "0.6"
 codespan = "0.11"
 dissect = "0.7"
@@ -62,7 +62,7 @@ xz2 = "0.1"
 
 [build-dependencies]
 lalrpop = "0.20"
-chrono-tz = "0.8"
+chrono-tz = "0.9"
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
# Pull request

## Description

Bumps chrono-tz crate dependency to v0.9 except for clickhouse which we pin to 0.8

## Related

* Related Issues: closes #2522

## Checklist

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

Negligeable impact


