### PR TITLE
Fix: message-id in postprocessor/gelf-chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Fixes
 * gbq connector naming is now `gbq_writer` as it is documented
 * fix gbq connector url missing `/`
-
+* fix GELF message-id from auto-increment to random-id in postprocessor/gelf_chunking.rs 
+  
 ## [0.13.0-rc.29]
 
 ### New features

--- a/tremor-interceptor/Cargo.toml
+++ b/tremor-interceptor/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { version = "1.0", default-features = false }
 
 #gelf
 rand = { version = "0.8", optional = true, default-features = false, features =  ["std_rng"] }
+sha2 = { version="0.10.8", optional = true, default-feature = false, features = ["std"]}
 
 # Compression
 brotli = { version = "6", optional = true, default-features = false, features = [
@@ -61,7 +62,7 @@ proptest = "1.5"
 [features]
 default = ["base64", "compression", "gelf", "length-prefix"]
 length-prefix = ["dep:bytes"]
-gelf = ["dep:rand"]
+gelf = ["dep:rand", "dep:sha2"]
 base64 = []
 compression = [
     "dep:brotli",

--- a/tremor-interceptor/Cargo.toml
+++ b/tremor-interceptor/Cargo.toml
@@ -25,8 +25,7 @@ anyhow = { version = "1.0", default-features = true }
 thiserror = { version = "1.0", default-features = false }
 
 #gelf
-rand = { version = "0.8", optional = true, default-features = false, features = [
-] }
+rand = { version = "0.8", optional = true, default-features = false, features =  ["std_rng"] }
 
 # Compression
 brotli = { version = "6", optional = true, default-features = false, features = [

--- a/tremor-interceptor/Cargo.toml
+++ b/tremor-interceptor/Cargo.toml
@@ -25,8 +25,7 @@ anyhow = { version = "1.0", default-features = true }
 thiserror = { version = "1.0", default-features = false }
 
 #gelf
-rand = { version = "0.8", optional = true, default-features = false, features =  ["std_rng"] }
-sha2 = { version="0.10.8", optional = true, default-feature = false, features = ["std"]}
+rand = { version = "0.8", optional = true, default-features = false, features =  [] }
 
 # Compression
 brotli = { version = "6", optional = true, default-features = false, features = [
@@ -62,7 +61,7 @@ proptest = "1.5"
 [features]
 default = ["base64", "compression", "gelf", "length-prefix"]
 length-prefix = ["dep:bytes"]
-gelf = ["dep:rand", "dep:sha2"]
+gelf = ["dep:rand"]
 base64 = []
 compression = [
     "dep:brotli",

--- a/tremor-interceptor/src/postprocessor/gelf_chunking.rs
+++ b/tremor-interceptor/src/postprocessor/gelf_chunking.rs
@@ -187,7 +187,7 @@ impl Postprocessor for Gelf {
 
     fn finish(&mut self, data: Option<&[u8]>) -> anyhow::Result<Vec<Vec<u8>>> {
         if let Some(data) = data {
-            let current_epoch_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64; 
+            let current_epoch_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64; 
             Ok(self.encode_gelf(data, current_epoch_timestamp)?)
         } else {
             Ok(vec![])

--- a/tremor-interceptor/src/postprocessor/gelf_chunking.rs
+++ b/tremor-interceptor/src/postprocessor/gelf_chunking.rs
@@ -16,7 +16,7 @@
 //!
 //! ## What's the logic for creating messgae id?
 //! 
-//! TL;DR: We are using ingest_ns + increment_id + thread_id combination as the message id.
+//! TL;DR: We are using `ingest_ns + increment_id + thread_id` combination as the message id.
 //! 
 //! *Long explaination:*
 //! 
@@ -34,11 +34,11 @@
 //! It probably doesn't have to be that clever:
 //! 
 //! Using the timestamp plus a random number will mean we only have to worry about collision of random numbers,
-//! we can make it more deterministic by using the ingest_ns + an incremental id as a message ID. 
+//! we can make it more deterministic by using the `ingest_ns` + an incremental id as a message ID. 
 //! 
-//! To keep it simple we're using this logic: (epoch_timestamp & 0xFF_FF) | (auto_increment_id << 16 )
+//! To keep it simple we're using this logic: `(epoch_timestamp & 0xFF_FF) | (auto_increment_id << 16 )`
 //! 
-//! [Reference conversation]{https://github.com/tremor-rs/tremor-runtime/pull/2662}
+//! [Reference conversation]<https://github.com/tremor-rs/tremor-runtime/pull/2662>
 //!
 
 use super::Postprocessor;
@@ -185,9 +185,10 @@ impl Postprocessor for Gelf {
         Ok(self.encode_gelf(data,ingest_ns)?)
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     fn finish(&mut self, data: Option<&[u8]>) -> anyhow::Result<Vec<Vec<u8>>> {
         if let Some(data) = data {
-            let current_epoch_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64; 
+            let current_epoch_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64;
             Ok(self.encode_gelf(data, current_epoch_timestamp)?)
         } else {
             Ok(vec![])

--- a/tremor-interceptor/src/postprocessor/gelf_chunking.rs
+++ b/tremor-interceptor/src/postprocessor/gelf_chunking.rs
@@ -264,4 +264,24 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn gelf_message_id_validation_with_max_autoincrement_id() -> anyhow::Result<()> {
+        let input_data = vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        ];
+        let mut encoder = super::Gelf {
+            auto_increment_id: u64::MAX,
+            chunk_size: 20
+        };
+
+        let encoded_gelf = encoder.encode_gelf(&input_data, 0)?;
+        let expected_message_id = generate_message_id(0, u64::MAX);
+        let encoded_gelf_2 = encoder.encode_gelf(&input_data, 0)?;
+        let expected_message_id_2 = generate_message_id(0, 0);
+        assert_eq!(u64::from_be_bytes(encoded_gelf[1][2..10].try_into().expect("slice with incorrect length")), expected_message_id);
+        assert_eq!(u64::from_be_bytes(encoded_gelf_2[1][2..10].try_into().expect("slice with incorrect length")), expected_message_id_2);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->

Changed message-id from auto-increment ID to randomized ID in postprocessor/gelf_chunking.rs

HELP NEEDED: I have avoided adding hostname while producing message-id, I am not sure how can we handle adding hostname, please suggest.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

- [Issue-820](https://github.com/tremor-rs/tremor-runtime/issues/820)
- [Reference code](https://github.com/osiegmar/logback-gelf/blob/master/src/main/java/de/siegmar/logbackgelf/MessageIdSupplier.java#L61)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [x] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [x] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


