### PR TITLE
Add graphite plaintext codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### New features
 * update apache-avro to version 0.17 adding support for nano resolution timestamp logical types in schemas
+* Added `graphite-plaintext` tremor codec to support the graphite plaintext line protocol
 
 ### Fixes
 * gbq connector naming is now `gbq_writer` as it is documented
 * fix gbq connector url missing `/`
-* fix GELF message-id from auto-increment to random-id in postprocessor/gelf_chunking.rs 
-  
+* fix GELF message-id from auto-increment to random-id in postprocessor/gelf_chunking.rs
+
 ## [0.13.0-rc.29]
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103db485efc3e41214fe4fda9f3dbeae2eb9082f48fd236e6095627a9422066e"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "flate2",
  "futures-core",
@@ -445,7 +445,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -556,7 +556,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1239,9 +1239,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytes-utils"
@@ -1304,9 +1304,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1481,7 +1481,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1934,7 +1934,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1956,14 +1956,14 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "dary_heap"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "dashmap"
@@ -2267,7 +2267,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3434,6 +3434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iter-read"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,7 +4155,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4281,7 +4287,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4419,7 +4425,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4955,7 +4961,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5607,11 +5613,24 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "1ac55e59090389fb9f0dd9e0f3c09615afed1d19094284d0b200441f13550793"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-pickle"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
+dependencies = [
+ "byteorder",
+ "iter-read",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5635,13 +5654,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5655,9 +5674,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa 1.0.11",
  "memchr",
@@ -5684,7 +5703,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5760,7 +5779,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5828,7 +5847,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5986,7 +6005,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "simd-json",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6228,7 +6247,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6239,7 +6258,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6258,7 +6277,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6382,9 +6401,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6522,7 +6541,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6533,7 +6552,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "test-case-core",
 ]
 
