### PR TITLE
Fix CVE-2025-62518 by migrating to astral-tokio-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5261,9 +5277,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -7079,6 +7095,7 @@ dependencies = [
 name = "tremor-archive"
 version = "0.13.0-rc.33"
 dependencies = [
+ "astral-tokio-tar",
  "log",
  "serde",
  "serde_json",
@@ -7087,7 +7104,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tremor-common",
  "tremor-script",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82-bookworm as builder
+FROM rust:1.83-bookworm as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.learn
+++ b/Dockerfile.learn
@@ -1,4 +1,4 @@
-FROM rust:1.82-bullseye as builder
+FROM rust:1.83-bullseye as builder
 
 RUN cargo install --features=ssl websocat
 

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM rust:1.82-bookworm as builder
+FROM rust:1.83-bookworm as builder
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83"
 components = [ "rustfmt", "clippy" ]

--- a/tremor-archive/Cargo.toml
+++ b/tremor-archive/Cargo.toml
@@ -15,7 +15,7 @@ tremor-common = { path = "../tremor-common", version = "0.13.0-rc.33" }
 tremor-script = { path = "../tremor-script", version = "0.13.0-rc.33" }
 
 tokio = { version = "1", default-features = false, features = [] }
-tokio-tar = "0.3"
+astral-tokio-tar = "0.5.6"
 tokio-stream = "0.1"
 thiserror = "1"
 sha2 = "0.10"


### PR DESCRIPTION
- **Upgrade to Rust 1.83**
- **Fix CVE-2025-62518 by migrating to astral-tokio-tar**

# Pull request

## Description

<!-- please add a description of what the goal of this pull request is -->


tokio-tar is abandoned and has a high severity CVE that is addressed by astral-tokio-tar 0.5.6

astral-tokio-tar can be used as an actively maintained drop-in replacement but requires Rust 1.83 or newer.

## Related

<!-- please include links to related issues are RFCs, remove if not required  -->

* [RFC](https://rfcs.tremor.rs/0000-.../)
* Related Issues: fixes #000, closed #000
* Related [docs PR](https://github.com/tremor-rs/tremor-www-docs/pull/000)

## Checklist

<!--
Please fill out the checklist below.

If an RFC is required and not submitted yet the PR will be tagged as RFC required and blocked
until the RFC is submitted and approved.

As a rule of thumb, bugfixes or minimal additions that have no backwards impact and are fully
self-contained usually do not require an RFC. Larger changes, changes to behavior, breaking changes
usually do. If in doubt, please open a ticket for a PR first to discuss the issue.

-->

* [ ] The RFC, if required, has been submitted and approved
* [ ] Any user-facing impact of the changes is reflected in docs.tremor.rs
* [ ] The code is tested
* [ ] Use of unsafe code is reasoned about in a comment
* [ ] Update CHANGELOG.md appropriately, recording any changes, bug fixes, or other observable changes in behavior
* [ ] The performance impact of the change is measured (see below)

## Performance

<!--
Measure or reason about the performance impact of the change.

A rough indication is sufficient here, we often use the `real-world-json-throughput` example to

1. cargo build -p tremor-cli --release (on main)
2. ./bench/run real-workflow-throughput-json
3. repeat on main

Share the two throughput numbers and the benchmark that produced them.

NOTE: We are fully aware this is not a perfect method, but it is a tradeoff between preventing large
performance degradation and putting an unreasonable burden on contributors.

NOTE: the total number is irrelevant as it will vary from system to system. The delta is what
matters.

If the benchmarks fail on your system, note it in the issue, and someone will try to run them for
you.

If your changes do not affect performance, and you can argue this, do it in this section, it is a
valid response.

-->


