### PR TITLE
Fix typo in tremor-common README.md

### DIFF
--- a/tremor-common/README.md
+++ b/tremor-common/README.md
@@ -1,3 +1,3 @@
-# tremor-commons
+# tremor-common
 
 Shared and useful functions for tremor


### PR DESCRIPTION
# Pull request

## Description

Small typo in tremor-common README that creates a 404 on crates.io linking to docs.rs

## Checklist

* [ x ] The RFC, if required, has been submitted and approved
* [ x ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ x ] The code is tested
* [ x ] Use of unsafe code is reasoned about in a comment
* [ x ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ x ] The performance impact of the change is measured (see below)

## Performance

No impact


