### PR TITLE
Rust 1.81.0 update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -129,13 +129,5 @@
     "whrt",
     "wintel"
   ],
-  "rust-analyzer.linkedProjects": [
-    "./Cargo.toml",
-    "./tremor-connectors/Cargo.toml",
-    "./tremor-connectors/Cargo.toml",
-    "./tremor-connectors/Cargo.toml",
-    "./tremor-connectors-gcp/Cargo.toml",
-    "./tremor-connectors-gcp/Cargo.toml",
-    "./tremor-connectors-gcp/Cargo.toml"
-  ]
+  "rust-analyzer.linkedProjects": ["./Cargo.toml"]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -1145,12 +1145,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-named-pipe",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.1",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal",
  "log",
  "pin-project-lite 0.2.14",
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-native-certs 0.7.1",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -1169,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.45.0-rc.26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
 dependencies = [
  "serde",
  "serde_repr",
@@ -2072,16 +2072,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2103,18 +2094,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2148,18 +2127,6 @@ name = "distance"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9d8664cf849d7d0f3114a3a387d2f5e4303176d746d5a951aaddc66dfe9240"
-
-[[package]]
-name = "dns-lookup"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
-dependencies = [
- "cfg-if",
- "libc",
- "socket2 0.5.7",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "docker_credential"
@@ -2343,6 +2310,17 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2940,51 +2918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot 0.12.2",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,25 +3170,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
- "hyper-util",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
@@ -3335,10 +3249,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
@@ -4251,12 +4165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,11 +5043,8 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.4",
- "hickory-resolver",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
@@ -5288,7 +5193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8792cccdf842159ef04a35f247df68ccc42192e9a67e389e6cd0f1a83970a6a0"
 dependencies = [
  "cached-path",
- "dirs 4.0.0",
+ "dirs",
  "half",
  "lazy_static",
  "ordered-float 3.9.2",
@@ -5426,20 +5331,6 @@ dependencies = [
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sct 0.7.1",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-pki-types",
- "rustls-webpki 0.102.4",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -6608,79 +6499,40 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.16.7"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d47265a44d1035a322691cf0a6cc227d79b62ef86ffb0dbc204b394fee3d07"
-dependencies = [
- "async-trait",
- "bollard",
- "bollard-stubs",
- "dirs 5.0.1",
- "dns-lookup",
- "docker_credential",
- "futures",
- "log",
- "parse-display",
- "serde",
- "serde_json",
- "serde_with 3.8.1",
- "tokio",
- "tokio-util 0.7.11",
- "url",
-]
-
-[[package]]
-name = "testcontainers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e0ac563d543e0354d984540e749859a83dbe5c0afb8d458dc48d91cef2d6a"
+checksum = "5f40cc2bd72e17f328faf8ca7687fe337e61bccd8acf9674fa78dd3792b045e1"
 dependencies = [
  "async-trait",
  "bollard",
  "bollard-stubs",
  "bytes",
- "dirs 5.0.1",
- "docker_credential",
- "futures",
- "log",
- "memchr",
- "parse-display",
- "serde",
- "serde_json",
- "serde_with 3.8.1",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.11",
- "url",
-]
-
-[[package]]
-name = "testcontainers"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c9b71635ab25d4f789a86678d114a4f390467c8b93fd7feeaf7c443732a511"
-dependencies = [
- "async-trait",
- "bollard",
- "bollard-stubs",
- "bytes",
- "dirs 5.0.1",
  "docker_credential",
  "either",
+ "etcetera",
  "futures",
  "log",
  "memchr",
  "parse-display",
- "reqwest 0.12.5",
+ "pin-project-lite 0.2.14",
  "serde",
  "serde_json",
  "serde_with 3.8.1",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-tar",
  "tokio-util 0.7.11",
  "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aef7d623e245645e421c3a6d40d92e4991524b8496f39a0c7ed7994653dbcbc"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -6916,17 +6768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -7357,7 +7198,7 @@ dependencies = [
  "socket2 0.5.7",
  "tempfile",
  "test-case",
- "testcontainers 0.16.7",
+ "testcontainers",
  "thiserror",
  "tide",
  "tokio",
@@ -7397,7 +7238,8 @@ dependencies = [
  "serde",
  "serial_test",
  "simd-json",
- "testcontainers 0.17.0",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror",
  "tokio",
  "tremor-common",
@@ -7456,11 +7298,13 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "serial_test",
  "simd-json",
  "simd-json-derive",
  "tempfile",
  "test-case",
- "testcontainers 0.18.0",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror",
  "tokio",
  "tonic",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79-bookworm as builder
+FROM rust:1.81-bookworm as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.learn
+++ b/Dockerfile.learn
@@ -1,4 +1,4 @@
-FROM rust:1.79-bullseye as builder
+FROM rust:1.81-bullseye as builder
 
 RUN cargo install --features=ssl websocat
 

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM rust:1.79-bookworm as builder
+FROM rust:1.81-bookworm as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.81.0"
 components = [ "rustfmt", "clippy" ]

--- a/tremor-codec/src/codec/dogstatsd.rs
+++ b/tremor-codec/src/codec/dogstatsd.rs
@@ -346,7 +346,7 @@ fn decode_metric(data: &str) -> Result<Value> {
 
     m.insert_nocheck("values".into(), Value::from(values));
 
-    let data = if data.starts_with(|c| matches!(c, 'c' | 'd' | 'g' | 'h' | 's')) {
+    let data = if data.starts_with(['c', 'd', 'g', 'h', 's']) {
         let (t, data) = data.split_at(1);
         m.insert_nocheck("type".into(), t.into());
         data

--- a/tremor-codec/src/codec/statsd.rs
+++ b/tremor-codec/src/codec/statsd.rs
@@ -165,7 +165,7 @@ fn decode(data: &[u8], _ingest_ns: u64) -> Result<Value> {
             .map_err(Error::from)?
     };
 
-    let data = if data.starts_with(|c| matches!(c, 'c' | 'h' | 's')) {
+    let data = if data.starts_with(['c', 'h', 's']) {
         let (t, data) = data.split_at(1);
         m.insert_nocheck("type".into(), t.into());
         data

--- a/tremor-common/src/primerge.rs
+++ b/tremor-common/src/primerge.rs
@@ -32,7 +32,6 @@ pin_project! {
     ///
     /// [`merge`]: trait.Stream.html#method.merge
     /// [`Stream`]: trait.Stream.html
-    #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     #[derive(Debug)]
     pub struct PriorityMerge<T, High, Low> {
         #[pin]

--- a/tremor-connectors-aws/Cargo.toml
+++ b/tremor-connectors-aws/Cargo.toml
@@ -38,10 +38,11 @@ aws-credential-types = { version = "1", default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false }
-testcontainers = { version = "0.17", default-features = false }
+testcontainers = { version = "0.23", default-features = false }
 serial_test = { version = "3.0", default-features = false }
 bytes = { version = "1.6", default-features = true }
 tremor-connectors-test-helpers = { path = "../tremor-connectors-test-helpers", version = "0.13.0-rc.29" }
+testcontainers-modules = { version = "0.11.1", features = ["localstack"] }
 
 [features]
 integration-harness = []

--- a/tremor-connectors-aws/src/lib.rs
+++ b/tremor-connectors-aws/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Tremor AWS connectors
-
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(

--- a/tremor-connectors-aws/src/s3.rs
+++ b/tremor-connectors-aws/src/s3.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_markdown, rustdoc::invalid_codeblock_attributes)]
 //! The Amazon Web Services `s3` provides integration with the AWS Simple Storage Service or
 //! drop-in compatible replacements such as [MinIO](https://www.min.io).
 //!

--- a/tremor-connectors-azure/Cargo.toml
+++ b/tremor-connectors-azure/Cargo.toml
@@ -1,7 +1,3 @@
-bin = []
-bench = []
-test = []
-
 [package]
 name = "tremor-connectors-azure"
 edition = "2021"
@@ -44,12 +40,3 @@ mockito = "1.4.0"
 
 [features]
 integration-harness = []
-
-[lib]
-path = "src/lib.rs"
-name = "tremor_connectors_azure"
-plugin = false
-proc-macro = false
-edition = "2021"
-required-features = []
-crate-type = ["rlib"]

--- a/tremor-connectors-azure/src/monitor/ingest/writer.rs
+++ b/tremor-connectors-azure/src/monitor/ingest/writer.rs
@@ -147,7 +147,7 @@ impl RequestBuilder {
         let mut request = azure_core::Request::new(endpoint, Method::Post);
         request.insert_header("content-type", "application/json");
         if let Some(auth_token) = &self.auth_token {
-            request.insert_header("authorization", &format!("Bearer {auth_token}"));
+            request.insert_header("authorization", format!("Bearer {auth_token}"));
         }
 
         let mut bytes = vec![];

--- a/tremor-connectors-gcp/Cargo.toml
+++ b/tremor-connectors-gcp/Cargo.toml
@@ -59,7 +59,7 @@ simd-json-derive = { version = "0.13", default-features = true }
 simd-json = { version = "0.13", default-features = true }
 
 [dev-dependencies]
-testcontainers = { version = "0.18", default-features = true }
+testcontainers = { version = "0.23", default-features = true }
 hyper = { version = "0.14", default-features = true, features = [
     "server",
     "http1",
@@ -74,6 +74,10 @@ tremor-codec = { path = "../tremor-codec", version = "0.13.0-rc.29" }
 tempfile = { version = "3", default-features = true }
 env_logger = { version = "0.11", default-features = true }
 tremor-connectors-test-helpers = { path = "../tremor-connectors-test-helpers", version = "0.13.0-rc.29" }
+serial_test = "3.1.1"
+testcontainers-modules = { version = "0.11.1", features = [
+    "google_cloud_sdk_emulators",
+] }
 
 [features]
 integration-harness = []

--- a/tremor-connectors-gcp/tests/gcp.rs
+++ b/tremor-connectors-gcp/tests/gcp.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(feature = "integration-tests-gcp")]
+#![cfg(feature = "integration-harness")]
 
 use hyper::{
     service::{make_service_fn, service_fn},

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -157,7 +157,7 @@ socket2 = { version = "0.5", optional = true, default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 test-case = "3.3"
 proptest = "1.5"
-testcontainers = "0.16.7"
+testcontainers = "0.23"
 serial_test = "3.0"
 http-types = "2.0"
 bytes = "1.6"

--- a/tremor-connectors/Cargo.toml
+++ b/tremor-connectors/Cargo.toml
@@ -266,8 +266,11 @@ integration-harness-local = [
     "integration-tests-udp",
     "integration-tests-unix-socket",
     "integration-tests-wal",
-    "websocket-integration",
+    "integration-tests-websocket",
 ]
+
+# enable flaky tests
+flaky-test = []
 
 integration-tests-bench = ["bench"]
 integration-tests-clickhouse = ["clickhouse", "dep:chrono"]
@@ -281,4 +284,4 @@ integration-tests-tcp = ["tcp"]
 integration-tests-udp = ["udp"]
 integration-tests-unix-socket = ["unix-socket"]
 integration-tests-wal = ["wal"]
-websocket-integration = ["websocket"]
+integration-tests-websocket = ["websocket"]

--- a/tremor-connectors/src/impls/crononome/handler.rs
+++ b/tremor-connectors/src/impls/crononome/handler.rs
@@ -149,7 +149,6 @@ impl<I> TemporalPriorityQueue<I> {
         self.q.push(Reverse(at));
     }
 
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[cfg(test)]
     pub(crate) fn pop(&mut self) -> Option<TemporalItem<I>> {
         let Reverse(x) = self.q.peek()?;
@@ -174,7 +173,6 @@ impl<I> TemporalPriorityQueue<I> {
         self.q.pop().map(|Reverse(x)| x)
     }
 
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[cfg(test)]
     pub(crate) fn drain(&mut self) -> Vec<TemporalItem<I>> {
         let now = Utc::now().timestamp();
@@ -226,7 +224,6 @@ impl ChronomicQueue {
         }
     }
 
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[cfg(test)]
     pub(crate) fn drain(&mut self) -> Vec<(String, Option<Value<'static>>)> {
         let due = self.tpq.drain();
@@ -238,7 +235,6 @@ impl ChronomicQueue {
         }
         trigger
     }
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[cfg(test)]
     pub(crate) fn next(&mut self) -> Option<(String, Option<Value<'static>>)> {
         self.tpq.pop().map(|ti| {
@@ -260,9 +256,7 @@ mod tests {
     use super::*;
     use std::convert::TryFrom;
 
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     use chrono::DateTime;
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     use std::time::Duration;
 
     #[test]
@@ -285,7 +279,6 @@ mod tests {
 
     // This tight requirements for timing are extremely problematic in tests
     // and lead to frequent issues with the test being flaky or unrelaibale
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tpq_fill_drain() -> anyhow::Result<()> {
         use chrono::prelude::Utc;
@@ -320,7 +313,6 @@ mod tests {
 
     // This tight requirements for timing are extremely problematic in tests
     // and lead to frequent issues with the test being flaky or unrelaibale
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tpq_fill_pop() -> anyhow::Result<()> {
         use chrono::prelude::Utc;
@@ -356,7 +348,6 @@ mod tests {
 
     // This tight requirements for timing are extremely problematic in tests
     // and lead to frequent issues with the test being flaky or unrelaibale
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cq_fill_drain_refill() -> anyhow::Result<()> {
         let mut cq = ChronomicQueue::default();
@@ -391,7 +382,6 @@ mod tests {
 
     // This tight requirements for timing are extremely problematic in tests
     // and lead to frequent issues with the test being flaky or unrelaibale
-    #[cfg(not(feature = "tarpaulin-exclude"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cq_fill_pop_refill() -> anyhow::Result<()> {
         let mut cq = ChronomicQueue::default();

--- a/tremor-connectors/tests/clickhouse/simple_test.rs
+++ b/tremor-connectors/tests/clickhouse/simple_test.rs
@@ -19,8 +19,10 @@ use super::utils;
 use clickhouse_rs::Pool;
 use log::error;
 use std::time::{Duration, Instant};
+use testcontainers::core::IntoContainerPort;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{GenericImage, RunnableImage};
+use testcontainers::GenericImage;
+use testcontainers::ImageExt;
 use tremor_common::ports::IN;
 use tremor_connectors::{harness::Harness, impls::clickhouse};
 use tremor_connectors_test_helpers::free_port;
@@ -38,15 +40,14 @@ use tremor_value::literal;
 async fn simple_insertion() -> anyhow::Result<()> {
     // The following lines spin up a regular ClickHouse container and wait for
     // the database to be up and running.
+    let local = free_port::find_free_tcp_port().await?;
 
-    let image = GenericImage::new(utils::CONTAINER_NAME, utils::CONTAINER_VERSION);
+    let image = GenericImage::new(utils::CONTAINER_NAME, utils::CONTAINER_VERSION)
+        .with_mapped_port(local, utils::SERVER_PORT.tcp());
     // We want to access the container from the host, so we need to make the
     // corresponding port available.
-    let local = free_port::find_free_tcp_port().await?;
-    let port_to_expose = (local, utils::SERVER_PORT);
-    let image = RunnableImage::from(image).with_mapped_port(port_to_expose);
-    let container = image.start().await;
-    let port = container.get_host_port_ipv4(9000).await;
+    let container = image.start().await?;
+    let port = container.get_host_port_ipv4(9000).await?;
     utils::wait_for_ok(port).await?;
 
     // Once the database is available, we use the regular client to create the
@@ -170,7 +171,7 @@ async fn simple_insertion() -> anyhow::Result<()> {
 
     assert_eq!(ages, [42, 101]);
 
-    container.stop().await;
+    container.stop().await?;
 
     Ok(())
 }

--- a/tremor-connectors/tests/elastic.rs
+++ b/tremor-connectors/tests/elastic.rs
@@ -29,7 +29,7 @@ use log::error;
 use serial_test::serial;
 use std::path::Path;
 use std::time::{Duration, Instant};
-use testcontainers::core::{Mount, WaitFor};
+use testcontainers::core::Mount;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::GenericImage;
 use testcontainers::ImageExt;
@@ -53,7 +53,6 @@ const VERSION: &str = "8.6.2";
 
 fn default_image() -> ContainerRequest<GenericImage> {
     GenericImage::new(IMAGE, VERSION)
-        .with_wait_for(WaitFor::message_on_stdout("license mode is"))
         // JVM memory settings
         .with_env_var("ES_JAVA_OPTS", "-Xms256m -Xmx256m")
         // single node mode

--- a/tremor-connectors/tests/kafka/consumer.rs
+++ b/tremor-connectors/tests/kafka/consumer.rs
@@ -41,7 +41,7 @@ use crate::{redpanda_container, PRODUCE_TIMEOUT};
 async fn transactional_retry() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test";
     let group_id = "transactional_retry";
@@ -266,7 +266,7 @@ async fn transactional_retry() -> anyhow::Result<()> {
 async fn custom_no_retry() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_no_retry";
     let group_id = "test1";
@@ -474,7 +474,7 @@ async fn custom_no_retry() -> anyhow::Result<()> {
 
 async fn performance() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
 
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_no_retry";
@@ -765,7 +765,7 @@ async fn invalid_rdkafka_options() -> anyhow::Result<()> {
 async fn connector_kafka_consumer_pause_resume() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
 
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_pause_resume";
@@ -858,7 +858,7 @@ async fn connector_kafka_consumer_pause_resume() -> anyhow::Result<()> {
 async fn transactional_store_offset_handling() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
 
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_store_offsets";
@@ -1058,7 +1058,7 @@ async fn transactional_store_offset_handling() -> anyhow::Result<()> {
 async fn transactional_commit_offset_handling() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
 
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
     let broker = format!("127.0.0.1:{port}");
     let topic = "tremor_test_commit_offset";
     let group_id = "group_commit_offset";

--- a/tremor-connectors/tests/kafka/producer.rs
+++ b/tremor-connectors/tests/kafka/producer.rs
@@ -37,7 +37,7 @@ use tremor_value::literal;
 #[serial(kafka)]
 async fn connector_kafka_producer() -> anyhow::Result<()> {
     let container = redpanda_container().await?;
-    let port = container.get_host_port_ipv4(9092).await;
+    let port = container.get_host_port_ipv4(9092).await?;
 
     let mut admin_config = ClientConfig::new();
     let broker = format!("127.0.0.1:{port}");

--- a/tremor-connectors/tests/ws.rs
+++ b/tremor-connectors/tests/ws.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(feature = "websockets-integration")]
+#![cfg(feature = "integration-tests-websocket")]
 
 use anyhow::{anyhow, bail, Result};
 use futures::SinkExt;
 use futures::StreamExt;
 use log::info;
-use rustls::ServerName;
+use rustls::pki_types::ServerName;
 use std::{
     net::SocketAddr,
     sync::{
@@ -45,7 +45,7 @@ use tokio_tungstenite::{
     },
     WebSocketStream,
 };
-use tremor_common::{ports::IN, url::Url};
+use tremor_common::url::Url;
 use tremor_connectors::{
     harness::Harness,
     impls::ws::{self, Defaults},
@@ -127,7 +127,8 @@ impl TestClient<WebSocket<MaybeTlsStream<std::net::TcpStream>>> {
     fn new(url: &str) -> Result<Self> {
         use tokio_tungstenite::tungstenite::connect;
 
-        let (client, _http_response) = connect(Url::<Defaults>::parse(url)?.url())?;
+        let url = Url::<Defaults>::parse(url)?.url().to_string();
+        let (client, _http_response) = connect(url)?;
         Ok(Self { client })
     }
 

--- a/tremor-influx/src/encoder.rs
+++ b/tremor-influx/src/encoder.rs
@@ -61,14 +61,14 @@ where
     tag_collection.sort_by_key(|v| v.0);
 
     for (key, value) in tag_collection {
-        output.write_all(&[b','])?;
+        output.write_all(b",")?;
         write_escaped_key(&mut output, key.as_bytes())?;
-        output.write_all(&[b'='])?;
+        output.write_all(b"=")?;
         // For the fields we escape differently then for values ...
         write_escaped_key(&mut output, value.as_bytes())?;
     }
 
-    output.write_all(&[b' '])?;
+    output.write_all(b" ")?;
 
     let fields = v
         .try_get_object("fields")?
@@ -83,10 +83,10 @@ where
         if first {
             first = false;
         } else {
-            output.write_all(&[b','])?;
+            output.write_all(b",")?;
         }
         write_escaped_key(&mut output, key.as_bytes())?;
-        output.write_all(&[b'='])?;
+        output.write_all(b"=")?;
 
         if let Some(s) = value.as_str() {
             write_escaped_value(&mut output, s.as_bytes())?;
@@ -95,14 +95,14 @@ where
                 ValueType::F64 | ValueType::Bool => value.write(&mut output)?,
                 ValueType::U64 | ValueType::I64 => {
                     value.write(&mut output)?;
-                    output.write_all(&[b'i'])?;
+                    output.write_all(b"i")?;
                 }
                 _ => return Err(Error::InvalidValue(key.to_string(), value.value_type())),
             }
         }
     }
 
-    output.write_all(&[b' '])?;
+    output.write_all(b" ")?;
     let t = v.get("timestamp").ok_or(Error::MissingField("timestamp"))?;
     if t.is_u64() {
         t.write(&mut output)?;
@@ -116,7 +116,7 @@ where
 fn write_escaped_value<W: Write>(writer: &mut W, string: &[u8]) -> Result<()> {
     let mut start = 0;
 
-    writer.write_all(&[b'"'])?;
+    writer.write_all(b"\"")?;
     for (index, ch) in string.iter().enumerate().skip(start) {
         let ch = *ch;
         if ch == b'"' || ch == b'\\' {
@@ -126,7 +126,7 @@ fn write_escaped_value<W: Write>(writer: &mut W, string: &[u8]) -> Result<()> {
         }
     }
     write_substr(writer, string, start..)?;
-    writer.write_all(&[b'"'])?;
+    writer.write_all(b"\"")?;
     Ok(())
 }
 

--- a/tremor-interceptor/src/preprocessor/separate.rs
+++ b/tremor-interceptor/src/preprocessor/separate.rs
@@ -730,7 +730,7 @@ mod test {
         assert_eq!(89, r[0].0.len());
         assert_eq!(10, r[1].0.len());
 
-        let r = pp.finish(Some(&[b'|']), None)?;
+        let r = pp.finish(Some(b"|"), None)?;
         assert_eq!(2, r.len());
         assert_eq!(0, r[0].0.len());
         assert_eq!(0, r[1].0.len());
@@ -752,7 +752,7 @@ mod test {
         assert_eq!(1, r.len());
         assert_eq!(89, r[0].0.len());
 
-        let r = pp.finish(Some(&[b'|', b'A']), None)?;
+        let r = pp.finish(Some(b"|A"), None)?;
         assert_eq!(2, r.len());
         assert_eq!(10, r[0].0.len());
         assert_eq!(1, r[1].0.len());

--- a/tremor-script/src/ast/query.rs
+++ b/tremor-script/src/ast/query.rs
@@ -475,8 +475,7 @@ impl<'script> DefinitionalArgsWith<'script> {
     /// here the following happens:
     /// 1) The creational with is merged into the definitial with, overwriting defaults
     /// 2) We check if all mandatory fiends defined in the creational-args are set
-    /// 3) we incoperate the merged args into the creational with - this results in the final map
-    /// in the with section
+    /// 3) we incoperate the merged args into the creational with - this results in the final map in the with section
     ///
     /// # Errors
     /// for unknown keys
@@ -552,7 +551,7 @@ impl<'script> DefinitionalArgs<'script> {
     /// 1) The creational with is merged into the definitial with, overwriting defaults
     /// 2) We check if all mandatory fiends defined in the creational-args are set
     /// 3) we incoperate the merged args into the creational with - this results in the final map
-    /// in the with section
+    ///    in the with section
     ///
     /// # Errors
     /// for unknown keys

--- a/tremor-value/src/serde/value/de.rs
+++ b/tremor-value/src/serde/value/de.rs
@@ -55,7 +55,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         }
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
@@ -67,7 +67,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         }
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
@@ -85,7 +85,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         }
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn deserialize_enum<V>(
         self,
         name: &str,
@@ -283,25 +283,25 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     /****************** unit ******************/
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
         Ok(Value::Static(StaticNode::Null))
     }
 
     /****************** bool ******************/
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
         Ok(Value::Static(StaticNode::Bool(value)))
     }
 
     /****************** Option ******************/
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
         Ok(Value::Static(StaticNode::Null))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
@@ -319,7 +319,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
      */
 
     /****************** i64 ******************/
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E>
     where
@@ -328,7 +328,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E>
     where
@@ -337,7 +337,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_i32<E>(self, value: i32) -> Result<Self::Value, E>
     where
@@ -346,7 +346,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
     where
@@ -356,7 +356,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     #[cfg(feature = "128bit")]
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E>
     where
@@ -367,7 +367,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
     /****************** u64 ******************/
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
     where
@@ -376,7 +376,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
     where
@@ -385,7 +385,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
     where
@@ -394,7 +394,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
     where
@@ -404,7 +404,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     #[cfg(feature = "128bit")]
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E>
     where
@@ -415,7 +415,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
     /****************** f64 ******************/
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E>
     where
@@ -424,7 +424,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Static(StaticNode::F64(f64::from(value))))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
     where
@@ -434,7 +434,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     /****************** stringy stuff ******************/
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_char<E>(self, value: char) -> Result<Self::Value, E>
     where
@@ -443,7 +443,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::from(value.to_string()))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E>
     where
@@ -452,7 +452,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::from(value))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
@@ -461,7 +461,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::String(value.to_owned().into()))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
     where
@@ -472,7 +472,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
     /****************** byte stuff ******************/
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
 
     fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E>
     where
@@ -482,7 +482,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
     /*
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_str<E>(self, value: &[u8]) -> Result<Self::Value, E>
     where
     'a: 'de
@@ -491,7 +491,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
       Ok(Value::String(value))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_string<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
     where
         E: de::Error,
@@ -501,7 +501,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
      */
     /****************** nested stuff ******************/
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
         A: MapAccess<'de>,
@@ -516,7 +516,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::from(m))
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[inline]
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,

--- a/tremor-value/src/value.rs
+++ b/tremor-value/src/value.rs
@@ -592,7 +592,7 @@ impl<'de> ValueDeserializer<'de> {
         Self(de)
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    #[inline]
     pub fn parse(&mut self) -> Value<'de> {
         // We know the tape is valid JSON
         match unsafe { self.0.next_() } {
@@ -603,7 +603,7 @@ impl<'de> ValueDeserializer<'de> {
         }
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    #[inline]
     #[allow(clippy::uninit_vec)]
     fn parse_array(&mut self, len: usize) -> Value<'de> {
         // Rust doesn't optimize the normal loop away here
@@ -619,7 +619,7 @@ impl<'de> ValueDeserializer<'de> {
         Value::Array(res)
     }
 
-    #[cfg_attr(not(feature = "no-inline"), inline(always))]
+    #[inline]
     fn parse_map(&mut self, len: usize) -> Value<'de> {
         let mut res = Object::with_capacity_and_hasher(len, ObjectHasher::default());
 


### PR DESCRIPTION
# Pull request

## Description

Rust 1.81.0 update
## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [x] The RFC, if required, has been submitted and approved
* [x] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [x] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [x] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


