### PR TITLE
Codecs avro updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### New features
+* update apache-avro to version 0.17 adding support for nano resolution timestamp logical types in schemas
+
 ### Fixes
 * gbq connector naming is now `gbq_writer` as it is documented
 * fix gbq connector url missing `/`
-  
+
 ## [0.13.0-rc.29]
 
 ### New features
@@ -186,7 +189,7 @@
 - Fixed error reporting in ConnectOutput and ConnectInput functions
 - Fixed kv test cases
 
-## [0.13.0-rc.1] 
+## [0.13.0-rc.1]
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,21 +209,22 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apache-avro"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+checksum = "1aef82843a0ec9f8b19567445ad2421ceeb1d711514384bdd3d49fe37102ee13"
 dependencies = [
+ "bigdecimal",
  "bzip2",
  "crc32fast",
  "digest 0.10.7",
- "lazy_static",
  "libflate",
  "log",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "quad-rand",
  "rand 0.8.5",
  "regex-lite",
  "serde",
+ "serde_bytes",
  "serde_json",
  "snap",
  "strum",
@@ -232,7 +233,7 @@ dependencies = [
  "typed-builder",
  "uuid",
  "xz2",
- "zstd 0.12.4",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -1061,6 +1062,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c0a9fb70c2c2cc2a520aa259b1d1345650046a07df1b6da1d3cefcd327f43e"
 dependencies = [
  "cidr",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
 ]
 
@@ -1685,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1965,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -3788,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "serde",
  "value-bag",
@@ -4056,12 +4071,13 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5040,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -5545,13 +5561,13 @@ dependencies = [
 
 [[package]]
 name = "schema_registry_converter"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f432569d012f914dff62c52f2d69859bd0e592d83a40fd337c0111ab27bae765"
+checksum = "bcc3cf40651cf503827a34bcd7efbbd4750a7e3adc6768bb8089977e4d07303b"
 dependencies = [
  "apache-avro",
  "byteorder",
- "dashmap 5.5.3",
+ "dashmap 6.1.0",
  "futures",
  "reqwest 0.12.5",
  "serde",
@@ -5665,6 +5681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
  "serde",
 ]
 
@@ -6272,17 +6297,17 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6756,9 +6781,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7223,7 +7248,7 @@ dependencies = [
  "chrono-tz 0.8.6",
  "clickhouse-rs",
  "cron",
- "dashmap 6.0.1",
+ "dashmap 6.1.0",
  "either",
  "elasticsearch",
  "env_logger",
@@ -7753,18 +7778,18 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.16.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.16.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7924,9 +7949,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -8552,15 +8577,6 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
@@ -8573,16 +8589,6 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/tremor-codec/Cargo.toml
+++ b/tremor-codec/Cargo.toml
@@ -30,7 +30,7 @@ chrono = "0.4"
 uuid = { version = "1.9", features = ["v4"] }
 async-recursion = "1"
 
-schema_registry_converter = { version = "4", default-features = false, features = [
+schema_registry_converter = { version = "4.2", default-features = false, features = [
     "futures",
     "rustls_tls",
     "avro",
@@ -45,14 +45,13 @@ reqwest = { version = "0.12", default-features = false, features = [
 csv = "1.2"
 tremor-influx = { version = "0.13.0-rc.29", path = "../tremor-influx" }
 simd-json = "0.13"
-apache-avro = { version = "0.16", features = [
+apache-avro = { version = "0.17", features = [
     "snappy",
     "bzip",
     "xz",
     "zstandard",
-    "bzip2",
 ] }
-# 
+#
 serde = "1"
 rmp-serde = "1.2"
 syslog_loose = "0.21"

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -212,22 +212,8 @@ where
         Schema::Double => AvroValue::Double(data.try_as_f64()?),
         Schema::Bytes => AvroValue::Bytes(data.try_as_bytes()?.to_vec()),
         Schema::String => AvroValue::String(data.try_as_str()?.to_string()),
-        Schema::Array(s) => {
-            array_value_to_avro(
-                data.try_as_array()?,
-                s,
-                resolver,
-            )
-            .await?
-        }
-        Schema::Map(s) => {
-            map_value_to_avro(
-                data.try_as_object()?,
-                s,
-                resolver,
-            )
-            .await?
-        }
+        Schema::Array(s) => array_value_to_avro(data.try_as_array()?, s, resolver).await?,
+        Schema::Map(s) => map_value_to_avro(data.try_as_object()?, s, resolver).await?,
         Schema::Union(s) => {
             for (i, variant) in s.variants().iter().enumerate() {
                 if let Ok(v) = value_to_avro(data, variant, resolver).await {

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -222,7 +222,7 @@ where
         }
         Schema::Map(s) => {
             map_value_to_avro(
-                data.as_object().ok_or("Expected an object/map")?.clone(),
+                data.try_as_object()?,
                 s,
                 resolver,
             )

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -144,7 +144,7 @@ impl SchemaResolver for AvroRegistry {
 }
 
 pub(crate) async fn array_value_to_avro<'v, R>(
-    data: Vec<Value<'v>>,
+    data: &[Value<'v>],
     schema: &ArraySchema,
     resolver: &R,
 ) -> Result<AvroValue>

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -214,7 +214,7 @@ where
         Schema::String => AvroValue::String(data.try_as_str()?.to_string()),
         Schema::Array(s) => {
             array_value_to_avro(
-                data.as_array().ok_or("Expected an array")?.clone(),
+                data.try_as_array()?,
                 s,
                 resolver,
             )

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -153,7 +153,7 @@ where
 {
     let mut res = Vec::with_capacity(data.len());
     for v in data {
-        let value = value_to_avro(&v, &schema.items, resolver).await?;
+        let value = value_to_avro(v, &schema.items, resolver).await?;
         res.push(value);
     }
     Ok(AvroValue::Array(res))
@@ -173,7 +173,7 @@ where
 
         res.insert(
             k.to_string(),
-            value_to_avro(&v, &schema.types, resolver).await?,
+            value_to_avro(v, &schema.types, resolver).await?,
         );
     }
     Ok(AvroValue::Map(res))

--- a/tremor-codec/src/codec/avro.rs
+++ b/tremor-codec/src/codec/avro.rs
@@ -160,7 +160,7 @@ where
 }
 
 pub(crate) async fn map_value_to_avro<'v, R>(
-    data: Object<'v>,
+    data: &Object<'v>,
     schema: &MapSchema,
     resolver: &R,
 ) -> Result<AvroValue>

--- a/tremor-connectors/src/impls/kafka.rs
+++ b/tremor-connectors/src/impls/kafka.rs
@@ -497,10 +497,7 @@ where
             rdkafka::config::RDKafkaLogLevel::Warning => {
                 warn!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
-            rdkafka::config::RDKafkaLogLevel::Notice => {
-                info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
-            }
-            rdkafka::config::RDKafkaLogLevel::Info => {
+            rdkafka::config::RDKafkaLogLevel::Notice | rdkafka::config::RDKafkaLogLevel::Info => {
                 info!(target: "librdkafka", "{} librdkafka: {} {}", self.ctx, fac, log_message);
             }
             rdkafka::config::RDKafkaLogLevel::Debug => {

--- a/tremor-connectors/src/lib.rs
+++ b/tremor-connectors/src/lib.rs
@@ -692,7 +692,7 @@ async fn connector_task(
                     info!("{ctx} Ignoring SourceDrained Msg. Current state: {connector_state}",);
                 }
                 Msg::SinkDrained => {
-                    info!("{ctx} Ignoring SourceDrained Msg. Current state: {connector_state}",);
+                    info!("{ctx} Ignoring SinkDrained Msg. Current state: {connector_state}",);
                 }
                 Msg::Stop(sender) => {
                     info!("{ctx} Stopping...");


### PR DESCRIPTION
# Pull request

## Description

Updates apache-avro and schema-registry-converters to latest so that tremor-codecs can be
used as a library in 3rd party projects. This expands type coverage to include nano resolution
timestamps in avro schemata. BigDecimal is not supported at this time due to limitations with
tremor's value model and data type system.

## Checklist

* [ x ] The RFC, if required, has been submitted and approved
* [ x ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ x ] The code is tested
* [ x ] Use of unsafe code is reasoned about in a comment
* [ x ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behaviour
* [ x ] The performance impact of the change is measured (see below)

## Performance

No or negligeable impact.


