### PR TITLE
Revert "Bump prost from 0.9.0 to 0.12.4"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,7 +2707,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e3984a414cce451bd6fa931298c2b384924ddc1b6201adec3b0c0c148dabfa"
 dependencies = [
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "tonic",
 ]
@@ -4566,17 +4566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
-dependencies = [
- "bytes",
- "prost-derive 0.12.5",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4592,7 +4582,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "regex",
  "tempfile",
@@ -4613,26 +4603,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.63",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -6751,8 +6728,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
@@ -7118,7 +7095,7 @@ dependencies = [
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "log",
- "prost 0.12.4",
+ "prost",
  "prost-types",
  "serde",
  "simd-json",
@@ -7245,7 +7222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6cfab2469df1b6c86199844e008f549cc6b19ca59ef0b43b68b8a62f21d63b"
 dependencies = [
  "async-channel 1.9.0",
- "prost 0.9.0",
+ "prost",
  "tonic",
  "tonic-build",
 ]

--- a/tremor-connectors-gcp/Cargo.toml
+++ b/tremor-connectors-gcp/Cargo.toml
@@ -33,7 +33,7 @@ googapis = { version = "0.6", default-features = true, features = [
     "google-storage-v2",
 ] }
 gouth = { version = "0.2", default-features = true }
-prost = { version = "0.12.4", default-features = true }
+prost = { version = "0.9.0", default-features = true }
 prost-types = { version = "0.9.0", default-features = true }
 tokio = { version = "1.34", default-features = true }
 tonic = { version = "0.6.1", default-features = true, features = [


### PR DESCRIPTION
Reverts tremor-rs/tremor-runtime#2525 as a ci bug let dependabot merge non working code