@@ -6592,7 +6611,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6732,9 +6751,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6766,7 +6785,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7012,7 +7031,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7141,6 +7160,8 @@ dependencies = [
  "ryu",
  "schema_registry_converter",
  "serde",
+ "serde-pickle",
+ "serde_json",
  "serde_yaml",
  "simd-json",
  "simd-json-derive",
@@ -7744,7 +7765,7 @@ checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7782,12 +7803,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -8074,7 +8092,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
@@ -8108,7 +8126,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8525,7 +8543,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,12 +3434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "iter-read"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5621,19 +5615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-pickle"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
-dependencies = [
- "byteorder",
- "iter-read",
- "num-bigint 0.4.6",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7160,8 +7141,6 @@ dependencies = [
  "ryu",
  "schema_registry_converter",
  "serde",
- "serde-pickle",
- "serde_json",
  "serde_yaml",
  "simd-json",
  "simd-json-derive",

--- a/tremor-codec/Cargo.toml
+++ b/tremor-codec/Cargo.toml
@@ -56,8 +56,6 @@ serde = "1"
 rmp-serde = "1.2"
 syslog_loose = "0.21"
 serde_yaml = "0.9"
-serde-pickle = "1.1.1"
-serde_json = "1.0.132"
 
 [dev-dependencies]
 proptest = "1.5"

--- a/tremor-codec/Cargo.toml
+++ b/tremor-codec/Cargo.toml
@@ -56,6 +56,8 @@ serde = "1"
 rmp-serde = "1.2"
 syslog_loose = "0.21"
 serde_yaml = "0.9"
+serde-pickle = "1.1.1"
+serde_json = "1.0.132"
 
 [dev-dependencies]
 proptest = "1.5"

--- a/tremor-codec/src/codec/graphite.rs
+++ b/tremor-codec/src/codec/graphite.rs
@@ -1,0 +1,188 @@
+// Copyright 2024, The Tremor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `graphite-plaintext` codec supports the [graphite plaintext format](https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol).
+//!
+//! The format is similar to the `influx` line protocol.
+//!
+//! The codec translates a single `graphite` measurement line into a structured event.
+//!
+//! ## Example
+//!
+//! The native format of a single graphite event line is as follows:
+//!
+//! ```text
+//! <metric_path> <value> <timestamp>
+//! ```
+//!
+//! The equivalent representation as a tremor value:
+//!
+//! ```json
+//! {
+//!   "metric": "my.metric.path",
+//!   "value": 7,
+//!  "timestamp": 1620649445 // number of seconds since the epoch
+//! }
+//! ```
+//!
+//! ## Supported types
+//!
+//! Graphite has only one type, `gauge` and supports only numeric values.
+//!
+//! ## Considerations
+//!
+//! If timestamps are not provided, the codec will use the current time as the event's timestamp.
+//!
+//! If timestamp value is -1 it will be replaced with the current time as the event's timestamp.
+
+use crate::prelude::*;
+use simd_json::ObjectHasher;
+use std::io::Write;
+
+#[derive(Clone, Default, Debug)]
+pub struct PlaintextProtocol {
+    buf: Vec<u8>,
+}
+
+#[async_trait::async_trait]
+impl Codec for PlaintextProtocol {
+    fn name(&self) -> &str {
+        "graphite-plaintext"
+    }
+
+    async fn decode<'input>(
+        &mut self,
+        data: &'input mut [u8],
+        ingest_ns: u64,
+        meta: Value<'input>,
+    ) -> Result<Option<(Value<'input>, Value<'input>)>> {
+        decode_plaintext(data, ingest_ns).map(|v| Some((v, meta)))
+    }
+
+    async fn encode(&mut self, data: &Value, _meta: &Value) -> Result<Vec<u8>> {
+        encode_plaintext(data, &mut self.buf)?;
+        let v = self.buf.clone();
+        self.buf.clear();
+        Ok(v)
+    }
+
+    fn boxed_clone(&self) -> Box<dyn Codec> {
+        Box::new(self.clone())
+    }
+}
+
+fn encode_plaintext(value: &Value, r: &mut impl Write) -> Result<()> {
+    let metric = value.get_str("metric").ok_or(ErrorKind::InvalidStatsD)?;
+    let val = value
+        .get("value")
+        .ok_or(ErrorKind::InvalidGraphitePlaintext)?;
+
+    let ts = value
+        .get("timestamp")
+        .ok_or(ErrorKind::InvalidGraphitePlaintext)?;
+
+    if !val.is_number() {
+        return Err(ErrorKind::InvalidGraphitePlaintext.into());
+    };
+
+    r.write_all(metric.as_bytes())?;
+    r.write_all(b" ")?;
+    r.write_all(val.encode().as_bytes())?;
+    r.write_all(b" ")?;
+    r.write_all(ts.encode().as_bytes())?;
+
+    Ok(())
+}
+
+fn decode_plaintext(data: &[u8], ingest_ns: u64) -> Result<Value> {
+    let data = simdutf8::basic::from_utf8(data)?;
+
+    let mut m = Object::with_capacity_and_hasher(3, ObjectHasher::default());
+
+    let (metric, data) = data
+        .split_once(' ')
+        .ok_or_else(|| Error::from(ErrorKind::InvalidGraphitePlaintext))?;
+
+    let (v, ts) = data
+        .split_once(' ')
+        .ok_or_else(|| Error::from(ErrorKind::InvalidGraphitePlaintext))?;
+
+    let value = if v.contains('.') {
+        lexical::parse::<f64, _>(v)
+            .map(Value::from)
+            .map_err(Error::from)?
+    } else if v.starts_with('-') {
+        lexical::parse::<i64, _>(v)
+            .map(Value::from)
+            .map_err(Error::from)?
+    } else {
+        lexical::parse::<u64, _>(v)
+            .map(Value::from)
+            .map_err(Error::from)?
+    };
+
+    m.insert_nocheck("metric".into(), Value::from(metric));
+
+    if "-1" == ts {
+        m.insert("timestamp".into(), Value::from(ingest_ns));
+    } else {
+        let ts = lexical::parse::<u64, _>(ts)?;
+        m.insert("timestamp".into(), Value::from(ts));
+    }
+
+    m.insert("value".into(), value);
+    Ok(Value::from(m))
+}
+
+#[cfg(test)]
+mod test {
+
+    mod plaintext {
+        use super::super::*;
+        use tremor_value::literal;
+
+        // beep.boop 7 1620649445
+        #[tokio::test(flavor = "multi_thread")]
+        async fn name_value_ts() {
+            let data = b"beep.boop 7 1620649445";
+            let parsed = decode_plaintext(data, 0).expect("failed to decode");
+            let expected = literal!({
+                "metric": "beep.boop",
+                "value": 7,
+                "timestamp": 1_620_649_445i64,
+
+            });
+            assert_eq!(parsed, expected);
+            let mut encoded = Vec::new();
+            encode_plaintext(&parsed, &mut encoded).expect("failed to encode");
+            assert_eq!(encoded.as_slice(), data);
+        }
+
+        // beep.boop 320.0 -1
+        #[tokio::test(flavor = "multi_thread")]
+        async fn name_value_minusone() {
+            let data = b"beep.boop 320.0 -1";
+            let parsed = decode_plaintext(data, 1234).expect("failed to decode");
+            let expected = literal!({
+                "metric": "beep.boop",
+                "value": 320.0,
+                "timestamp": 1234,
+            });
+            assert_eq!(parsed, expected);
+            let mut encoded = Vec::new();
+            encode_plaintext(&parsed, &mut encoded).expect("failed to encode");
+            assert_eq!(encoded, b"beep.boop 320.0 1234"); // -1 is replaced with 1234 so this is asymetric w.r.t. input
+        }
+    }
+}

--- a/tremor-codec/src/errors.rs
+++ b/tremor-codec/src/errors.rs
@@ -85,6 +85,12 @@ error_chain! {
             description("Invalid statsd metric")
                 display("Invalid statsd metric")
         }
+
+        InvalidGraphitePlaintext {
+            description("Invalid graphite plaintext protocol metric")
+                display("Invalid graphite plaintext protocol metric")
+        }
+
         InvalidDogStatsD {
             description("Invalid dogstatsd metric")
                 display("Invalid dogstatsd metric")

--- a/tremor-codec/src/lib.rs
+++ b/tremor-codec/src/lib.rs
@@ -37,6 +37,7 @@ mod codec {
     pub(crate) mod confluent_schema_registry;
     pub(crate) mod csv;
     pub(crate) mod dogstatsd;
+    pub(crate) mod graphite;
     pub(crate) mod influx;
     /// JSON codec
     pub mod json;
@@ -138,6 +139,7 @@ pub fn resolve(config: &Config) -> Result<Box<dyn Codec>> {
         "syslog" => Ok(Box::new(syslog::Syslog::utcnow())),
         "tremor" => Ok(Box::<tremor::Tremor>::default()),
         "yaml" => Ok(Box::new(yaml::Yaml {})),
+        "graphite-plaintext" => Ok(Box::new(graphite::PlaintextProtocol::default())),
         s => Err(ErrorKind::CodecNotFound(s.into()).into()),
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Adds the graphite line oriented plaintext protocol as used by graphite, the carbon-c-relay and carbon-relay-ng.

## Checklist

* [ x ] The RFC, if required, has been submitted and approved
* [ x ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ x ] The code is tested
* [ x ] Use of unsafe code is reasoned about in a comment
* [ x ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ x ] The performance impact of the change is measured (see below)

## Performance

Minimally functionally tested via `carbon-c-relay` and `carbon-relay-ng`


